### PR TITLE
fix(eclair): auto-build dependencies before serve for fresh clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Clone the repo and run Éclair with the demo graph.
 git clone https://github.com/NTCoding/living-architecture.git
 cd living-architecture
 pnpm install
-nx serve eclair
+pnpm nx serve eclair
 ```
 
 Open [localhost:5173/eclair](http://localhost:5173/eclair/)

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -98,7 +98,7 @@ Clone the repo and run Éclair with the demo graph.
 git clone https://github.com/NTCoding/living-architecture.git
 cd living-architecture
 pnpm install
-nx serve eclair
+pnpm nx serve eclair
 ```
 
 Open `http://localhost:5173/eclair/`

--- a/apps/docs/visualize/getting-started.md
+++ b/apps/docs/visualize/getting-started.md
@@ -10,7 +10,7 @@
 git clone https://github.com/NTCoding/living-architecture.git
 cd living-architecture
 pnpm install
-nx serve eclair
+pnpm nx serve eclair
 ```
 
 Open `http://localhost:5173/eclair/` — the demo graph loads automatically.

--- a/apps/eclair/package.json
+++ b/apps/eclair/package.json
@@ -18,6 +18,7 @@
       "serve": {
         "executor": "nx:run-commands",
         "continuous": true,
+        "dependsOn": ["^build"],
         "options": {
           "command": "vite",
           "cwd": "apps/eclair"


### PR DESCRIPTION
On a fresh clone, running `pnpm nx serve eclair` fails because the dist folders for riviere-query and riviere-schema don't exist (they're gitignored).

- Add dependsOn: ["^build"] to eclair serve target to auto-build deps
- Update docs to use `pnpm nx` prefix since nx isn't globally installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated startup and development server instructions to use pnpm for running the development environment consistently.

* **Chores**
  * Configured the serve task to automatically ensure the build step completes before starting the development server.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->