### PR TITLE
fix(ci): use run-many on main branch to ensure coverage files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World
-      - run: pnpm exec nx affected -t lint test build typecheck --verbose
+      # PRs: test affected only (faster feedback)
+      - name: Test affected (PR)
+        if: github.event_name == 'pull_request'
+        run: pnpm exec nx affected -t lint test build typecheck --verbose
+
+      # Main: test everything (ensures coverage files exist for SonarCloud)
+      - name: Test all (main)
+        if: github.ref == 'refs/heads/main'
+        run: pnpm exec nx run-many -t lint test build typecheck --verbose
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9

--- a/docs/workflow/task-workflow.md
+++ b/docs/workflow/task-workflow.md
@@ -86,6 +86,9 @@ After user confirms:
 # Assign the issue
 gh issue edit <number> --add-assignee @me
 
+# Pull latest from main
+git checkout main && git pull origin main
+
 # Create feature branch
 git checkout -b issue-<number>-short-description
 


### PR DESCRIPTION
## Summary
- Use `nx affected` for PRs (faster feedback on changed code)
- Use `nx run-many` for main branch (ensures coverage files always exist for SonarCloud)
- Add "pull from main" step to task workflow

## Problem
When docs-only commits merged to main, `nx affected` found no affected projects → no tests ran → no LCOV coverage files → SonarCloud reported 0% coverage → quality gate failed.

## Test plan
- [ ] PR passes all checks
- [ ] After merge, main branch CI passes SonarCloud quality gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI workflow with targeted checks for pull requests and comprehensive validation on main branch deployments.
  * Updated development workflow documentation to include synchronization with the latest main branch changes before creating new feature branches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->