### PR TITLE
docs: use full URL in milestone description for clickable PRD link

### DIFF
--- a/docs/workflow/task-workflow.md
+++ b/docs/workflow/task-workflow.md
@@ -248,7 +248,7 @@ When moving a PRD from `notstarted/` to `active/`:
    gh api repos/NTCoding/living-architecture/milestones \
      --method POST \
      --field title="<name>" \
-     --field description="See docs/project/PRD/active/PRD-<name>.md"
+     --field description="See https://github.com/NTCoding/living-architecture/blob/main/docs/project/PRD/active/PRD-<name>.md"
    ```
 
 3. Commit:


### PR DESCRIPTION
## Summary
Use full GitHub URL in milestone description so the PRD link is clickable in the GitHub UI.

Before: `See docs/project/PRD/active/PRD-<name>.md`
After: `See https://github.com/NTCoding/living-architecture/blob/main/docs/project/PRD/active/PRD-<name>.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated milestone documentation references to point to the external GitHub repository URL, providing direct access to milestone information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->