### PR TITLE
feat(riviere-builder): reject duplicate values in enrich operations

### DIFF
--- a/packages/riviere-builder/src/builder-enrichment-duplicates.spec.ts
+++ b/packages/riviere-builder/src/builder-enrichment-duplicates.spec.ts
@@ -1,0 +1,223 @@
+import { RiviereBuilder, type BuilderOptions } from './builder'
+
+function createValidOptions(): BuilderOptions {
+  return {
+    sources: [{ repository: 'test/repo', commit: 'abc123' }],
+    domains: {
+      orders: { description: 'Order domain', systemType: 'domain' },
+    },
+  }
+}
+
+function createSourceLocation() {
+  return { repository: 'test/repo', filePath: 'src/test.ts' }
+}
+
+describe('RiviereBuilder enrichComponent duplicate rejection', () => {
+  it('skips duplicate stateChange when enriching with same from:to', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      stateChanges: [{ from: 'draft', to: 'placed' }],
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      stateChanges: [{ from: 'draft', to: 'placed' }],
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      stateChanges: [{ from: 'draft', to: 'placed' }],
+    })
+  })
+
+  it('skips duplicate stateChange including trigger field', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      stateChanges: [{ from: 'draft', to: 'placed', trigger: 'submit' }],
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      stateChanges: [{ from: 'draft', to: 'placed', trigger: 'submit' }],
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      stateChanges: [{ from: 'draft', to: 'placed', trigger: 'submit' }],
+    })
+  })
+
+  it('adds stateChange when trigger differs', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      stateChanges: [{ from: 'draft', to: 'placed' }],
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      stateChanges: [{ from: 'draft', to: 'placed', trigger: 'submit' }],
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      stateChanges: [
+        { from: 'draft', to: 'placed' },
+        { from: 'draft', to: 'placed', trigger: 'submit' },
+      ],
+    })
+  })
+
+  it('skips duplicate businessRule', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      businessRules: ['Order must have items'],
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      businessRules: ['Order must have items'],
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      businessRules: ['Order must have items'],
+    })
+  })
+
+  it('skips duplicate behavior.reads', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      behavior: { reads: ['this.state'] },
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      behavior: { reads: ['this.state'] },
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      behavior: { reads: ['this.state'] },
+    })
+  })
+
+  it('skips duplicate behavior.validates', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      behavior: { validates: ['items.length > 0'] },
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      behavior: { validates: ['items.length > 0'] },
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      behavior: { validates: ['items.length > 0'] },
+    })
+  })
+
+  it('skips duplicate behavior.modifies', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      behavior: { modifies: ['this.state'] },
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      behavior: { modifies: ['this.state'] },
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      behavior: { modifies: ['this.state'] },
+    })
+  })
+
+  it('skips duplicate behavior.emits', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      behavior: { emits: ['OrderPlaced'] },
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      behavior: { emits: ['OrderPlaced'] },
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      behavior: { emits: ['OrderPlaced'] },
+    })
+  })
+
+  it('adds only new values when mix of existing and new provided', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    const domainOp = builder.addDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      operationName: 'placeOrder',
+      sourceLocation: createSourceLocation(),
+      businessRules: ['Rule A', 'Rule B'],
+      stateChanges: [{ from: 'draft', to: 'placed' }],
+      behavior: { reads: ['this.state'], emits: ['OrderPlaced'] },
+    })
+
+    builder.enrichComponent(domainOp.id, {
+      businessRules: ['Rule B', 'Rule C'],
+      stateChanges: [
+        { from: 'draft', to: 'placed' },
+        { from: 'placed', to: 'shipped' },
+      ],
+      behavior: { reads: ['this.state', 'items'], emits: ['OrderShipped'] },
+    })
+
+    const enriched = builder.graph.components.find((c) => c.id === domainOp.id)
+    expect(enriched).toMatchObject({
+      businessRules: ['Rule A', 'Rule B', 'Rule C'],
+      stateChanges: [
+        { from: 'draft', to: 'placed' },
+        { from: 'placed', to: 'shipped' },
+      ],
+      behavior: {
+        reads: ['this.state', 'items'],
+        emits: ['OrderPlaced', 'OrderShipped'],
+      },
+    })
+  })
+})

--- a/packages/riviere-builder/src/builder.ts
+++ b/packages/riviere-builder/src/builder.ts
@@ -22,6 +22,7 @@ import { assertCustomTypeExists, assertDomainExists, assertRequiredPropertiesPro
 import { ComponentId } from '@living-architecture/riviere-schema'
 import { createSourceNotFoundError, findNearMatches } from './component-suggestion'
 import { mergeBehavior } from './merge-behavior'
+import { deduplicateStrings, deduplicateStateTransitions } from './deduplicate'
 import {
   CustomTypeAlreadyDefinedError,
   DuplicateComponentError,
@@ -573,10 +574,14 @@ export class RiviereBuilder {
       component.entity = enrichment.entity
     }
     if (enrichment.stateChanges !== undefined) {
-      component.stateChanges = [...(component.stateChanges ?? []), ...enrichment.stateChanges]
+      const existing = component.stateChanges ?? []
+      const newItems = deduplicateStateTransitions(existing, enrichment.stateChanges)
+      component.stateChanges = [...existing, ...newItems]
     }
     if (enrichment.businessRules !== undefined) {
-      component.businessRules = [...(component.businessRules ?? []), ...enrichment.businessRules]
+      const existing = component.businessRules ?? []
+      const newItems = deduplicateStrings(existing, enrichment.businessRules)
+      component.businessRules = [...existing, ...newItems]
     }
     if (enrichment.behavior !== undefined) {
       component.behavior = mergeBehavior(component.behavior, enrichment.behavior)

--- a/packages/riviere-builder/src/deduplicate.spec.ts
+++ b/packages/riviere-builder/src/deduplicate.spec.ts
@@ -1,0 +1,57 @@
+import { deduplicateStrings, deduplicateStateTransitions } from './deduplicate'
+
+describe('deduplicateStrings', () => {
+  it('returns all incoming when no existing', () => {
+    const result = deduplicateStrings([], ['a', 'b'])
+    expect(result).toEqual(['a', 'b'])
+  })
+
+  it('filters out duplicates', () => {
+    const result = deduplicateStrings(['a', 'b'], ['b', 'c'])
+    expect(result).toEqual(['c'])
+  })
+
+  it('returns empty when all duplicates', () => {
+    const result = deduplicateStrings(['a', 'b'], ['a', 'b'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('deduplicateStateTransitions', () => {
+  it('returns all incoming when no existing', () => {
+    const result = deduplicateStateTransitions([], [{ from: 'a', to: 'b' }])
+    expect(result).toEqual([{ from: 'a', to: 'b' }])
+  })
+
+  it('filters out duplicates by from and to', () => {
+    const result = deduplicateStateTransitions(
+      [{ from: 'a', to: 'b' }],
+      [{ from: 'a', to: 'b' }, { from: 'b', to: 'c' }]
+    )
+    expect(result).toEqual([{ from: 'b', to: 'c' }])
+  })
+
+  it('treats different triggers as non-duplicates', () => {
+    const result = deduplicateStateTransitions(
+      [{ from: 'a', to: 'b' }],
+      [{ from: 'a', to: 'b', trigger: 'submit' }]
+    )
+    expect(result).toEqual([{ from: 'a', to: 'b', trigger: 'submit' }])
+  })
+
+  it('filters duplicates including trigger', () => {
+    const result = deduplicateStateTransitions(
+      [{ from: 'a', to: 'b', trigger: 'submit' }],
+      [{ from: 'a', to: 'b', trigger: 'submit' }]
+    )
+    expect(result).toEqual([])
+  })
+
+  it('returns empty when all duplicates', () => {
+    const result = deduplicateStateTransitions(
+      [{ from: 'a', to: 'b' }, { from: 'b', to: 'c' }],
+      [{ from: 'a', to: 'b' }, { from: 'b', to: 'c' }]
+    )
+    expect(result).toEqual([])
+  })
+})

--- a/packages/riviere-builder/src/deduplicate.ts
+++ b/packages/riviere-builder/src/deduplicate.ts
@@ -1,0 +1,18 @@
+import type { StateTransition } from '@living-architecture/riviere-schema'
+
+export function deduplicateStrings(existing: string[], incoming: string[]): string[] {
+  const existingSet = new Set(existing)
+  return incoming.filter((item) => !existingSet.has(item))
+}
+
+export function deduplicateStateTransitions(
+  existing: StateTransition[],
+  incoming: StateTransition[]
+): StateTransition[] {
+  return incoming.filter(
+    (item) =>
+      !existing.some(
+        (e) => e.from === item.from && e.to === item.to && e.trigger === item.trigger
+      )
+  )
+}

--- a/packages/riviere-builder/src/merge-behavior.ts
+++ b/packages/riviere-builder/src/merge-behavior.ts
@@ -1,4 +1,10 @@
 import type { DomainOpComponent, OperationBehavior } from '@living-architecture/riviere-schema'
+import { deduplicateStrings } from './deduplicate'
+
+function mergeStringArray(existing: string[] | undefined, incoming: string[]): string[] {
+  const base = existing ?? []
+  return [...base, ...deduplicateStrings(base, incoming)]
+}
 
 export function mergeBehavior(
   existing: DomainOpComponent['behavior'],
@@ -7,17 +13,9 @@ export function mergeBehavior(
   const base = existing ?? {}
   return {
     ...base,
-    ...(incoming.reads !== undefined && {
-      reads: [...(base.reads ?? []), ...incoming.reads],
-    }),
-    ...(incoming.validates !== undefined && {
-      validates: [...(base.validates ?? []), ...incoming.validates],
-    }),
-    ...(incoming.modifies !== undefined && {
-      modifies: [...(base.modifies ?? []), ...incoming.modifies],
-    }),
-    ...(incoming.emits !== undefined && {
-      emits: [...(base.emits ?? []), ...incoming.emits],
-    }),
+    ...(incoming.reads !== undefined && { reads: mergeStringArray(base.reads, incoming.reads) }),
+    ...(incoming.validates !== undefined && { validates: mergeStringArray(base.validates, incoming.validates) }),
+    ...(incoming.modifies !== undefined && { modifies: mergeStringArray(base.modifies, incoming.modifies) }),
+    ...(incoming.emits !== undefined && { emits: mergeStringArray(base.emits, incoming.emits) }),
   }
 }


### PR DESCRIPTION
## Summary
- Add deduplication logic to builder enrichment operations
- Skip duplicate stateChanges (comparing from/to/trigger fields)
- Skip duplicate businessRules (string equality)
- Skip duplicate behavior fields (reads, validates, modifies, emits)
- Duplicates are silently skipped (no error, no warning)

## Test plan
- [x] stateChange Draft:Placed added twice → one entry
- [x] stateChange with trigger field deduplication
- [x] businessRule "X" added twice → one entry  
- [x] behavior.reads duplicate rejected
- [x] behavior.validates duplicate rejected
- [x] behavior.modifies duplicate rejected
- [x] behavior.emits duplicate rejected
- [x] Mix of existing and new values → only new added
- [x] All tests pass with 100% coverage

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced component enrichment to properly handle and remove duplicate entries in state changes, business rules, and behavior properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->