### PR TITLE
feat: auto-add 'Closes #N' to PR body from branch name

### DIFF
--- a/scripts/submit-pr.sh
+++ b/scripts/submit-pr.sh
@@ -114,7 +114,7 @@ elif [[ "$MODE" == "create" ]]; then
     fi
 
     # Extract issue number from branch name (e.g., issue-40-description -> 40)
-    ISSUE_NUM=$(echo "$CURRENT_BRANCH" | sed -n 's/^issue-\([0-9]*\).*/\1/p')
+    ISSUE_NUM=$(echo "$CURRENT_BRANCH" | sed -n 's/^issue-\([0-9][0-9]*\).*/\1/p')
     if [[ -z "$ISSUE_NUM" ]] && [[ "$NO_ISSUE" == false ]]; then
         echo "Error: Branch name must include issue number (e.g., issue-40-description)" >&2
         echo "Current branch: $CURRENT_BRANCH" >&2


### PR DESCRIPTION
## Summary

- Extract issue number from branch name pattern (issue-N-description)
- Automatically prepend 'Closes #N' to PR body for auto-closing
- Add --no-issue flag for PRs without linked issues
- Enforce issue number in branch name unless --no-issue specified
- Use sed for cross-platform compatibility (macOS/Linux)

## Test plan

- [x] Script extracts issue number correctly
- [x] "Closes #N" prepended to PR body
- [x] --no-issue flag bypasses validation
- [x] Error handling for missing issue number

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detect issue numbers from branch names and add "Closes #..." to PR descriptions.
  * Added a --no-issue option to allow creating PRs without linked issues.

* **Chores**
  * Enforced validation requiring issue linkage by default (with clear error when missing).
  * Updated usage/help text and added checks to prevent inappropriate PR creation from main.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->