### PR TITLE
docs: add Draft Component term to glossary

### DIFF
--- a/docs/architecture/domain-terminology/contextive/definitions.glossary.yml
+++ b/docs/architecture/domain-terminology/contextive/definitions.glossary.yml
@@ -62,3 +62,6 @@ contexts:
 
       - name: Enforcement
         definition: A mechanism ensuring all code follows conventions. Typically ESLint rules or CI checks that fail when components lack required markers.
+
+      - name: Draft Component
+        definition: A component in a minimal state that has not been added to a graph yet because it lacks information, possibly including required fields. Draft components are not validated against the schema because they will likely fail validation.


### PR DESCRIPTION
Closes #39

## Summary

- Add "Draft Component" term to domain glossary under Extraction concepts
- Definition: A component in a minimal state that has not been added to a graph yet because it lacks information, possibly including required fields. Draft components are not validated against the schema because they will likely fail validation.

## Test plan

- [x] Term exists in glossary
- [x] Definition is clear and accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Draft Component" to the architecture domain terminology glossary, describing a component in its minimal state awaiting addition to a graph.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->