### PR TITLE
feat(scripts): add git worktree support to task workflow

### DIFF
--- a/docs/workflow/task-workflow.md
+++ b/docs/workflow/task-workflow.md
@@ -8,6 +8,14 @@ Work through the entire lifecycle autonomously until you have a mergeable PR or 
 
 *CRUCIAL*: Do not stop to ask the user for permission to do steps you are empowered to do autonomously. Never ask things like "Ready for /complete-task ?" - just do it if you have autonomy as defined in the table below.
 
+## Git Worktrees
+
+By default, `start-task.sh` creates a git worktree in a sibling directory (e.g., `../living-architecture-issue-40-desc/`). This allows working on multiple tasks in parallel without stashing or switching branches.
+
+- Use `--no-worktree` to create a branch in the current repo instead
+- Use `--no-issue=<name>` for ad-hoc tasks without a GitHub issue
+- After the PR is merged, run `cleanup-task.sh` from within the worktree to remove it
+
 ## Lifecycle Steps
 
 Autonomous = you can do this without user permission. Do not ask for permission, just do it.
@@ -20,6 +28,7 @@ Autonomous = you can do this without user permission. Do not ask for permission,
 | Amend Task | `./scripts/amend-task.sh <issue-number> "Amendment"` | Autonomous |
 | Complete Task | `/complete-task` | Autonomous |
 | Re-check PR | `/complete-task` | Autonomous |
+| Cleanup Task | `./scripts/cleanup-task.sh` | Autonomous |
 | Activate PRD | `./scripts/activate-prd.sh <prd-name>` | **User confirmation required** |
 | Archive PRD | `./scripts/archive-prd.sh <prd-name>` | **User confirmation required** |
 
@@ -31,13 +40,15 @@ Autonomous = you can do this without user permission. Do not ask for permission,
 
 **List Tasks** — User says "next task" or asks what's available. Run the script, propose the first task to the user, and ask them to confirm. Once confirmed, start the task (which provides the details), then create a plan. Do not create a plan before starting.
 
-**Start Task** — User has confirmed they want to begin a specific task. Run this FIRST—it provides the issue details needed for planning. Do not create a plan or fetch issue details separately before running this script.
+**Start Task** — User has confirmed they want to begin a specific task. Run this FIRST—it provides the issue details needed for planning. Do not create a plan or fetch issue details separately before running this script. Creates a git worktree by default.
 
 **Amend Task** — Requirements changed or need clarification during development.
 
 **Complete Task** — Implementation done, tests passing. Runs the complete autonomous pipeline: verify gate, code review, task-check, and PR submission.
 
 **Re-check PR** — PR feedback addressed, needs CI verification. Run `/complete-task` again to re-run the full pipeline.
+
+**Cleanup Task** — After PR is merged, remove the worktree. Run from within the worktree directory.
 
 **Activate PRD** — Moving a PRD from not started to active.
 

--- a/scripts/cleanup-task.sh
+++ b/scripts/cleanup-task.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# cleanup-task.sh - Remove a git worktree after task is complete
+# Usage: ./scripts/cleanup-task.sh
+#
+# Must be run from within a worktree directory.
+
+set -e
+
+# Get current worktree info
+WORKTREE_PATH=$(git rev-parse --show-toplevel)
+BRANCH_NAME=$(git branch --show-current)
+
+# Check if we're in a worktree (not the main repo)
+MAIN_REPO=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+
+if [[ "$WORKTREE_PATH" == "$MAIN_REPO" ]]; then
+    echo "Error: Not in a worktree. This script must be run from a worktree directory." >&2
+    echo "Current directory is the main repository." >&2
+    exit 1
+fi
+
+echo "Worktree: $WORKTREE_PATH"
+echo "Branch: $BRANCH_NAME"
+echo "Main repo: $MAIN_REPO"
+echo ""
+
+# Check for uncommitted changes
+UNCOMMITTED=$(git status --porcelain)
+if [[ -n "$UNCOMMITTED" ]]; then
+    echo "Error: Uncommitted changes detected. Commit or stash changes first." >&2
+    echo "$UNCOMMITTED" >&2
+    exit 1
+fi
+
+# Move to parent directory before removing worktree
+cd "$MAIN_REPO"
+
+# Remove the worktree
+echo "Removing worktree..."
+git worktree remove "$WORKTREE_PATH"
+
+echo ""
+echo "=========================================="
+echo "Cleanup complete."
+echo "You are now in: $MAIN_REPO"
+echo "=========================================="

--- a/scripts/start-task.sh
+++ b/scripts/start-task.sh
@@ -1,15 +1,61 @@
 #!/bin/bash
-# start-task.sh - Set up working environment for a GitHub issue
-# Usage: ./scripts/start-task.sh <issue-number>
+# start-task.sh - Set up working environment for a GitHub issue or ad-hoc task
+# Usage: ./scripts/start-task.sh <issue-number> [--no-worktree]
+#        ./scripts/start-task.sh --no-issue=<branch-name> [--no-worktree]
+#
+# By default, creates a git worktree in a sibling directory.
+# Use --no-worktree to create a branch in the current repo instead.
+# Use --no-issue=<name> to start a task without a GitHub issue.
 
 set -e
 
-if [[ -z "$1" ]]; then
-    echo "Usage: ./scripts/start-task.sh <issue-number>" >&2
+# Parse arguments
+ISSUE_NUMBER=""
+USE_WORKTREE=true
+NO_ISSUE_NAME=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-worktree)
+            USE_WORKTREE=false
+            shift
+            ;;
+        --no-issue=*)
+            NO_ISSUE_NAME="${1#--no-issue=}"
+            if [[ -z "$NO_ISSUE_NAME" ]]; then
+                echo "Error: --no-issue requires a branch name (e.g., --no-issue=my-task)" >&2
+                exit 1
+            fi
+            shift
+            ;;
+        *)
+            if [[ -z "$ISSUE_NUMBER" ]]; then
+                ISSUE_NUMBER="$1"
+            else
+                echo "Unknown option: $1" >&2
+                echo "Usage: ./scripts/start-task.sh <issue-number> [--no-worktree]" >&2
+                echo "       ./scripts/start-task.sh --no-issue=<branch-name> [--no-worktree]" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$ISSUE_NUMBER" ]] && [[ -z "$NO_ISSUE_NAME" ]]; then
+    echo "Usage: ./scripts/start-task.sh <issue-number> [--no-worktree]" >&2
+    echo "       ./scripts/start-task.sh --no-issue=<branch-name> [--no-worktree]" >&2
     exit 1
 fi
 
-ISSUE_NUMBER="$1"
+if [[ -n "$ISSUE_NUMBER" ]] && [[ -n "$NO_ISSUE_NAME" ]]; then
+    echo "Error: Cannot specify both issue number and --no-issue" >&2
+    exit 1
+fi
+
+# Get repo info
+REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_NAME=$(basename "$REPO_ROOT")
 
 # Step 1: Check current branch
 CURRENT_BRANCH=$(git branch --show-current)
@@ -25,30 +71,59 @@ fi
 echo "Pulling latest from origin..."
 git pull origin main
 
-# Step 4: Get issue title and create branch
-ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q .title)
-echo "Issue title: $ISSUE_TITLE"
+# Step 4: Determine branch name
+if [[ -n "$NO_ISSUE_NAME" ]]; then
+    # No-issue mode: use provided name directly
+    BRANCH_NAME="$NO_ISSUE_NAME"
+    echo "Ad-hoc task: $BRANCH_NAME"
+else
+    # Issue mode: get title from GitHub
+    ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q .title)
+    echo "Issue title: $ISSUE_TITLE"
 
-# Create short description from title (lowercase, hyphens, max 30 chars)
-SHORT_DESC=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-30)
-if [[ -z "$SHORT_DESC" ]]; then
-    SHORT_DESC="task"
+    # Create short description from title (lowercase, hyphens, max 30 chars)
+    SHORT_DESC=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-30)
+    if [[ -z "$SHORT_DESC" ]]; then
+        SHORT_DESC="task"
+    fi
+    BRANCH_NAME="issue-${ISSUE_NUMBER}-${SHORT_DESC}"
 fi
-BRANCH_NAME="issue-${ISSUE_NUMBER}-${SHORT_DESC}"
 
-echo "Creating branch: $BRANCH_NAME"
-git checkout -b "$BRANCH_NAME"
+# Step 5: Create branch (worktree or checkout)
+if [[ "$USE_WORKTREE" == true ]]; then
+    WORKTREE_DIR="${REPO_ROOT}/../${REPO_NAME}-${BRANCH_NAME}"
+    echo "Creating worktree: $WORKTREE_DIR"
+    git worktree add -b "$BRANCH_NAME" "$WORKTREE_DIR"
+else
+    echo "Creating branch: $BRANCH_NAME"
+    git checkout -b "$BRANCH_NAME"
+fi
 
-# Step 5: Assign issue to self
-echo "Assigning issue to @me..."
-gh issue edit "$ISSUE_NUMBER" --add-assignee @me
+# Step 6: Assign issue to self (only if issue mode)
+if [[ -n "$ISSUE_NUMBER" ]]; then
+    echo "Assigning issue to @me..."
+    gh issue edit "$ISSUE_NUMBER" --add-assignee @me
+fi
 
-# Step 6: Output full issue with comments
+# Step 7: Output summary
 echo ""
 echo "=========================================="
 echo "Branch: $BRANCH_NAME"
+if [[ "$USE_WORKTREE" == true ]]; then
+    echo "Worktree: $WORKTREE_DIR"
+fi
 echo "=========================================="
 echo ""
-gh issue view "$ISSUE_NUMBER" --comments
-echo ""
-echo "Ready to begin work."
+
+# Show issue details (only if issue mode)
+if [[ -n "$ISSUE_NUMBER" ]]; then
+    gh issue view "$ISSUE_NUMBER" --comments
+    echo ""
+fi
+
+if [[ "$USE_WORKTREE" == true ]]; then
+    echo "Worktree created. To start working:"
+    echo "  cd $WORKTREE_DIR"
+else
+    echo "Ready to begin work."
+fi


### PR DESCRIPTION
## Summary
- `start-task.sh` now creates git worktrees by default in sibling directories
- Added `--no-worktree` flag to preserve old checkout-branch behavior
- Added `--no-issue=<name>` flag for ad-hoc tasks without GitHub issues
- Added `cleanup-task.sh` to remove worktrees after PR is merged
- Updated task-workflow.md documentation

## Test plan
- [ ] Run `./scripts/start-task.sh <issue>` - creates worktree at `../living-architecture-issue-<N>-<desc>/`
- [ ] Run `./scripts/start-task.sh <issue> --no-worktree` - creates branch in current repo
- [ ] Run `./scripts/start-task.sh --no-issue=test-branch` - creates worktree for ad-hoc task
- [ ] From worktree: `./scripts/cleanup-task.sh` - removes worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workflow documentation with comprehensive Git Worktrees guidance and detailed Cleanup Task instructions.

* **New Features**
  * Added support for creating ad-hoc tasks without GitHub issues.
  * Added option to disable automatic worktree creation and work locally within the current repository.
  * Introduced automated task cleanup process for removing worktrees after task completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->