### PR TITLE
docs(conventions): standardize tsconfig.spec.json documentation

### DIFF
--- a/docs/conventions/codebase-structure.md
+++ b/docs/conventions/codebase-structure.md
@@ -137,7 +137,11 @@ Each app/package needs a 3-file tsconfig structure:
 
 **tsconfig.spec.json** (tests):
 
-See `packages/riviere-schema/tsconfig.spec.json` for the canonical example. The `references` array may include additional project references for test dependencies. The eclair app includes React-specific additions (jsx, lib, testing-library types).
+See `packages/riviere-schema/tsconfig.spec.json` for the canonical example. This uses the expanded pattern with full vitest ecosystem support (`types: ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]`) and comprehensive include patterns for `.test.*`, `.spec.*`, config files, and `.d.ts` files.
+
+The `references` array may include additional project references for test dependencies. The eclair app includes React-specific additions (jsx, lib, testing-library types).
+
+> **Maintenance note:** When modifying test tsconfigs, verify changes against the canonical file. If `packages/riviere-schema/tsconfig.spec.json` changes, update this documentation or ensure all packages follow the new pattern.
 
 The `references` arrays are automatically maintained by `pnpm nx sync`.
 


### PR DESCRIPTION
Closes #68

Replaces the inline tsconfig.spec.json example in codebase-structure.md with a reference to the canonical example in the riviere-schema package. This reduces documentation duplication and ensures the guidance stays current with the actual implementation.

Changes:
- Removed inline JSON example
- Added reference to packages/riviere-schema/tsconfig.spec.json as canonical example
- Noted special cases (eclair app has React-specific additions)
- Updated nx command examples to include pnpm prefix for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized tooling commands to pnpm nx equivalents across docs (installation, generation, sync).
  * Clarified canonical test-config guidance and expanded examples for test tooling support.
  * Updated maintenance notes to reference pnpm nx sync for automatic config upkeep.
  * Revised project-generation and inter-project dependency examples to reflect a pnpm-based workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->