### PR TITLE
feat(scripts): auto-register worktrees in Claude Code permissions

### DIFF
--- a/scripts/start-task.sh
+++ b/scripts/start-task.sh
@@ -108,8 +108,9 @@ if [[ "$USE_WORKTREE" == true ]]; then
               )
             ' "$SETTINGS_LOCAL" > "$SETTINGS_LOCAL.tmp" && mv "$SETTINGS_LOCAL.tmp" "$SETTINGS_LOCAL"
         else
-            # Create new settings.local.json
-            echo "{\"permissions\":{\"additionalDirectories\":[\"$WORKTREE_ABS\"]}}" | jq . > "$SETTINGS_LOCAL"
+            # Create new settings.local.json (ensure directory exists first)
+            mkdir -p "$(dirname "$SETTINGS_LOCAL")"
+            jq -n --arg dir "$WORKTREE_ABS" '{"permissions":{"additionalDirectories":[$dir]}}' > "$SETTINGS_LOCAL"
         fi
         echo "Registered worktree in Claude Code permissions"
     else


### PR DESCRIPTION
## Summary
- When creating a git worktree, automatically add its path to `.claude/settings.local.json` under `permissions.additionalDirectories`
- Prevents unnecessary permission prompts when Claude Code agents work in worktree directories
- Requires `jq`; falls back to printing `/add-dir` command if not installed

## Test plan
- [x] Verified worktree creation adds path to settings.local.json
- [x] Verified cleanup removes worktree successfully
- [ ] Manual test: Start task, verify agents don't prompt for worktree permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically registers newly created worktree paths in Claude Code permissions. If jq is available, updates or creates the settings file to include the new path (deduplicated). If jq is unavailable, displays a notice with installation or manual-update guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->