### PR TITLE
docs: update CLAUDE.md with riviere-extract-config dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ Current packages:
 - `living-architecture/riviere-cli` - CLI tool with binary "riviere" (depends on riviere-builder)
 - `@living-architecture/riviere-schema` - Riviere schema definitions
 - `@living-architecture/riviere-extract-config` - JSON Schema and validation for extraction config DSL
-- `@living-architecture/riviere-extract-conventions` - Decorators for marking architectural components
-- `@living-architecture/riviere-extract-ts` - TypeScript component extractor using ts-morph for AST parsing
+- `@living-architecture/riviere-extract-conventions` - Decorators for marking architectural components (depends on riviere-extract-config)
+- `@living-architecture/riviere-extract-ts` - TypeScript component extractor using ts-morph for AST parsing (depends on riviere-extract-config)
 
 Apps:
 - `living-architecture/eclair` - Web app for viewing your software architecture via Riviere a schema


### PR DESCRIPTION
### **User description**
Closes #47

## Summary
- Document that riviere-extract-conventions depends on riviere-extract-config
- Document that riviere-extract-ts depends on riviere-extract-config

## Test plan
- [x] Changes are documentation only
- [x] Package dependency structure is accurately reflected in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Document riviere-extract-config dependencies in package list

- Clarify that two packages depend on riviere-extract-config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["riviere-extract-config"] -- "dependency" --> B["riviere-extract-conventions"]
  A -- "dependency" --> C["riviere-extract-ts"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add riviere-extract-config dependencies to package list</code>&nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Added dependency notation to riviere-extract-conventions package <br>description<br> <li> Added dependency notation to riviere-extract-ts package description<br> <li> Clarified package dependency structure in documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/NTCoding/living-architecture/pull/87/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package dependency documentation to reflect configuration requirements for extraction packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->