### PR TITLE
fix(dev-workflow): use exit code 2 for stop hook blocks so reason is …

### DIFF
--- a/tools/dev-workflow/features/claude-hooks/claude-hooks.spec.ts
+++ b/tools/dev-workflow/features/claude-hooks/claude-hooks.spec.ts
@@ -160,7 +160,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('allows stop when response starts with [No Mergeable PR', () => {
@@ -173,7 +173,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('blocks stop when response lacks required prefix', () => {
@@ -186,8 +186,8 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(false)
-    expect(result.stopReason).toContain('[Mergeable PR]')
+    expect(result._tag).toBe('block')
+    expect(result._tag === 'block' && result.reason).toContain('[Mergeable PR]')
   })
 
   it('blocks stop when transcript is empty', () => {
@@ -196,14 +196,14 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(false)
+    expect(result._tag).toBe('block')
   })
 
   it('blocks stop when transcript file does not exist', () => {
     const input = createStopInput('/nonexistent/transcript.jsonl')
     const result = handleStop(input)
 
-    expect(result.continue).toBe(false)
+    expect(result._tag).toBe('block')
   })
 
   it('handles content array format', () => {
@@ -223,7 +223,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('finds last assistant message in multi-message transcript', () => {
@@ -248,7 +248,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('allows prefix with leading whitespace', () => {
@@ -261,7 +261,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('blocks when content array has no text blocks', () => {
@@ -281,7 +281,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(false)
+    expect(result._tag).toBe('block')
   })
 
   it('skips non-assistant transcript entries', () => {
@@ -298,7 +298,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('finds last assistant message when user message is last', () => {
@@ -315,7 +315,7 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('handles malformed JSON in transcript lines', () => {
@@ -327,6 +327,6 @@ describe('Stop handler', () => {
     const input = createStopInput(transcriptPath)
     const result = handleStop(input)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 })

--- a/tools/dev-workflow/features/claude-hooks/domain/handlers/stop-handler.spec.ts
+++ b/tools/dev-workflow/features/claude-hooks/domain/handlers/stop-handler.spec.ts
@@ -37,8 +37,8 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(false)
-    expect(result.stopReason).toContain('MANDATORY')
+    expect(result._tag).toBe('block')
+    expect(result._tag === 'block' && result.reason).toContain('MANDATORY')
   })
 
   it('allows stop when message has [Mergeable PR] prefix', () => {
@@ -51,7 +51,7 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('allows stop when message has [No Mergeable PR: prefix', () => {
@@ -64,7 +64,7 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('blocks stop when message lacks required prefix', () => {
@@ -77,8 +77,8 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(false)
-    expect(result.stopReason).toContain('MANDATORY')
+    expect(result._tag).toBe('block')
+    expect(result._tag === 'block' && result.reason).toContain('MANDATORY')
   })
 
   it('handles content as array of text blocks', () => {
@@ -98,7 +98,7 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('handles multiple lines taking last assistant message', () => {
@@ -123,7 +123,7 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('blocks when no assistant messages found', () => {
@@ -136,7 +136,7 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(false)
+    expect(result._tag).toBe('block')
   })
 
   it('handles invalid JSON lines gracefully', () => {
@@ -149,7 +149,7 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 
   it('allows prefix with leading whitespace', () => {
@@ -162,6 +162,6 @@ describe('handleStop', () => {
 
     const result = handleStop(baseInput)
 
-    expect(result.continue).toBe(true)
+    expect(result._tag).toBe('allow')
   })
 })

--- a/tools/dev-workflow/features/claude-hooks/domain/hook-output-schemas.spec.ts
+++ b/tools/dev-workflow/features/claude-hooks/domain/hook-output-schemas.spec.ts
@@ -84,36 +84,20 @@ describe('hook output schemas', () => {
   })
 
   describe('stopOutputSchema', () => {
-    it('parses continue true', () => {
-      const output = stopOutputSchema.parse({ continue: true })
+    it('parses allow tag', () => {
+      const output = stopOutputSchema.parse({ _tag: 'allow' })
 
-      expect(output.continue).toStrictEqual(true)
+      expect(output._tag).toBe('allow')
     })
 
-    it('parses continue false with stopReason', () => {
+    it('parses block tag with reason', () => {
       const output = stopOutputSchema.parse({
-        continue: false,
-        stopReason: 'must wait for CI',
+        _tag: 'block',
+        reason: 'must wait for CI',
       })
 
-      expect(output.continue).toStrictEqual(false)
-      expect(output.stopReason).toStrictEqual('must wait for CI')
-    })
-
-    it('parses empty object', () => {
-      const output = stopOutputSchema.parse({})
-
-      expect(output.continue).toBeUndefined()
-    })
-
-    it('parses outputToUser with passthrough false', () => {
-      const output = stopOutputSchema.parse({
-        outputToUser: { passthrough: false },
-        continue: false,
-        stopReason: 'blocked',
-      })
-
-      expect(output.outputToUser).toStrictEqual({ passthrough: false })
+      expect(output._tag).toBe('block')
+      expect(output._tag === 'block' && output.reason).toStrictEqual('must wait for CI')
     })
   })
 })
@@ -172,18 +156,18 @@ describe('hook output types', () => {
   })
 
   describe('StopOutput', () => {
-    it('allows continue true', () => {
-      const output: StopOutput = { continue: true }
-      expect(output.continue).toBe(true)
+    it('allows allow tag', () => {
+      const output: StopOutput = { _tag: 'allow' }
+      expect(output._tag).toBe('allow')
     })
 
-    it('allows continue false with stopReason', () => {
+    it('allows block tag with reason', () => {
       const output: StopOutput = {
-        continue: false,
-        stopReason: 'must wait for CI',
+        _tag: 'block',
+        reason: 'must wait for CI',
       }
-      expect(output.continue).toBe(false)
-      expect(output.stopReason).toBe('must wait for CI')
+      expect(output._tag).toBe('block')
+      expect(output.reason).toBe('must wait for CI')
     })
   })
 
@@ -202,8 +186,11 @@ describe('hook output types', () => {
     })
 
     it('accepts StopOutput', () => {
-      const output: HookOutput = { continue: true }
-      expect('continue' in output).toBe(true)
+      const output: HookOutput = {
+        _tag: 'block',
+        reason: 'test',
+      }
+      expect('_tag' in output).toBe(true)
       const parsed = stopOutputSchema.safeParse(output)
       expect(parsed.success).toBe(true)
     })

--- a/tools/dev-workflow/features/claude-hooks/domain/hook-output-schemas.ts
+++ b/tools/dev-workflow/features/claude-hooks/domain/hook-output-schemas.ts
@@ -17,13 +17,13 @@ export const postToolUseOutputSchema = z.object({
 })
 export type PostToolUseOutput = z.infer<typeof postToolUseOutputSchema>
 
-const outputToUserSchema = z.object({ passthrough: z.literal(false) })
-
-export const stopOutputSchema = z.object({
-  outputToUser: outputToUserSchema.optional(),
-  continue: z.boolean().optional(),
-  stopReason: z.string().optional(),
-})
+export const stopOutputSchema = z.discriminatedUnion('_tag', [
+  z.object({ _tag: z.literal('allow') }),
+  z.object({
+    _tag: z.literal('block'),
+    reason: z.string(),
+  }),
+])
 export type StopOutput = z.infer<typeof stopOutputSchema>
 
 export type HookOutput = PreToolUseOutput | PostToolUseOutput | StopOutput

--- a/tools/dev-workflow/features/claude-hooks/domain/permission-decision.ts
+++ b/tools/dev-workflow/features/claude-hooks/domain/permission-decision.ts
@@ -23,13 +23,12 @@ export function deny(reason: string): PreToolUseOutput {
 }
 
 export function allowStop(): StopOutput {
-  return { continue: true }
+  return { _tag: 'allow' }
 }
 
 export function blockStop(reason: string): StopOutput {
   return {
-    outputToUser: { passthrough: false },
-    continue: false,
-    stopReason: reason,
+    _tag: 'block',
+    reason,
   }
 }

--- a/tools/dev-workflow/features/claude-hooks/entrypoint/hook-router.spec.ts
+++ b/tools/dev-workflow/features/claude-hooks/entrypoint/hook-router.spec.ts
@@ -77,20 +77,60 @@ describe('hook-router', () => {
     expect(capturedOutput[0]).toStrictEqual('{}')
   })
 
-  it('outputs handler result for valid input', async () => {
+  it('outputs handler result for valid non-stop input', async () => {
+    mockShouldSkipHooks.mockReturnValue(false)
+    mockParseHookInput.mockReturnValue({
+      success: true,
+      input: { hook_event_name: 'PreToolUse' },
+    })
+    mockRouteToHandler.mockReturnValue({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow',
+        permissionDecisionReason: 'ok',
+      },
+    })
+    mockStdin('{"hook_event_name":"PreToolUse"}')
+
+    await import('./hook-router')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(mockRouteToHandler).toHaveBeenCalledWith({ hook_event_name: 'PreToolUse' })
+    expect(capturedOutput[0]).toContain('permissionDecision')
+  })
+
+  it('outputs empty JSON for stop allow result', async () => {
     mockShouldSkipHooks.mockReturnValue(false)
     mockParseHookInput.mockReturnValue({
       success: true,
       input: { hook_event_name: 'Stop' },
     })
-    mockRouteToHandler.mockReturnValue({ continue: true })
+    mockRouteToHandler.mockReturnValue({ _tag: 'allow' })
     mockStdin('{"hook_event_name":"Stop"}')
 
     await import('./hook-router')
     await new Promise((resolve) => setTimeout(resolve, 50))
 
-    expect(mockRouteToHandler).toHaveBeenCalledWith({ hook_event_name: 'Stop' })
-    expect(capturedOutput[0]).toContain('"continue":true')
+    expect(capturedOutput[0]).toStrictEqual('{}')
+  })
+
+  it('exits with code 2 and stderr for stop block result', async () => {
+    mockShouldSkipHooks.mockReturnValue(false)
+    mockParseHookInput.mockReturnValue({
+      success: true,
+      input: { hook_event_name: 'Stop' },
+    })
+    mockRouteToHandler.mockReturnValue({
+      _tag: 'block',
+      reason: 'missing prefix' 
+    })
+    mockStdin('{"hook_event_name":"Stop"}')
+
+    await import('./hook-router')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(capturedErrors[0]).toBe('missing prefix')
+    expect(mockProcessExit).toHaveBeenCalledWith(2)
   })
 
   it('exits with code 2 for malformed JSON', async () => {

--- a/tools/dev-workflow/features/claude-hooks/entrypoint/hook-router.ts
+++ b/tools/dev-workflow/features/claude-hooks/entrypoint/hook-router.ts
@@ -62,6 +62,14 @@ async function main(): Promise<void> {
   }
 
   const output = routeToHandler(parseResult.input)
+  if ('_tag' in output) {
+    if (output._tag === 'block') {
+      console.error(output.reason)
+      process.exit(2)
+    }
+    console.log(JSON.stringify({}))
+    return
+  }
   console.log(JSON.stringify(output))
 }
 

--- a/tools/dev-workflow/features/claude-hooks/use-cases/handle-hook.spec.ts
+++ b/tools/dev-workflow/features/claude-hooks/use-cases/handle-hook.spec.ts
@@ -128,6 +128,6 @@ describe('routeToHandler', () => {
 
     const result = routeToHandler(input)
 
-    expect(result).toHaveProperty('continue')
+    expect(result).toHaveProperty('_tag')
   })
 })


### PR DESCRIPTION
…hidden from user

The stop hook was using JSON stdout with stopReason/outputToUser fields, which displayed the MANDATORY reminder to the user. Switch to exit code 2 with stderr so the reason is only fed to Claude per the hooks API docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal permission decision handling to use a discriminated union pattern with explicit allow/block tags, improving type safety and decision outcome clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->