### PR TITLE
fix(dev-workflow): prepend Closes #N to PR body for auto-closing issues

### DIFF
--- a/tools/dev-workflow/features/complete-task/domain/pull-request-draft.spec.ts
+++ b/tools/dev-workflow/features/complete-task/domain/pull-request-draft.spec.ts
@@ -46,7 +46,7 @@ describe('resolvePRDetails', () => {
     const result = resolvePRDetails(123, taskDetails)
 
     expect(result.prTitle).toStrictEqual('feat: from task')
-    expect(result.prBody).toStrictEqual('Task body')
+    expect(result.prBody).toStrictEqual('Closes #123\n\nTask body')
     expect(result.hasIssue).toStrictEqual(true)
     expect(result.issueNumber).toStrictEqual(123)
   })

--- a/tools/dev-workflow/features/complete-task/domain/pull-request-draft.ts
+++ b/tools/dev-workflow/features/complete-task/domain/pull-request-draft.ts
@@ -42,7 +42,8 @@ export function resolvePRDetails(
   const cliCommitMessage = cli.parseArg('--commit-message')
 
   const prTitle = cliPrTitle ?? taskDetails?.title
-  const prBody = cliPrBody ?? taskDetails?.body
+  const rawBody = cliPrBody ?? taskDetails?.body
+  const prBody = issueNumber ? `Closes #${issueNumber}\n\n${rawBody}` : rawBody
   const commitMessage = cliCommitMessage
 
   if (!prTitle || !prBody) {


### PR DESCRIPTION
Lost during shell-to-TypeScript migration of submit-pr.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pull requests now automatically prepend an issue closing reference (e.g., "Closes #123") to the PR body when an issue number is linked, improving issue tracking and resolution workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->