### PR TITLE
fix(dev-workflow): register worktree in Claude Code permissions on start

### DIFF
--- a/scripts/start-task.sh
+++ b/scripts/start-task.sh
@@ -107,14 +107,15 @@ if [[ "$USE_WORKTREE" == true ]]; then
 
     WORKTREE_ABS=$(cd "$WORKTREE_DIR" && pwd)
     SETTINGS_LOCAL="$REPO_ROOT/.claude/settings.local.json"
+    mkdir -p "$(dirname "$SETTINGS_LOCAL")"
     if command -v jq &> /dev/null; then
         if [[ ! -f "$SETTINGS_LOCAL" ]]; then
             echo '{}' > "$SETTINGS_LOCAL"
         fi
         tmp=$(mktemp)
         if jq --arg dir "$WORKTREE_ABS" '
-          .permissions.additionalDirectories = (
-            ((.permissions.additionalDirectories // []) | map(select(. != $dir))) + [$dir]
+          .permissions.additionalDirectories |= (
+            (. // []) | map(select(. != $dir)) + [$dir]
           )
         ' "$SETTINGS_LOCAL" > "$tmp" && mv "$tmp" "$SETTINGS_LOCAL"; then
             echo "Added worktree to Claude Code permissions"


### PR DESCRIPTION
start-task.sh now adds the worktree directory to .claude/settings.local.json so Claude Code does not prompt for read permissions on every file in the worktree. Mirrors the removal logic already in cleanup-task.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced development environment setup to automatically configure Claude Code permissions when initializing worktrees. The update deduplicates directory entries, provides graceful fallback and user-facing warnings if automatic changes can't be applied, and performs cleanup on failure. This flow runs only for worktree-based setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->