### PR TITLE
fix(conventions,extract): fixes required after testing phase 11 changes on demo app

### DIFF
--- a/packages/riviere-extract-conventions/src/index.ts
+++ b/packages/riviere-extract-conventions/src/index.ts
@@ -24,6 +24,7 @@ export type {
   APIControllerDef,
   EventDef,
   EventHandlerDef,
+  IEventHandler,
   UIPageDef,
   DomainOpContainerDef,
 } from './interfaces'

--- a/packages/riviere-extract-conventions/src/interfaces.ts
+++ b/packages/riviere-extract-conventions/src/interfaces.ts
@@ -10,12 +10,10 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
  * Required properties:
  * - route: The URL path for this endpoint
  * - method: The HTTP method (GET, POST, PUT, PATCH, DELETE)
- * - handle: The request handler function
  */
 export interface APIControllerDef {
   readonly route: string
   readonly method: HttpMethod
-  handle(req: Request, res: Response): void | Promise<void>
 }
 
 /**
@@ -33,11 +31,20 @@ export interface EventDef {readonly type: string}
  *
  * Required properties:
  * - subscribedEvents: Array of event type names this handler processes
- * - handle: The event processing function
  */
-export interface EventHandlerDef {
+export interface EventHandlerDef {readonly subscribedEvents: readonly string[]}
+
+/**
+ * Generic event handler interface for use with fromGenericArg extraction.
+ * Classes implement this with a concrete event type to enable automatic
+ * subscribedEvents extraction from the generic argument.
+ *
+ * Example: class MyHandler implements IEventHandler<OrderPlaced> { ... }
+ * The extractor reads OrderPlaced from the generic arg as the subscribed event.
+ */
+export interface IEventHandler<TEvent = unknown> {
   readonly subscribedEvents: readonly string[]
-  handle(event: unknown): void | Promise<void>
+  readonly __eventType?: TEvent
 }
 
 /**

--- a/packages/riviere-extract-ts/src/domain/value-extraction/enrich-components-method-extraction.spec.ts
+++ b/packages/riviere-extract-ts/src/domain/value-extraction/enrich-components-method-extraction.spec.ts
@@ -1,0 +1,373 @@
+import {
+  describe, it, expect 
+} from 'vitest'
+import { Project } from 'ts-morph'
+import type {
+  ResolvedExtractionConfig, Module 
+} from '@living-architecture/riviere-extract-config'
+import type {
+  DraftComponent, GlobMatcher 
+} from '../component-extraction/extractor'
+import { enrichComponents } from './enrich-components'
+
+const sharedProject = new Project({ useInMemoryFileSystem: true })
+const counter = { value: 0 }
+
+function nextFile(path: string, content: string) {
+  counter.value++
+  const filePath = path.replace('.ts', `-m-${counter.value}.ts`)
+  sharedProject.createSourceFile(filePath, content)
+  return filePath
+}
+
+function alwaysMatchGlob(): GlobMatcher {
+  return () => true
+}
+
+function configWithModules(modules: Module[]): ResolvedExtractionConfig {
+  return { modules }
+}
+
+function notUsedModule(): Pick<Module, 'api' | 'useCase' | 'event' | 'ui'> {
+  return {
+    api: { notUsed: true },
+    useCase: { notUsed: true },
+    event: { notUsed: true },
+    ui: { notUsed: true },
+  }
+}
+
+describe('enrichComponents — fromMethodName extraction', () => {
+  it('extracts method name from method-based component', () => {
+    const file = nextFile(
+      '/src/orders/order.ops.ts',
+      `export class OrderOps {
+  placeOrder() {}
+  cancelOrder() {}
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'domainOp',
+        name: 'placeOrder',
+        location: {
+          file,
+          line: 2,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders/**',
+      domainOp: {
+        find: 'methods',
+        where: { nameEndsWith: { suffix: 'Order' } },
+        extract: { operationName: { fromMethodName: true } },
+      },
+      eventHandler: { notUsed: true },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents(drafts, config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.components[0]?.metadata).toStrictEqual({ operationName: 'placeOrder' })
+    expect(result.failures).toStrictEqual([])
+  })
+
+  it('records failure when no method found at specified line', () => {
+    const file = nextFile(
+      '/src/orders/order.ops.ts',
+      `export class OrderOps {
+  placeOrder() {}
+}`,
+    )
+
+    const draft: DraftComponent = {
+      type: 'domainOp',
+      name: 'placeOrder',
+      location: {
+        file,
+        line: 99,
+      },
+      domain: 'orders',
+    }
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders/**',
+      domainOp: {
+        find: 'methods',
+        where: { nameEndsWith: { suffix: 'Order' } },
+        extract: { operationName: { fromMethodName: true } },
+      },
+      eventHandler: { notUsed: true },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents([draft], config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.field).toBe('operationName')
+    expect(result.components[0]?._missing).toStrictEqual(['operationName'])
+  })
+
+  it('records failure when source file not found for fromMethodName', () => {
+    const draft: DraftComponent = {
+      type: 'domainOp',
+      name: 'placeOrder',
+      location: {
+        file: '/src/missing/ops.ts',
+        line: 2,
+      },
+      domain: 'orders',
+    }
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/**',
+      domainOp: {
+        find: 'methods',
+        where: { nameEndsWith: { suffix: 'Order' } },
+        extract: { operationName: { fromMethodName: true } },
+      },
+      eventHandler: { notUsed: true },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents([draft], config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.components[0]?._missing).toStrictEqual(['operationName'])
+  })
+})
+
+describe('enrichComponents — fromGenericArg extraction', () => {
+  it('extracts subscribed events from generic arg on containing class', () => {
+    const file = nextFile(
+      '/src/orders/order.handler.ts',
+      `interface IEventHandler<T> { subscribedEvents: string[] }
+export class OrderHandler implements IEventHandler<OrderPlaced> {
+  readonly subscribedEvents = ['OrderPlaced']
+  handle() {}
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'eventHandler',
+        name: 'handle',
+        location: {
+          file,
+          line: 4,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders/**',
+      domainOp: { notUsed: true },
+      eventHandler: {
+        find: 'methods',
+        where: { nameEndsWith: { suffix: 'handle' } },
+        extract: {
+          subscribedEvents: {
+            fromGenericArg: {
+              interface: 'IEventHandler',
+              position: 0,
+            },
+          },
+        },
+      },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents(drafts, config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.components[0]?.metadata).toStrictEqual({ subscribedEvents: ['OrderPlaced'] })
+    expect(result.failures).toStrictEqual([])
+  })
+
+  it('finds containing class when method is in second class of file', () => {
+    const file = nextFile(
+      '/src/orders/multi-class.handler.ts',
+      `interface IEventHandler<T> { subscribedEvents: string[] }
+export class UnrelatedService {
+  doSomething() {}
+}
+export class OrderHandler implements IEventHandler<OrderPlaced> {
+  readonly subscribedEvents = ['OrderPlaced']
+  handle() {}
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'eventHandler',
+        name: 'handle',
+        location: {
+          file,
+          line: 7,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders/**',
+      domainOp: { notUsed: true },
+      eventHandler: {
+        find: 'methods',
+        where: { nameEndsWith: { suffix: 'handle' } },
+        extract: {
+          subscribedEvents: {
+            fromGenericArg: {
+              interface: 'IEventHandler',
+              position: 0,
+            },
+          },
+        },
+      },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents(drafts, config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.components[0]?.metadata).toStrictEqual({ subscribedEvents: ['OrderPlaced'] })
+    expect(result.failures).toStrictEqual([])
+  })
+
+  it('records failure when no containing class found for fromGenericArg', () => {
+    const file = nextFile('/src/orders/standalone.ts', 'const x = 1')
+
+    const draft: DraftComponent = {
+      type: 'eventHandler',
+      name: 'handle',
+      location: {
+        file,
+        line: 1,
+      },
+      domain: 'orders',
+    }
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders/**',
+      domainOp: { notUsed: true },
+      eventHandler: {
+        find: 'methods',
+        where: { nameEndsWith: { suffix: 'handle' } },
+        extract: {
+          subscribedEvents: {
+            fromGenericArg: {
+              interface: 'IEventHandler',
+              position: 0,
+            },
+          },
+        },
+      },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents([draft], config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.field).toBe('subscribedEvents')
+    expect(result.components[0]?._missing).toStrictEqual(['subscribedEvents'])
+  })
+
+  it('records failure when source file not found for fromGenericArg', () => {
+    const draft: DraftComponent = {
+      type: 'eventHandler',
+      name: 'handle',
+      location: {
+        file: '/src/missing/handler.ts',
+        line: 4,
+      },
+      domain: 'orders',
+    }
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/**',
+      domainOp: { notUsed: true },
+      eventHandler: {
+        find: 'methods',
+        where: { nameEndsWith: { suffix: 'handle' } },
+        extract: {
+          subscribedEvents: {
+            fromGenericArg: {
+              interface: 'IEventHandler',
+              position: 0,
+            },
+          },
+        },
+      },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents([draft], config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.components[0]?._missing).toStrictEqual(['subscribedEvents'])
+  })
+
+  it('enriches class-based component with fromGenericArg', () => {
+    const file = nextFile(
+      '/src/orders/order.handler.ts',
+      `interface IEventHandler<T> { subscribedEvents: string[] }
+export class OrderHandler implements IEventHandler<OrderPlaced> {
+  readonly subscribedEvents = ['OrderPlaced']
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'eventHandler',
+        name: 'OrderHandler',
+        location: {
+          file,
+          line: 2,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders/**',
+      domainOp: { notUsed: true },
+      eventHandler: {
+        find: 'classes',
+        where: { nameEndsWith: { suffix: 'Handler' } },
+        extract: {
+          subscribedEvents: {
+            fromGenericArg: {
+              interface: 'IEventHandler',
+              position: 0,
+            },
+          },
+        },
+      },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents(drafts, config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.components[0]?.metadata).toStrictEqual({ subscribedEvents: ['OrderPlaced'] })
+    expect(result.failures).toStrictEqual([])
+  })
+})

--- a/packages/riviere-extract-ts/src/domain/value-extraction/enrich-components.ts
+++ b/packages/riviere-extract-ts/src/domain/value-extraction/enrich-components.ts
@@ -1,5 +1,5 @@
 import type {
-  ClassDeclaration, Project 
+  ClassDeclaration, MethodDeclaration, Project 
 } from 'ts-morph'
 import { posix } from 'node:path'
 import type {
@@ -11,6 +11,8 @@ import type {
   FromClassNameExtractionRule,
   FromFilePathExtractionRule,
   FromPropertyExtractionRule,
+  FromMethodNameExtractionRule,
+  FromGenericArgExtractionRule,
 } from '@living-architecture/riviere-extract-config'
 import type {
   DraftComponent, GlobMatcher 
@@ -21,7 +23,9 @@ import {
   evaluateFromClassNameRule,
   evaluateFromFilePathRule,
   evaluateFromPropertyRule,
+  evaluateFromMethodNameRule,
 } from './evaluate-extraction-rule'
+import { evaluateFromGenericArgRule } from './evaluate-extraction-rule-generic'
 import { ExtractionError } from '../../platform/domain/ast-literals/literal-detection'
 
 type MetadataValue = string | number | boolean | string[]
@@ -117,6 +121,14 @@ function isFromPropertyRule(rule: ExtractionRule): rule is FromPropertyExtractio
   return 'fromProperty' in rule
 }
 
+function isFromMethodNameRule(rule: ExtractionRule): rule is FromMethodNameExtractionRule {
+  return 'fromMethodName' in rule
+}
+
+function isFromGenericArgRule(rule: ExtractionRule): rule is FromGenericArgExtractionRule {
+  return 'fromGenericArg' in rule
+}
+
 function findClassAtLine(project: Project, draft: DraftComponent): ClassDeclaration {
   const sourceFile = project.getSourceFile(draft.location.file)
   if (sourceFile === undefined) {
@@ -140,6 +152,58 @@ function findClassAtLine(project: Project, draft: DraftComponent): ClassDeclarat
   }
 
   return classDecl
+}
+
+function findMethodAtLine(project: Project, draft: DraftComponent): MethodDeclaration {
+  const sourceFile = project.getSourceFile(draft.location.file)
+  if (sourceFile === undefined) {
+    throw new ExtractionError(
+      `Source file '${draft.location.file}' not found in project`,
+      draft.location.file,
+      draft.location.line,
+    )
+  }
+
+  for (const classDecl of sourceFile.getClasses()) {
+    const method = classDecl
+      .getMethods()
+      .find((m) => m.getStartLineNumber() === draft.location.line)
+    if (method !== undefined) {
+      return method
+    }
+  }
+
+  throw new ExtractionError(
+    `No method declaration found at line ${draft.location.line}`,
+    draft.location.file,
+    draft.location.line,
+  )
+}
+
+function findContainingClass(project: Project, draft: DraftComponent): ClassDeclaration {
+  const sourceFile = project.getSourceFile(draft.location.file)
+  if (sourceFile === undefined) {
+    throw new ExtractionError(
+      `Source file '${draft.location.file}' not found in project`,
+      draft.location.file,
+      draft.location.line,
+    )
+  }
+
+  const methodLine = draft.location.line
+  for (const classDecl of sourceFile.getClasses()) {
+    const classStart = classDecl.getStartLineNumber()
+    const classEnd = classDecl.getEndLineNumber()
+    if (methodLine >= classStart && methodLine <= classEnd) {
+      return classDecl
+    }
+  }
+
+  throw new ExtractionError(
+    `No containing class found for method at line ${methodLine}`,
+    draft.location.file,
+    draft.location.line,
+  )
 }
 
 function evaluateClassRule(rule: ExtractionRule, classDecl: ClassDeclaration): ExtractionResult {
@@ -170,6 +234,16 @@ function evaluateRule(
 
   if (isFromFilePathRule(rule)) {
     return evaluateFromFilePathRule(rule, draft.location.file)
+  }
+
+  if (isFromMethodNameRule(rule)) {
+    const methodDecl = findMethodAtLine(project, draft)
+    return evaluateFromMethodNameRule(rule, methodDecl)
+  }
+
+  if (isFromGenericArgRule(rule)) {
+    const classDecl = findContainingClass(project, draft)
+    return evaluateFromGenericArgRule(rule, classDecl)
   }
 
   const classDecl = findClassAtLine(project, draft)


### PR DESCRIPTION
- Remove handle from APIControllerDef and EventHandlerDef
- Add IEventHandler<T> for fromGenericArg extraction
- Wire fromMethodName/fromGenericArg into enrichment
- Add findMethodAtLine and findContainingClass
- Split method extraction tests into separate spec

Closes #168 (upstream fixes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new extraction strategies for component enrichment, enabling extraction from method names and generic arguments.
  * Enhanced event handler interface with improved type definitions for better type safety.

* **Tests**
  * Added comprehensive test coverage for extraction strategies, including success and failure scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->