### PR TITLE
fix(extract-conventions): fix typed ESLint test timeout on CI

### DIFF
--- a/packages/riviere-extract-conventions/src/eslint/event-publisher-method-signature.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/event-publisher-method-signature.spec.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import {
   afterAll, describe, expect, it 
 } from 'vitest'
@@ -14,7 +15,7 @@ const typedRuleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
       projectService: { allowDefaultProject: ['*.ts'] },
-      tsconfigRootDir: import.meta.dirname,
+      tsconfigRootDir: path.resolve(import.meta.dirname, '../..'),
     },
   },
 })


### PR DESCRIPTION
tsconfigRootDir pointed to src/eslint/ which has no tsconfig.json, forcing projectService into expensive allowDefaultProject fallback. Point to package root where tsconfig.spec.json exists instead.

First typed test: 9.2s → 1.1s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure configuration for ESLint rule testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->