### PR TITLE
fix(extract-conventions): increase testTimeout for typed ESLint tests

### DIFF
--- a/packages/riviere-extract-conventions/src/eslint/event-publisher-method-signature.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/event-publisher-method-signature.spec.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import {
   afterAll, describe, expect, it 
 } from 'vitest'
@@ -15,7 +14,7 @@ const typedRuleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
       projectService: { allowDefaultProject: ['*.ts'] },
-      tsconfigRootDir: path.resolve(import.meta.dirname, '../..'),
+      tsconfigRootDir: import.meta.dirname,
     },
   },
 })

--- a/packages/riviere-extract-conventions/vitest.config.mts
+++ b/packages/riviere-extract-conventions/vitest.config.mts
@@ -8,6 +8,7 @@ export default defineConfig(() => ({
   cacheDir: '../../node_modules/.vite/packages/riviere-extract-conventions',
   test: {
     name: '@living-architecture/riviere-extract-conventions',
+    testTimeout: 30_000,
     watch: false,
     globals: true,
     environment: 'node',


### PR DESCRIPTION
Reverts the ineffective tsconfigRootDir change from #257. The actual fix is increasing testTimeout to 30s — typed rule-tester tests bootstrap a full TypeScript program via allowDefaultProject, which takes ~9s on CI runners (shared vCPU Ubuntu) vs ~2s locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated ESLint rule tester configuration for improved directory resolution handling.
  * Increased test timeout duration to accommodate longer-running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->