### PR TITLE
fix(dev-workflow-v2): enable OpenCode workflow init path

### DIFF
--- a/.opencode/plugins/dev-workflow-v2.js
+++ b/.opencode/plugins/dev-workflow-v2.js
@@ -1,0 +1,3 @@
+import devWorkflowV2Plugin from '../../tools/dev-workflow-v2/src/shell/opencode-plugin.ts'
+
+export const DevWorkflowV2Plugin = devWorkflowV2Plugin

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,9 @@
   "$schema": "https://knip.dev/reference/knip-json",
   "ignoreDependencies": ["tailwindcss", "oxlint"],
   "workspaces": {
+    ".": {
+      "entry": [".opencode/plugins/dev-workflow-v2.js"]
+    },
     "apps/eclair": {
       "entry": ["src/main.tsx"],
       "project": ["src/**/*.ts", "src/**/*.tsx"]

--- a/knip.json
+++ b/knip.json
@@ -10,18 +10,17 @@
       "project": [".vitepress/**/*.ts", ".vitepress/**/*.vue"]
     },
     "packages/riviere-cli": {
-      "entry": ["src/shell/bin.ts", "src/shell/index.ts"],
+      "entry": ["src/shell/bin.ts"],
       "project": ["src/**/*.ts"]
     },
     "packages/riviere-role-enforcement": {
-      "entry": ["src/shell/bin.ts", "src/index.ts"],
       "project": ["src/**/*.ts"]
     },
     "packages/*": {
       "project": ["src/**/*.ts"]
     },
     "tools/dev-workflow-v2": {
-      "entry": ["src/shell/cli.ts"],
+      "entry": ["src/shell/cli.ts", "src/shell/opencode-plugin.ts"],
       "project": ["src/**/*.ts"],
       "ignoreDependencies": ["@types/better-sqlite3"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
     dependencies:
       '@ntcoding/agentic-workflow-builder':
         specifier: github:NTCoding/autonomous-claude-agent-team#path:packages/agentic-workflow-builder
-        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/5a91cb8ba2145c39fa495f9c3a9157e4d47b2a4e#path:packages/agentic-workflow-builder(zod@3.25.76)
+        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49#path:packages/agentic-workflow-builder(zod@3.25.76)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1595,9 +1595,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/5a91cb8ba2145c39fa495f9c3a9157e4d47b2a4e#path:packages/agentic-workflow-builder':
-    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/5a91cb8ba2145c39fa495f9c3a9157e4d47b2a4e}
-    version: 0.4.0
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49#path:packages/agentic-workflow-builder':
+    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49}
+    version: 0.5.0
     peerDependencies:
       zod: ^3.23.0
 
@@ -8443,7 +8443,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/5a91cb8ba2145c39fa495f9c3a9157e4d47b2a4e#path:packages/agentic-workflow-builder(zod@3.25.76)':
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49#path:packages/agentic-workflow-builder(zod@3.25.76)':
     dependencies:
       better-sqlite3: 12.8.0
       zod: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,7 +327,7 @@ importers:
     dependencies:
       '@ntcoding/agentic-workflow-builder':
         specifier: github:NTCoding/autonomous-claude-agent-team#path:packages/agentic-workflow-builder
-        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49#path:packages/agentic-workflow-builder(zod@3.25.76)
+        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336#path:packages/agentic-workflow-builder(zod@3.25.76)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1595,9 +1595,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49#path:packages/agentic-workflow-builder':
-    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49}
-    version: 0.5.0
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336#path:packages/agentic-workflow-builder':
+    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336}
+    version: 0.6.3
     peerDependencies:
       zod: ^3.23.0
 
@@ -1703,6 +1703,20 @@ packages:
 
   '@nx/workspace@22.5.2':
     resolution: {integrity: sha512-XImJ2NhUXo/bgNkuF1NAdYJjSzhN/iXZYSdhSREPN6Bh/thhloAQfpOrgFkxgxgNZv3RvldnnYNmGeKqMEW2jg==}
+
+  '@opencode-ai/plugin@1.4.3':
+    resolution: {integrity: sha512-Ob/3tVSIeuMRJBr2O23RtrnC5djRe01Lglx+TwGEmjrH9yDBJ2tftegYLnNEjRoMuzITgq9LD8168p4pzv+U/A==}
+    peerDependencies:
+      '@opentui/core': '>=0.1.97'
+      '@opentui/solid': '>=0.1.97'
+    peerDependenciesMeta:
+      '@opentui/core':
+        optional: true
+      '@opentui/solid':
+        optional: true
+
+  '@opencode-ai/sdk@1.4.3':
+    resolution: {integrity: sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.16.3':
     resolution: {integrity: sha512-CVyWHu6ACDqDcJxR4nmGiG8vDF4TISJHqRNzac5z/gPQycs/QrP/1pDsJBy0MD7jSw8nVq2E5WqeHQKabBG/Jg==}
@@ -3210,15 +3224,8 @@ packages:
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
-  better-sqlite3@12.8.0:
-    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
-
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
@@ -3347,9 +3354,6 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
@@ -3758,10 +3762,6 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -4134,10 +4134,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -4197,9 +4193,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -4353,9 +4346,6 @@ packages:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
     hasBin: true
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4553,9 +4543,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
@@ -5370,9 +5357,6 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -5397,9 +5381,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -5413,10 +5394,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
 
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
@@ -5736,12 +5713,6 @@ packages:
   preact@10.28.2:
     resolution: {integrity: sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5795,9 +5766,6 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   pumpify@1.5.1:
     resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
 
@@ -5834,10 +5802,6 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -6084,11 +6048,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -6151,12 +6110,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -6320,10 +6273,6 @@ packages:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -6356,9 +6305,6 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
-
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -7041,6 +6987,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
@@ -8443,10 +8392,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/f249fa7c919bdfbb9909619793c0465d16fbfc49#path:packages/agentic-workflow-builder(zod@3.25.76)':
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336#path:packages/agentic-workflow-builder(zod@3.25.76)':
     dependencies:
-      better-sqlite3: 12.8.0
+      '@opencode-ai/plugin': 1.4.3
       zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentui/core'
+      - '@opentui/solid'
 
   '@nx/devkit@22.5.2(nx@22.5.2(@swc-node/register@1.11.1(@swc/core@1.15.10)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.10))':
     dependencies:
@@ -8625,6 +8577,15 @@ snapshots:
       - '@swc-node/register'
       - '@swc/core'
       - debug
+
+  '@opencode-ai/plugin@1.4.3':
+    dependencies:
+      '@opencode-ai/sdk': 1.4.3
+      zod: 4.1.8
+
+  '@opencode-ai/sdk@1.4.3':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@oxc-resolver/binding-android-arm-eabi@11.16.3':
     optional: true
@@ -10268,18 +10229,9 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
-  better-sqlite3@12.8.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   birpc@2.9.0: {}
 
@@ -10422,8 +10374,6 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   check-error@2.1.3: {}
-
-  chownr@1.1.4: {}
 
   ci-info@4.3.1: {}
 
@@ -10837,8 +10787,6 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-eql@5.0.2: {}
-
-  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -11413,8 +11361,6 @@ snapshots:
 
   events@3.3.0: {}
 
-  expand-template@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   express-rate-limit@5.5.1: {}
@@ -11500,8 +11446,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  file-uri-to-path@1.0.0: {}
 
   filelist@1.0.4:
     dependencies:
@@ -11658,8 +11602,6 @@ snapshots:
       dargs: 8.1.0
       meow: 12.1.1
       split2: 4.2.0
-
-  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -11886,8 +11828,6 @@ snapshots:
   indent-string@5.0.0: {}
 
   inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   ini@4.1.1: {}
 
@@ -12804,8 +12744,6 @@ snapshots:
 
   mitt@3.0.1: {}
 
-  mkdirp-classic@0.5.3: {}
-
   mkdirp@1.0.4: {}
 
   mrmime@2.0.1: {}
@@ -12818,8 +12756,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0: {}
-
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -12827,10 +12763,6 @@ snapshots:
   negotiator@0.6.4: {}
 
   neo-async@2.6.2: {}
-
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.7.4
 
   node-fetch@2.6.7:
     dependencies:
@@ -13219,21 +13151,6 @@ snapshots:
 
   preact@10.28.2: {}
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.89.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-
   prelude-ls@1.2.1: {}
 
   prettier@3.8.0: {}
@@ -13288,11 +13205,6 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   pumpify@1.5.1:
     dependencies:
       duplexify: 3.7.1
@@ -13325,13 +13237,6 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -13601,8 +13506,6 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.7.4: {}
-
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -13706,14 +13609,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
 
   sirv@3.0.2:
     dependencies:
@@ -13913,8 +13808,6 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
-  strip-json-comments@2.0.1: {}
-
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -13936,13 +13829,6 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
-
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
 
   tar-stream@2.2.0:
     dependencies:
@@ -14716,6 +14602,8 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.8: {}
 
   zod@4.3.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
   tools/dev-workflow-v2:
     dependencies:
       '@ntcoding/agentic-workflow-builder':
-        specifier: github:NTCoding/autonomous-claude-agent-team#path:packages/agentic-workflow-builder
-        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336#path:packages/agentic-workflow-builder(zod@3.25.76)
+        specifier: github:NTCoding/autonomous-claude-agent-team#d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab&path:packages/agentic-workflow-builder
+        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab#path:packages/agentic-workflow-builder(zod@3.25.76)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1595,8 +1595,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336#path:packages/agentic-workflow-builder':
-    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336}
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab#path:packages/agentic-workflow-builder':
+    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab}
     version: 0.6.3
     peerDependencies:
       zod: ^3.23.0
@@ -8392,7 +8392,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/204a21b24ec242d600832efc8f814f9bf0a70336#path:packages/agentic-workflow-builder(zod@3.25.76)':
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab#path:packages/agentic-workflow-builder(zod@3.25.76)':
     dependencies:
       '@opencode-ai/plugin': 1.4.3
       zod: 3.25.76

--- a/tools/dev-workflow-v2/package.json
+++ b/tools/dev-workflow-v2/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ntcoding/agentic-workflow-builder": "github:NTCoding/autonomous-claude-agent-team#path:packages/agentic-workflow-builder",
+    "@ntcoding/agentic-workflow-builder": "github:NTCoding/autonomous-claude-agent-team#d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab&path:packages/agentic-workflow-builder",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tools/dev-workflow-v2/src/features/workflow/domain/fixtures/workflow-test-fixtures.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/domain/fixtures/workflow-test-fixtures.ts
@@ -21,7 +21,6 @@ const cleanGit: GitInfo = {
 export function makeDeps(overrides?: Partial<WorkflowDeps>): WorkflowDeps {
   return {
     getGitInfo: () => cleanGit,
-    checkPrChecks: () => true,
     getPrFeedback: () => ({
       unresolvedCount: 0,
       threads: [],

--- a/tools/dev-workflow-v2/src/features/workflow/domain/workflow.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/domain/workflow.ts
@@ -106,7 +106,6 @@ const RECORDING_OPS = defineRecordingOps<StateName, WorkflowState, WorkflowOpera
 /** @riviere-role value-object */
 export type WorkflowDeps = {
   readonly getGitInfo: () => GitInfo
-  readonly checkPrChecks: (prNumber: number) => boolean
   readonly getPrFeedback: (prNumber: number) => PRFeedbackResult
   readonly now: () => string
 }

--- a/tools/dev-workflow-v2/src/features/workflow/entrypoint/fixtures/workflow-cli-test-fixtures.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/entrypoint/fixtures/workflow-cli-test-fixtures.ts
@@ -54,7 +54,6 @@ export function buildTestContext(
       changedFilesVsDefault: ['src/test.ts'],
       hasCommitsVsDefault: true,
     }),
-    checkPrChecks: () => true,
     getPrFeedback: () => ({
       unresolvedCount: 0,
       threads: [],

--- a/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.spec.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.spec.ts
@@ -141,49 +141,6 @@ describe('WORKFLOW_DEFINITION', () => {
       expect(ctx.from).toStrictEqual('IMPLEMENTING')
       expect(ctx.to).toStrictEqual('REVIEWING')
     })
-
-    it('sets prChecksPass to false when prNumber exists', () => {
-      const state: WorkflowState = {
-        currentStateMachineState: 'IMPLEMENTING',
-        architectureReviewPassed: false,
-        codeReviewPassed: false,
-        bugScannerPassed: false,
-        taskCheckPassed: false,
-        ciPassed: false,
-        feedbackClean: false,
-        feedbackAddressed: false,
-        prNumber: 42,
-      }
-      const deps = makeWorkflowDeps()
-      const ctx = WORKFLOW_DEFINITION.buildTransitionContext(
-        state,
-        'IMPLEMENTING',
-        'REVIEWING',
-        deps,
-      )
-      expect(ctx.prChecksPass).toStrictEqual(false)
-    })
-
-    it('sets prChecksPass to false when no prNumber', () => {
-      const state: WorkflowState = {
-        currentStateMachineState: 'IMPLEMENTING',
-        architectureReviewPassed: false,
-        codeReviewPassed: false,
-        bugScannerPassed: false,
-        taskCheckPassed: false,
-        ciPassed: false,
-        feedbackClean: false,
-        feedbackAddressed: false,
-      }
-      const deps = makeWorkflowDeps()
-      const ctx = WORKFLOW_DEFINITION.buildTransitionContext(
-        state,
-        'IMPLEMENTING',
-        'REVIEWING',
-        deps,
-      )
-      expect(ctx.prChecksPass).toStrictEqual(false)
-    })
   })
 
   describe('buildTransitionEvent', () => {

--- a/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.spec.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.spec.ts
@@ -15,7 +15,6 @@ function makeWorkflowDeps(): WorkflowDeps {
       changedFilesVsDefault: [],
       hasCommitsVsDefault: false,
     }),
-    checkPrChecks: () => true,
     getPrFeedback: () => ({
       unresolvedCount: 0,
       threads: [],
@@ -143,7 +142,7 @@ describe('WORKFLOW_DEFINITION', () => {
       expect(ctx.to).toStrictEqual('REVIEWING')
     })
 
-    it('sets prChecksPass from deps when prNumber exists', () => {
+    it('sets prChecksPass to false when prNumber exists', () => {
       const state: WorkflowState = {
         currentStateMachineState: 'IMPLEMENTING',
         architectureReviewPassed: false,
@@ -162,7 +161,7 @@ describe('WORKFLOW_DEFINITION', () => {
         'REVIEWING',
         deps,
       )
-      expect(ctx.prChecksPass).toStrictEqual(true)
+      expect(ctx.prChecksPass).toStrictEqual(false)
     })
 
     it('sets prChecksPass to false when no prNumber', () => {

--- a/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.ts
@@ -70,11 +70,10 @@ export const WORKFLOW_DEFINITION: WorkflowDefinition<
     to: StateName,
     deps: WorkflowDeps,
   ): TransitionContext<WorkflowState, StateName> {
-    const prChecksPass = state.prNumber === undefined ? false : deps.checkPrChecks(state.prNumber)
     return {
       state,
       gitInfo: deps.getGitInfo(),
-      prChecksPass,
+      prChecksPass: false,
       from,
       to,
     }

--- a/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/infra/persistence/workflow-definition.ts
@@ -73,7 +73,6 @@ export const WORKFLOW_DEFINITION: WorkflowDefinition<
     return {
       state,
       gitInfo: deps.getGitInfo(),
-      prChecksPass: false,
       from,
       to,
     }

--- a/tools/dev-workflow-v2/src/shell/cli.ts
+++ b/tools/dev-workflow-v2/src/shell/cli.ts
@@ -23,7 +23,6 @@ createClaudeCodeWorkflowCli({
   processDeps: createDefaultProcessDeps(),
   buildWorkflowDeps: (platform) => ({
     getGitInfo,
-    checkPrChecks: () => true,
     getPrFeedback: createGetPrFeedback(runGh),
     now: platform.now,
   }),

--- a/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
+++ b/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
@@ -1,0 +1,45 @@
+import { createOpenCodeWorkflowPlugin } from '@ntcoding/agentic-workflow-builder/opencode'
+import { fileURLToPath } from 'node:url'
+import {
+  dirname, join 
+} from 'node:path'
+import type {
+  Workflow, WorkflowDeps 
+} from '../features/workflow/domain/workflow'
+import type {
+  WorkflowState,
+  StateName,
+  WorkflowOperation,
+} from '../features/workflow/domain/workflow-types'
+import { WORKFLOW_DEFINITION } from '../features/workflow/infra/persistence/workflow-definition'
+import {
+  ROUTES, PRE_TOOL_USE_POLICY 
+} from '../features/workflow/entrypoint/workflow-cli'
+import {
+  getGitInfo, runGh 
+} from '../features/workflow/infra/external-clients/git/git'
+import { createGetPrFeedback } from '../features/workflow/infra/external-clients/github/get-pr-feedback'
+
+const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+/** @riviere-role main */
+export default createOpenCodeWorkflowPlugin<
+  Workflow,
+  WorkflowState,
+  WorkflowDeps,
+  StateName,
+  WorkflowOperation
+>({
+  workflowDefinition: WORKFLOW_DEFINITION,
+  routes: ROUTES,
+  bashForbidden: PRE_TOOL_USE_POLICY.bashForbidden,
+  isWriteAllowed: PRE_TOOL_USE_POLICY.isWriteAllowed,
+  pluginRoot,
+  commandDirectories: [join(pluginRoot, 'commands')],
+  buildWorkflowDeps: (platform) => ({
+    getGitInfo,
+    checkPrChecks: () => true,
+    getPrFeedback: createGetPrFeedback(runGh),
+    now: platform.now,
+  }),
+})

--- a/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
+++ b/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
@@ -56,7 +56,6 @@ const basePlugin = createOpenCodeWorkflowPlugin<
   commandPrefix: 'dev-workflow-v2:',
   buildWorkflowDeps: (platform) => ({
     getGitInfo,
-    checkPrChecks: () => true,
     getPrFeedback: createGetPrFeedback(runGh),
     now: platform.now,
   }),

--- a/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
+++ b/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
@@ -22,8 +22,25 @@ import { createGetPrFeedback } from '../features/workflow/infra/external-clients
 
 const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
-/** @riviere-role main */
-export default createOpenCodeWorkflowPlugin<
+const OPEN_CODE_WORKFLOW_COMMAND = 'dev-workflow-v2:workflow'
+
+const OPEN_CODE_WORKFLOW_TEMPLATE = [
+  'Use the `workflow` tool.',
+  '',
+  'Arguments:',
+  '- First token of `$ARGUMENTS`: `operation`',
+  '- Remaining tokens of `$ARGUMENTS`: `args` array',
+  '',
+  'Examples:',
+  '- `/dev-workflow-v2:workflow init` -> `workflow({ operation: "init" })`',
+  '- `/dev-workflow-v2:workflow transition REVIEWING`',
+  '  -> `workflow({ operation: "transition", args: ["REVIEWING"] })`',
+].join('\n')
+
+type BaseHooks = Awaited<ReturnType<typeof basePlugin>>
+type OpenCodeConfigInput = Parameters<NonNullable<BaseHooks['config']>>[0]
+
+const basePlugin = createOpenCodeWorkflowPlugin<
   Workflow,
   WorkflowState,
   WorkflowDeps,
@@ -36,6 +53,7 @@ export default createOpenCodeWorkflowPlugin<
   isWriteAllowed: PRE_TOOL_USE_POLICY.isWriteAllowed,
   pluginRoot,
   commandDirectories: [join(pluginRoot, 'commands')],
+  commandPrefix: 'dev-workflow-v2:',
   buildWorkflowDeps: (platform) => ({
     getGitInfo,
     checkPrChecks: () => true,
@@ -43,3 +61,26 @@ export default createOpenCodeWorkflowPlugin<
     now: platform.now,
   }),
 })
+
+/** @riviere-role main */
+export default async (
+  input?: Parameters<typeof basePlugin>[0],
+  options?: Parameters<typeof basePlugin>[1],
+) => {
+  const hooks = await basePlugin(input, options)
+  const baseConfigHook = hooks.config
+
+  return {
+    ...hooks,
+    config: async (config: OpenCodeConfigInput) => {
+      if (baseConfigHook !== undefined) {
+        await baseConfigHook(config)
+      }
+
+      const command = config.command?.[OPEN_CODE_WORKFLOW_COMMAND]
+      if (command !== undefined) {
+        command.template = OPEN_CODE_WORKFLOW_TEMPLATE
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add project-local OpenCode plugin wiring at `.opencode/plugins/dev-workflow-v2.js` and include it in knip workspace entries so repo verification passes
- update `tools/dev-workflow-v2/src/shell/opencode-plugin.ts` to namespace commands as `dev-workflow-v2:*` and make `/dev-workflow-v2:workflow` map directly to the OpenCode `workflow` tool contract
- refresh lockfile to `@ntcoding/agentic-workflow-builder` `0.6.3`, which includes the Bun session-existence fix needed for successful `workflow init`

## Validation
- `opencode run "/dev-workflow-v2:workflow init" --print-logs --log-level DEBUG` now initializes successfully and returns IMPLEMENTING state guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stable dev-workflow v2 plugin entrypoint and exposed its workflow command with a user-facing workflow template.

* **Bug Fixes**
  * PR-check behavior changed: workflows no longer assume PR checks pass by default; PR gating now requires explicit checks.

* **Chores**
  * Updated workspace and entry-point configuration to improve tooling and plugin discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->