### PR TITLE
feat(extract): add HTTP client linking and conventions

### DIFF
--- a/apps/docs/reference/extraction-config/schema.md
+++ b/apps/docs/reference/extraction-config/schema.md
@@ -171,7 +171,7 @@ Extracts value from decorator argument on the containing class
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `fromClassDecoratorArg` | `object` | **Yes** | (no description) |
+| `fromClassDecoratorArg` | `any` \| `any` | **Yes** | (no description) |
 
 ---
 

--- a/apps/docs/reference/extraction-config/schema.md
+++ b/apps/docs/reference/extraction-config/schema.md
@@ -106,6 +106,7 @@ Extraction rules mapping field names to extraction rules
 - `fromFilePathExtractionRule` — Extracts value from the file path using regex capture
 - `fromPropertyExtractionRule` — Extracts value from a class property
 - `fromDecoratorArgExtractionRule` — Extracts value from decorator argument
+- `fromClassDecoratorArgExtractionRule` — Extracts value from decorator argument on the containing class
 - `fromDecoratorNameExtractionRule` — Extracts value from the decorator name itself
 - `fromGenericArgExtractionRule` — Extracts value from generic type argument
 - `fromMethodSignatureExtractionRule` — Extracts method parameters and return type
@@ -159,6 +160,18 @@ Extracts value from decorator argument
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `fromDecoratorArg` | `object` | **Yes** | (no description) |
+
+---
+
+### `fromClassDecoratorArgExtractionRule`
+
+Extracts value from decorator argument on the containing class
+
+**Properties:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fromClassDecoratorArg` | `object` | **Yes** | (no description) |
 
 ---
 

--- a/packages/riviere-cli/src/features/extract/__fixtures__/extraction-test-fixtures.ts
+++ b/packages/riviere-cli/src/features/extract/__fixtures__/extraction-test-fixtures.ts
@@ -28,6 +28,18 @@ const extractedLinkOutputSchema = z.looseObject({
   _uncertain: z.string().optional(),
 })
 
+const externalLinkOutputSchema = z.looseObject({
+  source: z.string(),
+  target: z.object({ name: z.string() }),
+  type: z.string().optional(),
+  sourceLocation: z
+    .object({
+      filePath: z.string(),
+      lineNumber: z.number(),
+    })
+    .optional(),
+})
+
 const extractionOutputSchema = z.object({
   success: z.literal(true),
   data: z.array(draftComponentSchema),
@@ -38,6 +50,7 @@ const fullExtractionOutputSchema = z.object({
   data: z.object({
     components: z.array(draftComponentSchema),
     links: z.array(extractedLinkOutputSchema),
+    externalLinks: z.array(externalLinkOutputSchema).optional(),
   }),
 })
 

--- a/packages/riviere-cli/src/features/extract/commands/enrich-draft-components-result.ts
+++ b/packages/riviere-cli/src/features/extract/commands/enrich-draft-components-result.ts
@@ -4,6 +4,7 @@ import type {
   EnrichedComponent,
   ExtractedLink,
 } from '@living-architecture/riviere-extract-ts'
+import type { ExternalLink } from '@living-architecture/riviere-schema'
 
 interface EnrichDraftComponentsDraftOnlyResult {
   kind: 'draftOnly'
@@ -14,6 +15,7 @@ interface EnrichDraftComponentsFullResult {
   kind: 'full'
   components: EnrichedComponent[]
   links: ExtractedLink[]
+  externalLinks: ExternalLink[]
   timings: ConnectionTimings[]
   failedFields: string[]
 }

--- a/packages/riviere-cli/src/features/extract/commands/extract-draft-components-result.ts
+++ b/packages/riviere-cli/src/features/extract/commands/extract-draft-components-result.ts
@@ -4,6 +4,7 @@ import type {
   EnrichedComponent,
   ExtractedLink,
 } from '@living-architecture/riviere-extract-ts'
+import type { ExternalLink } from '@living-architecture/riviere-schema'
 
 interface ExtractDraftComponentsDraftOnlyResult {
   kind: 'draftOnly'
@@ -14,6 +15,7 @@ interface ExtractDraftComponentsFullResult {
   kind: 'full'
   components: EnrichedComponent[]
   links: ExtractedLink[]
+  externalLinks: ExternalLink[]
   timings: ConnectionTimings[]
   failedFields: string[]
 }

--- a/packages/riviere-cli/src/features/extract/domain/detect-connections-per-module.spec.ts
+++ b/packages/riviere-cli/src/features/extract/domain/detect-connections-per-module.spec.ts
@@ -14,6 +14,7 @@ const {
   mockDeduplicateCrossStrategy,
   mockDetectCrossModule,
   mockDetectPerModule,
+  mockStripHttpCallComponents,
 } = vi.hoisted(() => ({
   mockExtractComponents: vi.fn().mockReturnValue([]),
   mockEnrichComponents: vi.fn().mockReturnValue({
@@ -30,6 +31,7 @@ const {
         type: 'sync',
       },
     ],
+    externalLinks: [],
     timings: {
       callGraphMs: 1,
       configurableMs: 0,
@@ -38,8 +40,10 @@ const {
   }),
   mockDetectCrossModule: vi.fn().mockReturnValue({
     links: [],
+    externalLinks: [],
     timings: { asyncDetectionMs: 0 },
   }),
+  mockStripHttpCallComponents: vi.fn((components: unknown[]) => components),
 }))
 
 vi.mock('@living-architecture/riviere-extract-ts', () => ({
@@ -49,6 +53,7 @@ vi.mock('@living-architecture/riviere-extract-ts', () => ({
   detectPerModuleConnections: mockDetectPerModule,
   detectCrossModuleConnections: mockDetectCrossModule,
   deduplicateCrossStrategy: mockDeduplicateCrossStrategy,
+  stripHttpCallComponents: mockStripHttpCallComponents,
 }))
 
 function createModule(name: string): Module {
@@ -115,6 +120,7 @@ describe('ExtractionProject.extractDraftComponents', () => {
           type: 'sync' as const,
         },
       ],
+      externalLinks: [],
       timings: {
         callGraphMs: 1,
         configurableMs: 0,

--- a/packages/riviere-cli/src/features/extract/domain/enrich-per-module.spec.ts
+++ b/packages/riviere-cli/src/features/extract/domain/enrich-per-module.spec.ts
@@ -22,11 +22,13 @@ const {
   mockDetectPerModuleConnections,
   mockDetectCrossModuleConnections,
   mockDeduplicateCrossStrategy,
+  mockStripHttpCallComponents,
 } = vi.hoisted(() => ({
   mockEnrichComponents: vi.fn(),
   mockMatchesGlob: vi.fn(),
   mockDetectPerModuleConnections: vi.fn().mockReturnValue({
     links: [],
+    externalLinks: [],
     timings: {
       callGraphMs: 0,
       configurableMs: 0,
@@ -35,9 +37,11 @@ const {
   }),
   mockDetectCrossModuleConnections: vi.fn().mockReturnValue({
     links: [],
+    externalLinks: [],
     timings: { asyncDetectionMs: 0 },
   }),
   mockDeduplicateCrossStrategy: vi.fn((links: ExtractedLink[]): ExtractedLink[] => links),
+  mockStripHttpCallComponents: vi.fn((components: unknown[]) => components),
 }))
 
 vi.mock('@living-architecture/riviere-extract-ts', () => ({
@@ -46,6 +50,7 @@ vi.mock('@living-architecture/riviere-extract-ts', () => ({
   detectPerModuleConnections: mockDetectPerModuleConnections,
   detectCrossModuleConnections: mockDetectCrossModuleConnections,
   deduplicateCrossStrategy: mockDeduplicateCrossStrategy,
+  stripHttpCallComponents: mockStripHttpCallComponents,
 }))
 
 const notUsedRule: ComponentRule = { notUsed: true }

--- a/packages/riviere-cli/src/features/extract/domain/extraction-outcome.ts
+++ b/packages/riviere-cli/src/features/extract/domain/extraction-outcome.ts
@@ -4,6 +4,7 @@ import type {
   EnrichedComponent,
   ExtractedLink,
 } from '@living-architecture/riviere-extract-ts'
+import type { ExternalLink } from '@living-architecture/riviere-schema'
 
 interface DraftOnlyOutcome {
   kind: 'draftOnly'
@@ -15,6 +16,7 @@ interface FullExtractionOutcome {
   components: EnrichedComponent[]
   failedFields: string[]
   links: ExtractedLink[]
+  externalLinks: ExternalLink[]
   timings: ConnectionTimings[]
 }
 

--- a/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
+++ b/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
@@ -10,11 +10,13 @@ import {
   enrichComponents,
   extractComponents,
   matchesGlob,
+  stripHttpCallComponents,
   type ConnectionTimings,
   type DraftComponent,
   type EnrichedComponent,
   type ExtractedLink,
 } from '@living-architecture/riviere-extract-ts'
+import type { ExternalLink } from '@living-architecture/riviere-schema'
 import type { ExtractionOutcome } from './extraction-outcome'
 
 /** @riviere-role value-object */
@@ -84,12 +86,14 @@ export class ExtractionProject {
     }
 
     const connectionResult = this.detectConnections(enrichment.components, options.allowIncomplete)
+    const visibleComponents = stripHttpCallComponents(enrichment.components)
 
     return {
       kind: 'full',
-      components: enrichment.components,
+      components: visibleComponents,
       failedFields: enrichment.failedFields,
       links: connectionResult.links,
+      externalLinks: connectionResult.externalLinks,
       timings: connectionResult.timings,
     }
   }
@@ -114,12 +118,14 @@ export class ExtractionProject {
     }
 
     const connectionResult = this.detectConnections(enrichment.components, options.allowIncomplete)
+    const visibleComponents = stripHttpCallComponents(enrichment.components)
 
     return {
       kind: 'full',
-      components: enrichment.components,
+      components: visibleComponents,
       failedFields: enrichment.failedFields,
       links: connectionResult.links,
+      externalLinks: connectionResult.externalLinks,
       timings: connectionResult.timings,
     }
   }
@@ -133,9 +139,11 @@ export class ExtractionProject {
     allowIncomplete: boolean,
   ): {
     links: ExtractedLink[]
+    externalLinks: ExternalLink[]
     timings: ConnectionTimings[]
   } {
     const links: ExtractedLink[] = []
+    const externalLinks: ExternalLink[] = []
     const timings: ConnectionTimings[] = []
 
     for (const moduleContext of this.moduleContexts) {
@@ -157,6 +165,7 @@ export class ExtractionProject {
         matchesGlob,
       )
       links.push(...result.links)
+      externalLinks.push(...result.externalLinks)
       timings.push({
         callGraphMs: result.timings.callGraphMs,
         asyncDetectionMs: 0,
@@ -173,6 +182,7 @@ export class ExtractionProject {
       eventPublishers: this.resolvedConfig.connections?.eventPublishers,
     })
     links.push(...crossResult.links)
+    externalLinks.push(...crossResult.externalLinks)
     timings.push({
       callGraphMs: 0,
       asyncDetectionMs: crossResult.timings.asyncDetectionMs,
@@ -183,6 +193,7 @@ export class ExtractionProject {
 
     return {
       links: deduplicateCrossStrategy(links),
+      externalLinks,
       timings,
     }
   }

--- a/packages/riviere-cli/src/features/extract/infra/cli/output/present-extraction-result.ts
+++ b/packages/riviere-cli/src/features/extract/infra/cli/output/present-extraction-result.ts
@@ -82,6 +82,7 @@ function presentFullResult(
     formatSuccess({
       components: result.components,
       links: result.links,
+      externalLinks: result.externalLinks,
     }),
     createOutputOptions(options.output),
   )

--- a/packages/riviere-extract-config/docs/generated/schema.md
+++ b/packages/riviere-extract-config/docs/generated/schema.md
@@ -171,7 +171,7 @@ Extracts value from decorator argument on the containing class
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `fromClassDecoratorArg` | `object` | **Yes** | (no description) |
+| `fromClassDecoratorArg` | `any` \| `any` | **Yes** | (no description) |
 
 ---
 

--- a/packages/riviere-extract-config/docs/generated/schema.md
+++ b/packages/riviere-extract-config/docs/generated/schema.md
@@ -106,6 +106,7 @@ Extraction rules mapping field names to extraction rules
 - `fromFilePathExtractionRule` — Extracts value from the file path using regex capture
 - `fromPropertyExtractionRule` — Extracts value from a class property
 - `fromDecoratorArgExtractionRule` — Extracts value from decorator argument
+- `fromClassDecoratorArgExtractionRule` — Extracts value from decorator argument on the containing class
 - `fromDecoratorNameExtractionRule` — Extracts value from the decorator name itself
 - `fromGenericArgExtractionRule` — Extracts value from generic type argument
 - `fromMethodSignatureExtractionRule` — Extracts method parameters and return type
@@ -159,6 +160,18 @@ Extracts value from decorator argument
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `fromDecoratorArg` | `object` | **Yes** | (no description) |
+
+---
+
+### `fromClassDecoratorArgExtractionRule`
+
+Extracts value from decorator argument on the containing class
+
+**Properties:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fromClassDecoratorArg` | `object` | **Yes** | (no description) |
 
 ---
 

--- a/packages/riviere-extract-config/extraction-config.schema.json
+++ b/packages/riviere-extract-config/extraction-config.schema.json
@@ -16,10 +16,7 @@
       "description": "Module definitions for component extraction",
       "minItems": 1,
       "items": {
-        "oneOf": [
-          { "$ref": "#/$defs/module" },
-          { "$ref": "#/$defs/moduleRef" }
-        ]
+        "oneOf": [{ "$ref": "#/$defs/module" }, { "$ref": "#/$defs/moduleRef" }]
       }
     },
     "connections": {
@@ -167,6 +164,7 @@
         { "$ref": "#/$defs/fromFilePathExtractionRule" },
         { "$ref": "#/$defs/fromPropertyExtractionRule" },
         { "$ref": "#/$defs/fromDecoratorArgExtractionRule" },
+        { "$ref": "#/$defs/fromClassDecoratorArgExtractionRule" },
         { "$ref": "#/$defs/fromDecoratorNameExtractionRule" },
         { "$ref": "#/$defs/fromGenericArgExtractionRule" },
         { "$ref": "#/$defs/fromMethodSignatureExtractionRule" },
@@ -241,6 +239,26 @@
           "additionalProperties": false,
           "minProperties": 1,
           "properties": {
+            "decorator": { "type": "string", "minLength": 1 },
+            "position": { "type": "integer", "minimum": 0 },
+            "name": { "type": "string", "minLength": 1 },
+            "transform": { "$ref": "#/$defs/transform" }
+          }
+        }
+      }
+    },
+    "fromClassDecoratorArgExtractionRule": {
+      "type": "object",
+      "description": "Extracts value from decorator argument on the containing class",
+      "required": ["fromClassDecoratorArg"],
+      "additionalProperties": false,
+      "properties": {
+        "fromClassDecoratorArg": {
+          "type": "object",
+          "required": ["decorator"],
+          "additionalProperties": false,
+          "properties": {
+            "decorator": { "type": "string", "minLength": 1 },
             "position": { "type": "integer", "minimum": 0 },
             "name": { "type": "string", "minLength": 1 },
             "transform": { "$ref": "#/$defs/transform" }

--- a/packages/riviere-extract-config/extraction-config.schema.json
+++ b/packages/riviere-extract-config/extraction-config.schema.json
@@ -262,7 +262,17 @@
             "position": { "type": "integer", "minimum": 0 },
             "name": { "type": "string", "minLength": 1 },
             "transform": { "$ref": "#/$defs/transform" }
-          }
+          },
+          "oneOf": [
+            {
+              "required": ["position"],
+              "not": { "required": ["name"] }
+            },
+            {
+              "required": ["name"],
+              "not": { "required": ["position"] }
+            }
+          ]
         }
       }
     },

--- a/packages/riviere-extract-config/src/extraction-config-schema.ts
+++ b/packages/riviere-extract-config/src/extraction-config-schema.ts
@@ -96,6 +96,17 @@ export interface FromPropertyExtractionRule {
 /** Extracts value from decorator argument. */
 export interface FromDecoratorArgExtractionRule {
   fromDecoratorArg: {
+    decorator?: string
+    position?: number
+    name?: string
+    transform?: Transform
+  }
+}
+
+/** Extracts value from decorator argument on the containing class. */
+export interface FromClassDecoratorArgExtractionRule {
+  fromClassDecoratorArg: {
+    decorator: string
     position?: number
     name?: string
     transform?: Transform
@@ -146,6 +157,7 @@ export type ExtractionRule =
   | FromFilePathExtractionRule
   | FromPropertyExtractionRule
   | FromDecoratorArgExtractionRule
+  | FromClassDecoratorArgExtractionRule
   | FromDecoratorNameExtractionRule
   | FromGenericArgExtractionRule
   | FromMethodSignatureExtractionRule

--- a/packages/riviere-extract-config/src/extraction-config-schema.ts
+++ b/packages/riviere-extract-config/src/extraction-config-schema.ts
@@ -105,12 +105,19 @@ export interface FromDecoratorArgExtractionRule {
 
 /** Extracts value from decorator argument on the containing class. */
 export interface FromClassDecoratorArgExtractionRule {
-  fromClassDecoratorArg: {
-    decorator: string
-    position?: number
-    name?: string
-    transform?: Transform
-  }
+  fromClassDecoratorArg:
+    | {
+      decorator: string
+      position: number
+      name?: never
+      transform?: Transform
+    }
+    | {
+      decorator: string
+      name: string
+      position?: never
+      transform?: Transform
+    }
 }
 
 /** Extracts value from the decorator name itself. */

--- a/packages/riviere-extract-config/src/validation-from-class-decorator-arg.spec.ts
+++ b/packages/riviere-extract-config/src/validation-from-class-decorator-arg.spec.ts
@@ -1,0 +1,25 @@
+import { validateExtractionConfigSchema } from './validation'
+import { createMutableConfig } from './validation-fixtures'
+
+describe('fromClassDecoratorArg extraction rule schema validation', () => {
+  it('returns valid when decorator and position are provided', () => {
+    const {
+      config, module 
+    } = createMutableConfig()
+
+    module.api = {
+      find: 'methods',
+      where: { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+      extract: {
+        serviceName: {
+          fromClassDecoratorArg: {
+            decorator: 'HttpClient',
+            position: 0,
+          },
+        },
+      },
+    }
+
+    expect(validateExtractionConfigSchema(config).valid).toBe(true)
+  })
+})

--- a/packages/riviere-extract-config/src/validation-from-class-decorator-arg.spec.ts
+++ b/packages/riviere-extract-config/src/validation-from-class-decorator-arg.spec.ts
@@ -22,4 +22,102 @@ describe('fromClassDecoratorArg extraction rule schema validation', () => {
 
     expect(validateExtractionConfigSchema(config).valid).toBe(true)
   })
+
+  it('returns invalid when decorator is missing', () => {
+    const {
+      config, module 
+    } = createMutableConfig()
+
+    module.api = {
+      find: 'methods',
+      where: { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+      extract: { serviceName: { fromClassDecoratorArg: { position: 0 } } },
+    }
+
+    const result = validateExtractionConfigSchema(config)
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((error) => error.message.includes('decorator'))).toBe(true)
+  })
+
+  it('returns invalid when neither position nor name is provided', () => {
+    const {
+      config, module 
+    } = createMutableConfig()
+
+    module.api = {
+      find: 'methods',
+      where: { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+      extract: { serviceName: { fromClassDecoratorArg: { decorator: 'HttpClient' } } },
+    }
+
+    const result = validateExtractionConfigSchema(config)
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.errors.some(
+        (error) => error.path.includes('/fromClassDecoratorArg') || error.message.includes('oneOf'),
+      ),
+    ).toBe(true)
+  })
+
+  it('returns invalid when both position and name are provided', () => {
+    const {
+      config, module 
+    } = createMutableConfig()
+
+    module.api = {
+      find: 'methods',
+      where: { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+      extract: {
+        serviceName: {
+          fromClassDecoratorArg: {
+            decorator: 'HttpClient',
+            position: 0,
+            name: 'serviceName',
+          },
+        },
+      },
+    }
+
+    const result = validateExtractionConfigSchema(config)
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((error) => error.message.includes('must NOT be valid'))).toBe(true)
+  })
+
+  it('returns invalid when decorator and position have wrong types', () => {
+    const invalidConfig: unknown = {
+      modules: [
+        {
+          name: 'test',
+          path: '.',
+          glob: 'src/**',
+          api: {
+            find: 'methods',
+            where: { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+            extract: {
+              serviceName: {
+                fromClassDecoratorArg: {
+                  decorator: 123,
+                  position: 'zero',
+                },
+              },
+            },
+          },
+          useCase: { notUsed: true },
+          domainOp: { notUsed: true },
+          event: { notUsed: true },
+          eventHandler: { notUsed: true },
+          ui: { notUsed: true },
+        },
+      ],
+    }
+
+    const result = validateExtractionConfigSchema(invalidConfig)
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((error) => error.message.includes('must be string'))).toBe(true)
+    expect(result.errors.some((error) => error.message.includes('must be integer'))).toBe(true)
+  })
 })

--- a/packages/riviere-extract-conventions/src/decorators.spec.ts
+++ b/packages/riviere-extract-conventions/src/decorators.spec.ts
@@ -12,6 +12,8 @@ import {
   DomainOp,
   APIEndpoint,
   EventHandler,
+  HttpClient,
+  HttpCall,
   Custom,
   Ignore,
   getCustomType,
@@ -179,6 +181,20 @@ describe('Method-level decorators', () => {
       }
 
       expect(new OrderEventListener().onOrderCreated()).toBe(true)
+    })
+  })
+
+  describe('HttpClient and HttpCall', () => {
+    it('preserves method behavior when class and method are decorated', () => {
+      @HttpClient('Fraud Detection Service')
+      class FraudClient {
+        @HttpCall('/api/check')
+        check(): string {
+          return 'ok'
+        }
+      }
+
+      expect(new FraudClient().check()).toBe('ok')
     })
   })
 })

--- a/packages/riviere-extract-conventions/src/decorators.ts
+++ b/packages/riviere-extract-conventions/src/decorators.ts
@@ -89,6 +89,28 @@ export function EventHandler<T extends Method>(target: T, _: ClassMethodDecorato
   return target
 }
 
+/**
+ * Marks a class as an HTTP client for a named remote service.
+ */
+export function HttpClient(
+  _serviceName: string,
+): <T>(target: T, context: ClassDecoratorContext) => T {
+  return function <T>(target: T, _: ClassDecoratorContext): T {
+    return target
+  }
+}
+
+/**
+ * Marks a method as an HTTP call operation.
+ */
+export function HttpCall(
+  _route: string,
+): <T extends Method>(target: T, context: ClassMethodDecoratorContext) => T {
+  return function <T extends Method>(target: T, _: ClassMethodDecoratorContext): T {
+    return target
+  }
+}
+
 // ============================================================================
 // Other Decorators
 // ============================================================================

--- a/packages/riviere-extract-conventions/src/default-config.spec.ts
+++ b/packages/riviere-extract-conventions/src/default-config.spec.ts
@@ -89,6 +89,37 @@ describe('Default extraction config', () => {
     expect(moduleKeys).toStrictEqual(expect.arrayContaining(requiredKeys))
     expect(moduleKeys).toHaveLength(10)
     expect(module.customTypes).toHaveProperty('eventPublisher')
+    expect(module.customTypes).toHaveProperty('httpCall')
+  })
+
+  it('configures httpCall customType extraction from HttpClient and HttpCall decorators', () => {
+    const config = loadDefaultConfig()
+    const module = getFirstModule(config)
+    const customTypes = module.customTypes
+    expect(customTypes).toBeDefined()
+    expect(customTypes?.['httpCall']).toStrictEqual({
+      find: 'methods',
+      where: {
+        and: [
+          { hasDecorator: { name: 'HttpCall' } },
+          { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+        ],
+      },
+      extract: {
+        serviceName: {
+          fromClassDecoratorArg: {
+            decorator: 'HttpClient',
+            position: 0,
+          },
+        },
+        route: {
+          fromDecoratorArg: {
+            decorator: 'HttpCall',
+            position: 0,
+          },
+        },
+      },
+    })
   })
 
   it.each([

--- a/packages/riviere-extract-conventions/src/default-config.spec.ts
+++ b/packages/riviere-extract-conventions/src/default-config.spec.ts
@@ -101,8 +101,20 @@ describe('Default extraction config', () => {
       find: 'methods',
       where: {
         and: [
-          { hasDecorator: { name: 'HttpCall' } },
-          { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+          {
+            hasDecorator: {
+              name: 'HttpCall',
+              from: '@living-architecture/riviere-extract-conventions',
+            },
+          },
+          {
+            inClassWith: {
+              hasDecorator: {
+                name: 'HttpClient',
+                from: '@living-architecture/riviere-extract-conventions',
+              },
+            },
+          },
         ],
       },
       extract: {

--- a/packages/riviere-extract-conventions/src/default-extraction.config.json
+++ b/packages/riviere-extract-conventions/src/default-extraction.config.json
@@ -101,13 +101,15 @@
             "and": [
               {
                 "hasDecorator": {
-                  "name": "HttpCall"
+                  "name": "HttpCall",
+                  "from": "@living-architecture/riviere-extract-conventions"
                 }
               },
               {
                 "inClassWith": {
                   "hasDecorator": {
-                    "name": "HttpClient"
+                    "name": "HttpClient",
+                    "from": "@living-architecture/riviere-extract-conventions"
                   }
                 }
               }

--- a/packages/riviere-extract-conventions/src/default-extraction.config.json
+++ b/packages/riviere-extract-conventions/src/default-extraction.config.json
@@ -94,6 +94,39 @@
           "extract": {
             "publishedEventType": { "fromParameterType": { "position": 0 } }
           }
+        },
+        "httpCall": {
+          "find": "methods",
+          "where": {
+            "and": [
+              {
+                "hasDecorator": {
+                  "name": "HttpCall"
+                }
+              },
+              {
+                "inClassWith": {
+                  "hasDecorator": {
+                    "name": "HttpClient"
+                  }
+                }
+              }
+            ]
+          },
+          "extract": {
+            "serviceName": {
+              "fromClassDecoratorArg": {
+                "decorator": "HttpClient",
+                "position": 0
+              }
+            },
+            "route": {
+              "fromDecoratorArg": {
+                "decorator": "HttpCall",
+                "position": 0
+              }
+            }
+          }
         }
       }
     }

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-http-client-container.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-http-client-container.cjs
@@ -1,0 +1,68 @@
+function hasDecoratorNamed(decorators, decoratorName) {
+  /* v8 ignore next 3 -- typescript-eslint provides an array for decorators on class and method nodes; undefined is structurally unreachable in current parser output */
+  if (!decorators) {
+    return false
+  }
+  return decorators.some((decorator) => {
+    const expression = decorator.expression
+    if (expression.type === 'Identifier') {
+      return expression.name === decoratorName
+    }
+    return (
+      expression.type === 'CallExpression' &&
+      expression.callee.type === 'Identifier' &&
+      expression.callee.name === decoratorName
+    )
+  })
+}
+
+function isMethodWithHttpCallDecorator(member) {
+  if (member.type !== 'MethodDefinition') {
+    return false
+  }
+  if (member.key.type !== 'Identifier') {
+    return false
+  }
+  return hasDecoratorNamed(member.decorators, 'HttpCall')
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Require HttpCall methods to be inside HttpClient classes' },
+    schema: [],
+    messages: {
+      missingHttpClientContainer:
+        "Method '{{methodName}}' uses @HttpCall but its class '{{className}}' is missing @HttpClient",
+    },
+  },
+  create(context) {
+    return {
+      ClassDeclaration(node) {
+        if (!node.id) {
+          return
+        }
+
+        const hasHttpClientDecorator = hasDecoratorNamed(node.decorators, 'HttpClient')
+        if (hasHttpClientDecorator) {
+          return
+        }
+
+        for (const member of node.body.body) {
+          if (!isMethodWithHttpCallDecorator(member)) {
+            continue
+          }
+
+          context.report({
+            node: member.key,
+            messageId: 'missingHttpClientContainer',
+            data: {
+              className: node.id.name,
+              methodName: member.key.name,
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-http-client-container.d.cts
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-http-client-container.d.cts
@@ -1,0 +1,5 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+declare const rule: TSESLint.RuleModule<string, readonly unknown[]>
+
+export = rule

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-http-client-container.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-http-client-container.spec.ts
@@ -1,0 +1,66 @@
+import {
+  afterAll, describe, expect, it 
+} from 'vitest'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './http-call-requires-http-client-container.cjs'
+
+RuleTester.afterAll = afterAll
+RuleTester.it = it
+RuleTester.describe = describe
+
+const ruleTester = new RuleTester()
+
+const missingContainerError = (className: string, methodName: string) => ({
+  messageId: 'missingHttpClientContainer' as const,
+  data: {
+    className,
+    methodName,
+  },
+})
+
+describe('http-call-requires-http-client-container', () => {
+  it('is a valid ESLint rule', () => {
+    expect(rule).toBeDefined()
+  })
+
+  ruleTester.run('http-call-requires-http-client-container', rule, {
+    valid: [
+      {
+        name: 'passes when class has HttpClient and method has HttpCall',
+        code: "@HttpClient('Fraud Service') class FraudClient { @HttpCall('/check') checkFraud() {} }",
+      },
+      {
+        name: 'passes when class uses identifier HttpClient decorator syntax',
+        code: "@HttpClient class FraudClient { @HttpCall('/check') checkFraud() {} }",
+      },
+      {
+        name: 'ignores classes without HttpCall methods',
+        code: 'class FraudClient { checkFraud() {} }',
+      },
+      {
+        name: 'ignores anonymous default export classes',
+        code: "export default class { @HttpCall('/check') checkFraud() {} }",
+      },
+      {
+        name: 'ignores non-method class members',
+        code: "class FraudClient { readonly route = '/check' }",
+      },
+      {
+        name: 'ignores methods with non-identifier keys',
+        code: "class FraudClient { @HttpCall('/check') ['checkFraud']() {} }",
+      },
+    ],
+    invalid: [
+      {
+        name: 'reports when class has HttpCall method but no HttpClient decorator',
+        code: "class FraudClient { @HttpCall('/check') checkFraud() {} }",
+        errors: [missingContainerError('FraudClient', 'checkFraud')],
+      },
+      {
+        name: 'reports when method uses identifier HttpCall decorator and class has no HttpClient',
+        code: 'class FraudClient { @HttpCall checkFraud() {} }',
+        errors: [missingContainerError('FraudClient', 'checkFraud')],
+      },
+    ],
+  })
+})

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.cjs
@@ -1,0 +1,74 @@
+function findHttpCallDecoratorExpression(decorators) {
+  for (const decorator of decorators) {
+    const expression = decorator.expression
+    if (expression.type === 'Identifier' && expression.name === 'HttpCall') {
+      return expression
+    }
+    if (expression.type !== 'CallExpression') {
+      continue
+    }
+    if (expression.callee.type !== 'Identifier' || expression.callee.name !== 'HttpCall') {
+      continue
+    }
+    return expression
+  }
+  return null
+}
+
+function getRouteViolation(decoratorExpression) {
+  if (decoratorExpression.type === 'Identifier') {
+    return 'missingRoute'
+  }
+  if (decoratorExpression.arguments.length === 0) {
+    return 'missingRoute'
+  }
+
+  const firstArgument = decoratorExpression.arguments[0]
+  if (firstArgument.type !== 'Literal' || typeof firstArgument.value !== 'string') {
+    return 'routeNotLiteral'
+  }
+
+  if (firstArgument.value.trim().length === 0) {
+    return 'emptyRoute'
+  }
+
+  return null
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Require HttpCall decorator to include route' },
+    schema: [],
+    messages: {
+      missingRoute: "Method '{{methodName}}' uses @HttpCall but is missing route argument",
+      routeNotLiteral: "Method '{{methodName}}' uses @HttpCall but route must be a string literal",
+      emptyRoute: "Method '{{methodName}}' uses @HttpCall but route must be non-empty",
+    },
+  },
+  create(context) {
+    return {
+      MethodDefinition(node) {
+        if (node.key.type !== 'Identifier' || !node.decorators) {
+          return
+        }
+
+        const decoratorExpression = findHttpCallDecoratorExpression(node.decorators)
+        if (!decoratorExpression) {
+          return
+        }
+
+        const violation = getRouteViolation(decoratorExpression)
+        if (!violation) {
+          return
+        }
+
+        context.report({
+          node: node.key,
+          messageId: violation,
+          data: { methodName: node.key.name },
+        })
+      },
+    }
+  },
+}

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.d.cts
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.d.cts
@@ -1,0 +1,5 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+declare const rule: TSESLint.RuleModule<string, readonly unknown[]>
+
+export = rule

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.spec.ts
@@ -1,0 +1,79 @@
+import {
+  afterAll, describe, expect, it 
+} from 'vitest'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './http-call-requires-route.cjs'
+
+RuleTester.afterAll = afterAll
+RuleTester.it = it
+RuleTester.describe = describe
+
+const ruleTester = new RuleTester()
+
+const missingRouteError = (methodName: string) => ({
+  messageId: 'missingRoute' as const,
+  data: { methodName },
+})
+
+const routeNotLiteralError = (methodName: string) => ({
+  messageId: 'routeNotLiteral' as const,
+  data: { methodName },
+})
+
+const emptyRouteError = (methodName: string) => ({
+  messageId: 'emptyRoute' as const,
+  data: { methodName },
+})
+
+describe('http-call-requires-route', () => {
+  it('is a valid ESLint rule', () => {
+    expect(rule).toBeDefined()
+  })
+
+  ruleTester.run('http-call-requires-route', rule, {
+    valid: [
+      {
+        name: 'ignores methods without HttpCall decorator',
+        code: 'class FraudClient { checkFraud() {} }',
+      },
+      {
+        name: 'accepts HttpCall when route is non-empty string literal',
+        code: "class FraudClient { @HttpCall('/check') checkFraud() {} }",
+      },
+      {
+        name: 'ignores non-call decorators that are not HttpCall',
+        code: 'class FraudClient { @Other checkFraud() {} }',
+      },
+      {
+        name: 'ignores call decorators that are not HttpCall',
+        code: "class FraudClient { @Other('/check') checkFraud() {} }",
+      },
+      {
+        name: 'ignores methods with non-identifier keys',
+        code: "class FraudClient { @HttpCall('/check') ['checkFraud']() {} }",
+      },
+    ],
+    invalid: [
+      {
+        name: 'reports when HttpCall has no route argument',
+        code: 'class FraudClient { @HttpCall() checkFraud() {} }',
+        errors: [missingRouteError('checkFraud')],
+      },
+      {
+        name: 'reports when HttpCall route is not a string literal',
+        code: "const ROUTE = '/fraud/check'; class FraudClient { @HttpCall(ROUTE) checkFraud() {} }",
+        errors: [routeNotLiteralError('checkFraud')],
+      },
+      {
+        name: 'reports when HttpCall route is an empty string literal',
+        code: "class FraudClient { @HttpCall('') checkFraud() {} }",
+        errors: [emptyRouteError('checkFraud')],
+      },
+      {
+        name: 'reports when HttpCall decorator is used without call syntax',
+        code: 'class FraudClient { @HttpCall checkFraud() {} }',
+        errors: [missingRouteError('checkFraud')],
+      },
+    ],
+  })
+})

--- a/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.cjs
@@ -1,0 +1,73 @@
+function hasDecoratorNamed(decorators, decoratorName) {
+  /* v8 ignore next 3 -- typescript-eslint provides an array for decorators on class and method nodes; undefined is structurally unreachable in current parser output */
+  if (!decorators) {
+    return false
+  }
+
+  return decorators.some((decorator) => {
+    const expression = decorator.expression
+    if (expression.type === 'Identifier') {
+      return expression.name === decoratorName
+    }
+    return (
+      expression.type === 'CallExpression' &&
+      expression.callee.type === 'Identifier' &&
+      expression.callee.name === decoratorName
+    )
+  })
+}
+
+function isPublicInstanceMethod(member) {
+  if (member.type !== 'MethodDefinition') {
+    return false
+  }
+  if (member.kind === 'constructor' || member.kind === 'get' || member.kind === 'set') {
+    return false
+  }
+  if (member.static) {
+    return false
+  }
+  if (member.accessibility === 'private' || member.accessibility === 'protected') {
+    return false
+  }
+  return member.key.type === 'Identifier'
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {description: 'Require public methods in HttpClient classes to have HttpCall decorator',},
+    schema: [],
+    messages: {
+      missingHttpCall:
+        "Public method '{{methodName}}' in @HttpClient class '{{className}}' must have @HttpCall",
+    },
+  },
+  create(context) {
+    return {
+      ClassDeclaration(node) {
+        if (!node.id || !hasDecoratorNamed(node.decorators, 'HttpClient')) {
+          return
+        }
+
+        for (const member of node.body.body) {
+          if (!isPublicInstanceMethod(member)) {
+            continue
+          }
+          if (hasDecoratorNamed(member.decorators, 'HttpCall')) {
+            continue
+          }
+
+          context.report({
+            node: member.key,
+            messageId: 'missingHttpCall',
+            data: {
+              className: node.id.name,
+              methodName: member.key.name,
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.cjs
@@ -46,11 +46,18 @@ module.exports = {
   create(context) {
     return {
       ClassDeclaration(node) {
+        if (hasDecoratorNamed(node.decorators, 'Ignore')) {
+          return
+        }
+
         if (!node.id || !hasDecoratorNamed(node.decorators, 'HttpClient')) {
           return
         }
 
         for (const member of node.body.body) {
+          if (hasDecoratorNamed(member.decorators, 'Ignore')) {
+            continue
+          }
           if (!isPublicInstanceMethod(member)) {
             continue
           }

--- a/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.d.cts
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.d.cts
@@ -1,0 +1,5 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+declare const rule: TSESLint.RuleModule<string, readonly unknown[]>
+
+export = rule

--- a/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.spec.ts
@@ -1,0 +1,77 @@
+import {
+  afterAll, describe, expect, it 
+} from 'vitest'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './http-client-public-methods-require-http-call.cjs'
+
+RuleTester.afterAll = afterAll
+RuleTester.it = it
+RuleTester.describe = describe
+
+const ruleTester = new RuleTester()
+
+const missingHttpCallError = (className: string, methodName: string) => ({
+  messageId: 'missingHttpCall' as const,
+  data: {
+    className,
+    methodName,
+  },
+})
+
+describe('http-client-public-methods-require-http-call', () => {
+  it('is a valid ESLint rule', () => {
+    expect(rule).toBeDefined()
+  })
+
+  ruleTester.run('http-client-public-methods-require-http-call', rule, {
+    valid: [
+      {
+        name: 'passes when HttpClient public method has HttpCall',
+        code: "@HttpClient('Fraud Service') class FraudClient { @HttpCall('/check') checkFraud() {} }",
+      },
+      {
+        name: 'passes when HttpClient and HttpCall use identifier decorator syntax',
+        code: '@HttpClient class FraudClient { @HttpCall checkFraud() {} }',
+      },
+      {
+        name: 'ignores classes without HttpClient decorator',
+        code: 'class FraudClient { checkFraud() {} }',
+      },
+      {
+        name: 'ignores anonymous default export classes',
+        code: "export default class { @HttpCall('/check') checkFraud() {} }",
+      },
+      {
+        name: 'ignores constructors in HttpClient classes',
+        code: "@HttpClient('Fraud Service') class FraudClient { constructor() {} }",
+      },
+      {
+        name: 'ignores getters and setters in HttpClient classes',
+        code: "@HttpClient('Fraud Service') class FraudClient { get status() { return 'ok' } set status(v) {} }",
+      },
+      {
+        name: 'ignores static methods in HttpClient classes',
+        code: "@HttpClient('Fraud Service') class FraudClient { static checkFraud() {} }",
+      },
+      {
+        name: 'ignores private and protected methods in HttpClient classes',
+        code: "@HttpClient('Fraud Service') class FraudClient { private checkPrivate() {} protected checkProtected() {} }",
+      },
+      {
+        name: 'ignores non-method class members in HttpClient classes',
+        code: "@HttpClient('Fraud Service') class FraudClient { readonly route = '/check' }",
+      },
+      {
+        name: 'ignores methods with non-identifier keys in HttpClient classes',
+        code: "@HttpClient('Fraud Service') class FraudClient { ['checkFraud']() {} }",
+      },
+    ],
+    invalid: [
+      {
+        name: 'reports when HttpClient public method is missing HttpCall',
+        code: "@HttpClient('Fraud Service') class FraudClient { checkFraud() {} }",
+        errors: [missingHttpCallError('FraudClient', 'checkFraud')],
+      },
+    ],
+  })
+})

--- a/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-public-methods-require-http-call.spec.ts
@@ -39,7 +39,15 @@ describe('http-client-public-methods-require-http-call', () => {
       },
       {
         name: 'ignores anonymous default export classes',
-        code: "export default class { @HttpCall('/check') checkFraud() {} }",
+        code: "@HttpClient('Fraud Service') export default class { @HttpCall('/check') checkFraud() {} }",
+      },
+      {
+        name: 'ignores classes decorated with Ignore',
+        code: "@Ignore @HttpClient('Fraud Service') class FraudClient { checkFraud() {} }",
+      },
+      {
+        name: 'ignores methods decorated with Ignore',
+        code: "@HttpClient('Fraud Service') class FraudClient { @Ignore checkFraud() {} }",
       },
       {
         name: 'ignores constructors in HttpClient classes',

--- a/packages/riviere-extract-conventions/src/eslint/http-client-requires-remote-name.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-requires-remote-name.cjs
@@ -1,0 +1,77 @@
+function findHttpClientDecoratorExpression(decorators) {
+  for (const decorator of decorators) {
+    const expression = decorator.expression
+    if (expression.type === 'Identifier' && expression.name === 'HttpClient') {
+      return expression
+    }
+    if (expression.type !== 'CallExpression') {
+      continue
+    }
+    if (expression.callee.type !== 'Identifier' || expression.callee.name !== 'HttpClient') {
+      continue
+    }
+    return expression
+  }
+  return null
+}
+
+function getServiceNameViolation(callExpression) {
+  if (callExpression.type === 'Identifier') {
+    return 'missingServiceName'
+  }
+
+  if (callExpression.arguments.length === 0) {
+    return 'missingServiceName'
+  }
+
+  const firstArgument = callExpression.arguments[0]
+  if (firstArgument.type !== 'Literal' || typeof firstArgument.value !== 'string') {
+    return 'serviceNameNotLiteral'
+  }
+
+  if (firstArgument.value.trim().length === 0) {
+    return 'emptyServiceName'
+  }
+
+  return null
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Require HttpClient decorator to include service name' },
+    schema: [],
+    messages: {
+      missingServiceName:
+        "Class '{{className}}' uses @HttpClient but is missing service name argument",
+      serviceNameNotLiteral:
+        "Class '{{className}}' uses @HttpClient but service name must be a string literal",
+      emptyServiceName: "Class '{{className}}' uses @HttpClient but service name must be non-empty",
+    },
+  },
+  create(context) {
+    return {
+      ClassDeclaration(node) {
+        if (!node.id || !node.decorators) {
+          return
+        }
+
+        const decoratorCall = findHttpClientDecoratorExpression(node.decorators)
+        if (!decoratorCall) {
+          return
+        }
+
+        const violation = getServiceNameViolation(decoratorCall)
+        if (!violation) {
+          return
+        }
+
+        context.report({
+          node: node.id,
+          messageId: violation,
+          data: { className: node.id.name },
+        })
+      },
+    }
+  },
+}

--- a/packages/riviere-extract-conventions/src/eslint/http-client-requires-remote-name.d.cts
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-requires-remote-name.d.cts
@@ -1,0 +1,5 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+declare const rule: TSESLint.RuleModule<string, readonly unknown[]>
+
+export = rule

--- a/packages/riviere-extract-conventions/src/eslint/http-client-requires-remote-name.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/http-client-requires-remote-name.spec.ts
@@ -1,0 +1,79 @@
+import {
+  afterAll, describe, expect, it 
+} from 'vitest'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './http-client-requires-remote-name.cjs'
+
+RuleTester.afterAll = afterAll
+RuleTester.it = it
+RuleTester.describe = describe
+
+const ruleTester = new RuleTester()
+
+const missingServiceNameError = (className: string) => ({
+  messageId: 'missingServiceName' as const,
+  data: { className },
+})
+
+const serviceNameNotLiteralError = (className: string) => ({
+  messageId: 'serviceNameNotLiteral' as const,
+  data: { className },
+})
+
+const emptyServiceNameError = (className: string) => ({
+  messageId: 'emptyServiceName' as const,
+  data: { className },
+})
+
+describe('http-client-requires-service-name', () => {
+  it('is a valid ESLint rule', () => {
+    expect(rule).toBeDefined()
+  })
+
+  ruleTester.run('http-client-requires-service-name', rule, {
+    valid: [
+      {
+        name: 'ignores classes without HttpClient decorator',
+        code: 'class CheckoutGateway {}',
+      },
+      {
+        name: 'ignores classes with non-call decorators that are not HttpClient',
+        code: '@SomeDecorator class CheckoutGateway {}',
+      },
+      {
+        name: 'ignores classes with call decorators that are not HttpClient',
+        code: '@SomeDecorator() class CheckoutGateway {}',
+      },
+      {
+        name: 'accepts HttpClient when service name is non-empty string literal',
+        code: "@HttpClient('Fraud Service') class FraudClient {}",
+      },
+      {
+        name: 'ignores anonymous default export classes',
+        code: 'export default class {}',
+      },
+    ],
+    invalid: [
+      {
+        name: 'reports error when HttpClient has no service name argument',
+        code: '@HttpClient() class FraudClient {}',
+        errors: [missingServiceNameError('FraudClient')],
+      },
+      {
+        name: 'reports error when HttpClient argument is not a string literal',
+        code: "const REMOTE = 'Fraud Service'; @HttpClient(REMOTE) class FraudClient {}",
+        errors: [serviceNameNotLiteralError('FraudClient')],
+      },
+      {
+        name: 'reports error when HttpClient argument is an empty string literal',
+        code: "@HttpClient('') class FraudClient {}",
+        errors: [emptyServiceNameError('FraudClient')],
+      },
+      {
+        name: 'reports error when HttpClient decorator is used without call syntax',
+        code: '@HttpClient class FraudClient {}',
+        errors: [missingServiceNameError('FraudClient')],
+      },
+    ],
+  })
+})

--- a/packages/riviere-extract-conventions/src/eslint/index.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/index.cjs
@@ -27,6 +27,13 @@ function toRestrictedImportPath(packageName) {
   }
 }
 
+function toRestrictedImportPattern(packageName) {
+  return {
+    group: [`${packageName}/*`],
+    message: `Do not import subpaths from '${packageName}'. Use @HttpClient/@HttpCall conventions for HTTP boundary code.`,
+  }
+}
+
 module.exports = {
   rules: {
     'require-component-decorator': requireComponentDecorator,
@@ -46,7 +53,10 @@ module.exports = {
       rules: {
         'no-restricted-imports': [
           'error',
-          {paths: restrictedHttpClientImports.map(toRestrictedImportPath),},
+          {
+            paths: restrictedHttpClientImports.map(toRestrictedImportPath),
+            patterns: restrictedHttpClientImports.map(toRestrictedImportPattern),
+          },
         ],
       },
     },

--- a/packages/riviere-extract-conventions/src/eslint/index.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/index.cjs
@@ -4,6 +4,28 @@ const eventRequiresTypeProperty = require('./event-requires-type-property.cjs')
 const eventHandlerRequiresSubscribedEvents = require('./event-handler-requires-subscribed-events.cjs')
 const uiPageRequiresRoute = require('./ui-page-requires-route.cjs')
 const eventPublisherMethodSignature = require('./event-publisher-method-signature.cjs')
+const httpClientRequiresRemoteName = require('./http-client-requires-remote-name.cjs')
+const httpCallRequiresRoute = require('./http-call-requires-route.cjs')
+const httpCallRequiresHttpClientContainer = require('./http-call-requires-http-client-container.cjs')
+const httpClientPublicMethodsRequireHttpCall = require('./http-client-public-methods-require-http-call.cjs')
+const noFetchOutsideHttpClient = require('./no-fetch-outside-http-client.cjs')
+
+const restrictedHttpClientImports = [
+  'axios',
+  'got',
+  'node-fetch',
+  'undici',
+  'superagent',
+  'node:http',
+  'node:https',
+]
+
+function toRestrictedImportPath(packageName) {
+  return {
+    name: packageName,
+    message: `Do not import '${packageName}' directly. Use @HttpClient/@HttpCall conventions for HTTP boundary code.`,
+  }
+}
 
 module.exports = {
   rules: {
@@ -13,5 +35,20 @@ module.exports = {
     'event-handler-requires-subscribed-events': eventHandlerRequiresSubscribedEvents,
     'ui-page-requires-route': uiPageRequiresRoute,
     'event-publisher-method-signature': eventPublisherMethodSignature,
+    'http-client-requires-service-name': httpClientRequiresRemoteName,
+    'http-call-requires-route': httpCallRequiresRoute,
+    'http-call-requires-http-client-container': httpCallRequiresHttpClientContainer,
+    'http-client-public-methods-require-http-call': httpClientPublicMethodsRequireHttpCall,
+    'no-fetch-outside-http-client': noFetchOutsideHttpClient,
+  },
+  configs: {
+    'http-client-import-boundary': {
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {paths: restrictedHttpClientImports.map(toRestrictedImportPath),},
+        ],
+      },
+    },
   },
 }

--- a/packages/riviere-extract-conventions/src/eslint/index.d.ts
+++ b/packages/riviere-extract-conventions/src/eslint/index.d.ts
@@ -40,6 +40,7 @@ interface Plugin {
           'error',
           {
             paths: Array<{ name: string; message: string }>
+            patterns: Array<{ group: string[]; message: string }>
           },
         ]
       }

--- a/packages/riviere-extract-conventions/src/eslint/index.d.ts
+++ b/packages/riviere-extract-conventions/src/eslint/index.d.ts
@@ -15,6 +15,35 @@ interface Plugin {
       'missingSubscribedEvents' | 'subscribedEventsNotLiteralArray'
     >
     'ui-page-requires-route': TSESLint.RuleModule<'missingRoute' | 'routeNotLiteral'>
+    'event-publisher-method-signature': TSESLint.RuleModule<
+      | 'missingParameter'
+      | 'tooManyParameters'
+      | 'missingTypeAnnotation'
+      | 'notTypeReference'
+      | 'notEventDef'
+      | 'nonPublicMethod'
+    >
+    'http-client-requires-service-name': TSESLint.RuleModule<
+      'missingServiceName' | 'serviceNameNotLiteral' | 'emptyServiceName'
+    >
+    'http-call-requires-route': TSESLint.RuleModule<
+      'missingRoute' | 'routeNotLiteral' | 'emptyRoute'
+    >
+    'http-call-requires-http-client-container': TSESLint.RuleModule<'missingHttpClientContainer'>
+    'http-client-public-methods-require-http-call': TSESLint.RuleModule<'missingHttpCall'>
+    'no-fetch-outside-http-client': TSESLint.RuleModule<'fetchOutsideHttpClient'>
+  }
+  configs: {
+    'http-client-import-boundary': {
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: Array<{ name: string; message: string }>
+          },
+        ]
+      }
+    }
   }
 }
 

--- a/packages/riviere-extract-conventions/src/eslint/no-fetch-outside-http-client.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/no-fetch-outside-http-client.cjs
@@ -1,0 +1,60 @@
+function hasDecoratorNamed(decorators, decoratorName) {
+  /* v8 ignore next 3 -- typescript-eslint provides an array for decorators on class and method nodes; undefined is structurally unreachable in current parser output */
+  if (!decorators) {
+    return false
+  }
+  return decorators.some((decorator) => {
+    const expression = decorator.expression
+    if (expression.type === 'Identifier') {
+      return expression.name === decoratorName
+    }
+    return (
+      expression.type === 'CallExpression' &&
+      expression.callee.type === 'Identifier' &&
+      expression.callee.name === decoratorName
+    )
+  })
+}
+
+function getEnclosingClassDeclaration(sourceCode, node) {
+  const ancestors = sourceCode.getAncestors(node)
+  for (let index = ancestors.length - 1; index >= 0; index -= 1) {
+    const ancestor = ancestors[index]
+    if (ancestor.type === 'ClassDeclaration') {
+      return ancestor
+    }
+  }
+  return null
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Disallow fetch usage outside HttpClient classes' },
+    schema: [],
+    messages: {
+      fetchOutsideHttpClient:
+        "Call to '{{calleeName}}' is only allowed inside classes decorated with @HttpClient",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'fetch') {
+          return
+        }
+
+        const enclosingClass = getEnclosingClassDeclaration(context.sourceCode, node)
+        if (enclosingClass && hasDecoratorNamed(enclosingClass.decorators, 'HttpClient')) {
+          return
+        }
+
+        context.report({
+          node,
+          messageId: 'fetchOutsideHttpClient',
+          data: { calleeName: 'fetch' },
+        })
+      },
+    }
+  },
+}

--- a/packages/riviere-extract-conventions/src/eslint/no-fetch-outside-http-client.d.cts
+++ b/packages/riviere-extract-conventions/src/eslint/no-fetch-outside-http-client.d.cts
@@ -1,0 +1,5 @@
+import type { TSESLint } from '@typescript-eslint/utils'
+
+declare const rule: TSESLint.RuleModule<string, readonly unknown[]>
+
+export = rule

--- a/packages/riviere-extract-conventions/src/eslint/no-fetch-outside-http-client.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/no-fetch-outside-http-client.spec.ts
@@ -1,0 +1,47 @@
+import {
+  afterAll, describe, expect, it 
+} from 'vitest'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import rule from './no-fetch-outside-http-client.cjs'
+
+RuleTester.afterAll = afterAll
+RuleTester.it = it
+RuleTester.describe = describe
+
+const ruleTester = new RuleTester()
+
+const fetchOutsideHttpClientError = () => ({
+  messageId: 'fetchOutsideHttpClient' as const,
+  data: { calleeName: 'fetch' },
+})
+
+describe('no-fetch-outside-http-client', () => {
+  it('is a valid ESLint rule', () => {
+    expect(rule).toBeDefined()
+  })
+
+  ruleTester.run('no-fetch-outside-http-client', rule, {
+    valid: [
+      {
+        name: 'allows fetch inside HttpClient class method',
+        code: "@HttpClient('Fraud Service') class FraudClient { @HttpCall('/check') async check() { await fetch('/x') } }",
+      },
+      {
+        name: 'allows fetch inside identifier HttpClient class decorator syntax',
+        code: "@HttpClient class FraudClient { async check() { await fetch('/x') } }",
+      },
+    ],
+    invalid: [
+      {
+        name: 'reports fetch usage outside HttpClient class',
+        code: "async function check() { await fetch('/x') }",
+        errors: [fetchOutsideHttpClientError()],
+      },
+      {
+        name: 'reports fetch usage inside class without HttpClient decorator',
+        code: "class FraudClient { async check() { await fetch('/x') } }",
+        errors: [fetchOutsideHttpClientError()],
+      },
+    ],
+  })
+})

--- a/packages/riviere-extract-conventions/src/eslint/rule-module-declarations.d.ts
+++ b/packages/riviere-extract-conventions/src/eslint/rule-module-declarations.d.ts
@@ -1,0 +1,59 @@
+type GenericRuleModule = import('@typescript-eslint/utils').TSESLint.RuleModule<
+  string,
+  readonly unknown[]
+>
+
+declare module './api-controller-requires-route-and-method.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './event-handler-requires-subscribed-events.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './event-publisher-method-signature.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './event-requires-type-property.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './http-call-requires-http-client-container.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './http-call-requires-route.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './http-client-public-methods-require-http-call.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './http-client-requires-remote-name.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './no-fetch-outside-http-client.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './require-component-decorator.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}
+
+declare module './ui-page-requires-route.cjs' {
+  const rule: GenericRuleModule
+  export default rule
+}

--- a/packages/riviere-extract-conventions/src/index.ts
+++ b/packages/riviere-extract-conventions/src/index.ts
@@ -12,6 +12,8 @@ export {
   DomainOp,
   APIEndpoint,
   EventHandler,
+  HttpClient,
+  HttpCall,
   // Other decorators
   Custom,
   Ignore,

--- a/packages/riviere-extract-conventions/tsconfig.spec.json
+++ b/packages/riviere-extract-conventions/tsconfig.spec.json
@@ -2,13 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
-    "types": [
-      "vitest/globals",
-      "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ],
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"],
     "forceConsistentCasingInFileNames": true
   },
   "include": [
@@ -24,7 +18,8 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "src/**/*.d.cts"
   ],
   "references": [
     {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.dedup.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.dedup.spec.ts
@@ -1,8 +1,11 @@
 import {
   describe, it, expect 
 } from 'vitest'
-import { deduplicateCrossStrategy } from './detect-connections'
+import {
+  deduplicateCrossStrategy, stripHttpCallComponents 
+} from './detect-connections'
 import type { ExtractedLink } from './extracted-link'
+import { buildComponent } from './call-graph/call-graph-fixtures'
 
 function createLink(overrides: Partial<ExtractedLink> = {}): ExtractedLink {
   return {
@@ -51,5 +54,20 @@ describe('deduplicateCrossStrategy', () => {
     const result = deduplicateCrossStrategy([linkA, linkB])
 
     expect(result).toHaveLength(2)
+  })
+})
+
+describe('stripHttpCallComponents', () => {
+  it('removes httpCall components and keeps non-httpCall components', () => {
+    const filePath = '/src/http.ts'
+    const useCase = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: { serviceName: 'Fraud Detection Service' },
+    })
+
+    const result = stripHttpCallComponents([useCase, httpCall])
+
+    expect(result).toStrictEqual([useCase])
   })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
@@ -271,11 +271,10 @@ export function detectConnections(
     repository,
   )
 
-  const totalMs = performance.now() - totalStart
-
   const allLinks = [...syncLinks, ...publishLinks, ...subscribeLinks, ...configurableLinks]
   const deduplicatedLinks = deduplicateCrossStrategy(allLinks)
   const rewritten = rewriteHttpCallLinks(deduplicatedLinks, components)
+  const totalMs = performance.now() - totalStart
 
   return {
     links: rewritten.links,

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
@@ -4,6 +4,7 @@ import type {
   ConnectionPattern,
   EventPublisherConfig,
 } from '@living-architecture/riviere-extract-config'
+import type { ExternalLink } from '@living-architecture/riviere-schema'
 import type { EnrichedComponent } from '../value-extraction/enrich-components'
 import type { GlobMatcher } from '../component-extraction/extractor'
 import type { ExtractedLink } from './extracted-link'
@@ -12,6 +13,10 @@ import { buildCallGraph } from './call-graph/build-call-graph'
 import { detectEventPublisherConnections } from './async-detection/detect-event-publisher-connections'
 import { detectSubscribeConnections } from './async-detection/detect-subscribe-connections'
 import { detectConfigurableConnections } from './configurable/detect-configurable-connections'
+import {
+  rewriteHttpCallLinks,
+  stripHttpCallComponents as stripHttpCallComponentsInternal,
+} from './http-call-link-rewrite'
 
 /** @riviere-role value-object */
 export interface ConnectionDetectionOptions {
@@ -34,6 +39,7 @@ export interface ConnectionTimings {
 /** @riviere-role value-object */
 export interface ConnectionDetectionResult {
   links: ExtractedLink[]
+  externalLinks: ExternalLink[]
   timings: ConnectionTimings
 }
 
@@ -65,6 +71,13 @@ export function deduplicateCrossStrategy(links: ExtractedLink[]): ExtractedLink[
   return [...seen.values()]
 }
 
+/** @riviere-role domain-service */
+export function stripHttpCallComponents(
+  components: readonly EnrichedComponent[],
+): EnrichedComponent[] {
+  return stripHttpCallComponentsInternal(components)
+}
+
 /** @riviere-role value-object */
 export interface PerModuleConnectionOptions {
   allowIncomplete?: boolean
@@ -83,6 +96,7 @@ export interface PerModuleTimings {
 /** @riviere-role value-object */
 export interface PerModuleDetectionResult {
   links: ExtractedLink[]
+  externalLinks: ExternalLink[]
   timings: PerModuleTimings
 }
 
@@ -121,8 +135,11 @@ export function detectPerModuleConnections(
     repository,
   )
 
+  const rewritten = rewriteHttpCallLinks([...syncLinks, ...configurableLinks], components)
+
   return {
-    links: [...syncLinks, ...configurableLinks],
+    links: rewritten.links,
+    externalLinks: rewritten.externalLinks,
     timings: {
       callGraphMs,
       configurableMs,
@@ -144,6 +161,7 @@ export interface CrossModuleTimings {asyncDetectionMs: number}
 /** @riviere-role value-object */
 export interface CrossModuleDetectionResult {
   links: ExtractedLink[]
+  externalLinks: ExternalLink[]
   timings: CrossModuleTimings
 }
 
@@ -170,6 +188,7 @@ export function detectCrossModuleConnections(
 
   return {
     links: [...publishLinks, ...subscribeLinks],
+    externalLinks: [],
     timings: { asyncDetectionMs },
   }
 }
@@ -256,9 +275,11 @@ export function detectConnections(
 
   const allLinks = [...syncLinks, ...publishLinks, ...subscribeLinks, ...configurableLinks]
   const deduplicatedLinks = deduplicateCrossStrategy(allLinks)
+  const rewritten = rewriteHttpCallLinks(deduplicatedLinks, components)
 
   return {
-    links: deduplicatedLinks,
+    links: rewritten.links,
+    externalLinks: rewritten.externalLinks,
     timings: {
       callGraphMs,
       asyncDetectionMs,

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
@@ -144,4 +144,53 @@ class ExcludedUseCase {
       }),
     ])
   })
+
+  it('rewrites links targeting httpCall components into external links', () => {
+    const project = createProject()
+    const filePath = '/src/http.ts'
+    project.createSourceFile(
+      filePath,
+      `
+class FraudClient {
+  check(): void {}
+}
+
+class PlaceOrder {
+  private fraud: FraudClient
+  constructor(fraud: FraudClient) { this.fraud = fraud }
+  execute(): void {
+    this.fraud.check()
+  }
+}
+`,
+    )
+
+    const useCase = buildComponent('PlaceOrder', filePath, 6)
+    const httpCall = buildComponent('check', filePath, 3, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'Fraud Detection Service',
+        route: '/api/check',
+      },
+    })
+
+    const result = detectPerModuleConnections(
+      project,
+      [useCase, httpCall],
+      {
+        repository: 'test-repo',
+        moduleGlobs: ['/src/**/*.ts'],
+      },
+      matchesGlob,
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      expect.objectContaining({
+        source: 'orders:useCase:PlaceOrder',
+        target: { name: 'Fraud Detection Service' },
+        type: 'sync',
+      }),
+    ])
+  })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
@@ -188,7 +188,10 @@ class PlaceOrder {
     expect(result.externalLinks).toStrictEqual([
       expect.objectContaining({
         source: 'orders:useCase:PlaceOrder',
-        target: { name: 'Fraud Detection Service' },
+        target: {
+          name: 'Fraud Detection Service',
+          route: '/api/check',
+        },
         type: 'sync',
       }),
     ])

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -34,7 +34,10 @@ describe('rewriteHttpCallLinks', () => {
     expect(result.externalLinks).toStrictEqual([
       {
         source: 'orders:useCase:PlaceOrder',
-        target: { name: 'Fraud Detection Service' },
+        target: {
+          name: 'Fraud Detection Service',
+          route: '/api/check',
+        },
         type: 'sync',
       },
     ])
@@ -67,6 +70,55 @@ describe('rewriteHttpCallLinks', () => {
       metadata: {},
     })
 
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, target],
+      ),
+    ).toThrowError(/serviceName/)
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, target],
+      ),
+    ).toThrow(ConnectionDetectionError)
+  })
+
+  it('throws when httpCall route metadata is invalid', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const target = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'Fraud Detection Service',
+        route: 123,
+      },
+    })
+
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, target],
+      ),
+    ).toThrowError(/route/)
     expect(() =>
       rewriteHttpCallLinks(
         [

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -1,0 +1,136 @@
+import {
+  describe, it, expect 
+} from 'vitest'
+import { buildComponent } from './call-graph/call-graph-fixtures'
+import { ConnectionDetectionError } from './connection-detection-error'
+import {
+  rewriteHttpCallLinks, stripHttpCallComponents 
+} from './http-call-link-rewrite'
+
+describe('rewriteHttpCallLinks', () => {
+  it('rewrites links targeting httpCall components into external links', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const target = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'Fraud Detection Service',
+        route: '/api/check',
+      },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, target],
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: { name: 'Fraud Detection Service' },
+        type: 'sync',
+      },
+    ])
+  })
+
+  it('keeps non-httpCall links unchanged', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const target = buildComponent('OrderRepository', filePath, 2, { type: 'repository' })
+
+    const links = [
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: 'orders:repository:OrderRepository',
+        type: 'sync' as const,
+      },
+    ]
+
+    const result = rewriteHttpCallLinks(links, [source, target])
+
+    expect(result.links).toStrictEqual(links)
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('throws when httpCall serviceName metadata is missing', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const target = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {},
+    })
+
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, target],
+      ),
+    ).toThrow(ConnectionDetectionError)
+  })
+
+  it('omits type when input link has undefined type and keeps source location', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const target = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: { serviceName: 'Fraud Detection Service' },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          sourceLocation: {
+            repository: 'test-repo',
+            filePath,
+            lineNumber: 10,
+            methodName: 'execute',
+          },
+        },
+      ],
+      [source, target],
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: { name: 'Fraud Detection Service' },
+        sourceLocation: {
+          repository: 'test-repo',
+          filePath,
+          lineNumber: 10,
+          methodName: 'execute',
+        },
+      },
+    ])
+  })
+})
+
+describe('stripHttpCallComponents', () => {
+  it('removes httpCall components from final list', () => {
+    const filePath = '/src/http.ts'
+    const useCase = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: { serviceName: 'Fraud Detection Service' },
+    })
+
+    const result = stripHttpCallComponents([useCase, httpCall])
+    expect(result).toStrictEqual([useCase])
+  })
+})

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -62,6 +62,75 @@ describe('rewriteHttpCallLinks', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
+  it('keeps internal link when httpCall serviceName matches internal component name', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'FraudGateway',
+        route: '/api/check',
+      },
+    })
+    const internalTarget = buildComponent('FraudGateway', filePath, 3, { type: 'repository' })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalTarget],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: 'orders:repository:FraudGateway',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('throws when httpCall serviceName matches multiple internal components', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: { serviceName: 'FraudGateway' },
+    })
+    const repositoryTarget = buildComponent('FraudGateway', filePath, 3, { type: 'repository' })
+    const useCaseTarget = buildComponent('FraudGateway', filePath, 4, { type: 'useCase' })
+
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, httpCall, repositoryTarget, useCaseTarget],
+      ),
+    ).toThrowError(/exactly one internal component/)
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, httpCall, repositoryTarget, useCaseTarget],
+      ),
+    ).toThrow(ConnectionDetectionError)
+  })
+
   it('throws when httpCall serviceName metadata is missing', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -20,6 +20,25 @@ function mapComponentsByIdentity(
   return byIdentity
 }
 
+function mapInternalComponentsByName(
+  components: readonly EnrichedComponent[],
+): ReadonlyMap<string, readonly EnrichedComponent[]> {
+  const byName = new Map<string, EnrichedComponent[]>()
+  for (const component of components) {
+    if (component.type === 'httpCall') {
+      continue
+    }
+
+    const existing = byName.get(component.name)
+    if (existing === undefined) {
+      byName.set(component.name, [component])
+      continue
+    }
+    existing.push(component)
+  }
+  return byName
+}
+
 function parseServiceName(httpCallComponent: EnrichedComponent): string {
   const rawServiceName = httpCallComponent.metadata['serviceName']
   if (typeof rawServiceName === 'string' && rawServiceName.trim().length > 0) {
@@ -76,6 +95,7 @@ export function rewriteHttpCallLinks(
   const linksToKeep: ExtractedLink[] = []
   const externalLinks: ExternalLink[] = []
   const componentsByIdentity = mapComponentsByIdentity(components)
+  const internalComponentsByName = mapInternalComponentsByName(components)
 
   for (const link of links) {
     const targetComponent = componentsByIdentity.get(link.target)
@@ -85,6 +105,27 @@ export function rewriteHttpCallLinks(
     }
 
     const serviceName = parseServiceName(targetComponent)
+    const matchedInternalComponents = internalComponentsByName.get(serviceName) ?? []
+    const matchedInternalCount = matchedInternalComponents.length
+    if (matchedInternalCount > 1) {
+      throw new ConnectionDetectionError({
+        file: targetComponent.location.file,
+        line: targetComponent.location.line,
+        typeName: componentIdentity(targetComponent),
+        reason: `Expected metadata.serviceName to match exactly one internal component name, got ${matchedInternalCount} matches for ${JSON.stringify(serviceName)}`,
+      })
+    }
+
+    const [uniqueInternalTarget] = matchedInternalComponents
+
+    if (uniqueInternalTarget !== undefined) {
+      linksToKeep.push({
+        ...link,
+        target: componentIdentity(uniqueInternalTarget),
+      })
+      continue
+    }
+
     const route = parseRoute(targetComponent)
     externalLinks.push(toExternalLink(link, serviceName, route))
   }

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -34,10 +34,35 @@ function parseServiceName(httpCallComponent: EnrichedComponent): string {
   })
 }
 
-function toExternalLink(link: ExtractedLink, serviceName: string): ExternalLink {
+function parseRoute(httpCallComponent: EnrichedComponent): string | undefined {
+  const rawRoute = httpCallComponent.metadata['route']
+  if (rawRoute === undefined) {
+    return undefined
+  }
+
+  if (typeof rawRoute === 'string' && rawRoute.trim().length > 0) {
+    return rawRoute
+  }
+
+  throw new ConnectionDetectionError({
+    file: httpCallComponent.location.file,
+    line: httpCallComponent.location.line,
+    typeName: componentIdentity(httpCallComponent),
+    reason: `Expected metadata.route to be a non-empty string when provided, got ${JSON.stringify(rawRoute)}`,
+  })
+}
+
+function toExternalLink(
+  link: ExtractedLink,
+  serviceName: string,
+  route: string | undefined,
+): ExternalLink {
   return {
     source: link.source,
-    target: { name: serviceName },
+    target: {
+      name: serviceName,
+      ...(route === undefined ? {} : { route }),
+    },
     ...(link.type === undefined ? {} : { type: link.type }),
     ...(link.sourceLocation === undefined ? {} : { sourceLocation: link.sourceLocation }),
   }
@@ -60,7 +85,8 @@ export function rewriteHttpCallLinks(
     }
 
     const serviceName = parseServiceName(targetComponent)
-    externalLinks.push(toExternalLink(link, serviceName))
+    const route = parseRoute(targetComponent)
+    externalLinks.push(toExternalLink(link, serviceName, route))
   }
 
   return {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -1,0 +1,77 @@
+import type { ExternalLink } from '@living-architecture/riviere-schema'
+import type { EnrichedComponent } from '../value-extraction/enrich-components'
+import type { ExtractedLink } from './extracted-link'
+import { componentIdentity } from './call-graph/call-graph-types'
+import { ConnectionDetectionError } from './connection-detection-error'
+
+/** @riviere-role value-object */
+export interface HttpCallRewriteResult {
+  links: ExtractedLink[]
+  externalLinks: ExternalLink[]
+}
+
+function mapComponentsByIdentity(
+  components: readonly EnrichedComponent[],
+): ReadonlyMap<string, EnrichedComponent> {
+  const byIdentity = new Map<string, EnrichedComponent>()
+  for (const component of components) {
+    byIdentity.set(componentIdentity(component), component)
+  }
+  return byIdentity
+}
+
+function parseServiceName(httpCallComponent: EnrichedComponent): string {
+  const rawServiceName = httpCallComponent.metadata['serviceName']
+  if (typeof rawServiceName === 'string' && rawServiceName.trim().length > 0) {
+    return rawServiceName
+  }
+
+  throw new ConnectionDetectionError({
+    file: httpCallComponent.location.file,
+    line: httpCallComponent.location.line,
+    typeName: componentIdentity(httpCallComponent),
+    reason: `Expected metadata.serviceName to be a non-empty string, got ${JSON.stringify(rawServiceName)}`,
+  })
+}
+
+function toExternalLink(link: ExtractedLink, serviceName: string): ExternalLink {
+  return {
+    source: link.source,
+    target: { name: serviceName },
+    ...(link.type === undefined ? {} : { type: link.type }),
+    ...(link.sourceLocation === undefined ? {} : { sourceLocation: link.sourceLocation }),
+  }
+}
+
+/** @riviere-role domain-service */
+export function rewriteHttpCallLinks(
+  links: readonly ExtractedLink[],
+  components: readonly EnrichedComponent[],
+): HttpCallRewriteResult {
+  const linksToKeep: ExtractedLink[] = []
+  const externalLinks: ExternalLink[] = []
+  const componentsByIdentity = mapComponentsByIdentity(components)
+
+  for (const link of links) {
+    const targetComponent = componentsByIdentity.get(link.target)
+    if (targetComponent?.type !== 'httpCall') {
+      linksToKeep.push(link)
+      continue
+    }
+
+    const serviceName = parseServiceName(targetComponent)
+    externalLinks.push(toExternalLink(link, serviceName))
+  }
+
+  return {
+    links: linksToKeep,
+    externalLinks,
+  }
+}
+
+/** @riviere-role domain-service */
+export function stripHttpCallComponents(
+  components: readonly EnrichedComponent[],
+): EnrichedComponent[] {
+  return components.filter((component) => component.type !== 'httpCall')
+}

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-decorator-guidance.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-decorator-guidance.spec.ts
@@ -1,0 +1,134 @@
+import {
+  describe, expect, it 
+} from 'vitest'
+import { Project } from 'ts-morph'
+import type {
+  Module, ExtractionRule 
+} from '@living-architecture/riviere-extract-config'
+import { enrichComponents } from './enrich-components'
+import type { DraftComponent } from '../component-extraction/extractor'
+
+const project = new Project({ useInMemoryFileSystem: true })
+const alwaysMatch = () => true
+
+function nextFile(content: string): string {
+  const filePath = `/src/orders/http-client-${project.getSourceFiles().length + 1}.ts`
+  project.createSourceFile(filePath, content)
+  return filePath
+}
+
+function createBaseModule(extract: Record<string, ExtractionRule>): Module {
+  return {
+    name: 'orders',
+    path: '/src/orders',
+    glob: '**',
+    api: {
+      find: 'classes',
+      where: { hasDecorator: { name: 'HttpClient' } },
+      extract,
+    },
+    useCase: { notUsed: true },
+    domainOp: { notUsed: true },
+    event: { notUsed: true },
+    eventHandler: { notUsed: true },
+    ui: { notUsed: true },
+  }
+}
+
+function createDraft(file: string): DraftComponent {
+  return {
+    type: 'api',
+    name: 'FraudClient',
+    location: {
+      file,
+      line: 2,
+    },
+    domain: 'orders',
+  }
+}
+
+describe('enrichComponents decorator rule guidance', () => {
+  it('returns guidance when fromDecoratorArg is used on class components', () => {
+    const file = nextFile(
+      `function HttpClient(_: string) { return () => {} }
+@HttpClient('Fraud Detection Service')
+export class FraudClient {}`,
+    )
+    const module = createBaseModule({
+      serviceName: {
+        fromDecoratorArg: {
+          decorator: 'HttpClient',
+          position: 0,
+        },
+      },
+    })
+
+    const result = enrichComponents(
+      [createDraft(file)],
+      { modules: [module] },
+      project,
+      alwaysMatch,
+      '/',
+    )
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.error).toContain('fromDecoratorArg')
+    expect(result.failures[0]?.error).toContain("Use 'fromClassDecoratorArg' for class decorators")
+    expect(result.components[0]?._missing).toStrictEqual(['serviceName'])
+  })
+
+  it('returns guidance when fromDecoratorName is used on class components', () => {
+    const file = nextFile(
+      `function HttpClient(_: string) { return () => {} }
+@HttpClient('Fraud Detection Service')
+export class FraudClient {}`,
+    )
+    const module = createBaseModule({ decoratorName: { fromDecoratorName: true } })
+
+    const result = enrichComponents(
+      [createDraft(file)],
+      { modules: [module] },
+      project,
+      alwaysMatch,
+      '/',
+    )
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.error).toContain('fromDecoratorName')
+    expect(result.failures[0]?.error).toContain("Use 'fromClassDecoratorArg' for class decorators")
+    expect(result.components[0]?._missing).toStrictEqual(['decoratorName'])
+  })
+
+  it('preserves source-file-not-found error for fromDecoratorArg', () => {
+    const missingDraft: DraftComponent = {
+      type: 'api',
+      name: 'MissingFileComponent',
+      location: {
+        file: '/src/orders/missing.ts',
+        line: 1,
+      },
+      domain: 'orders',
+    }
+    const module = createBaseModule({
+      serviceName: {
+        fromDecoratorArg: {
+          decorator: 'HttpClient',
+          position: 0,
+        },
+      },
+    })
+
+    const result = enrichComponents(
+      [missingDraft],
+      { modules: [module] },
+      project,
+      alwaysMatch,
+      '/',
+    )
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.error).toContain("Source file '/src/orders/missing.ts' not found")
+    expect(result.failures[0]?.error).not.toContain('requires a method component')
+    expect(result.components[0]?._missing).toStrictEqual(['serviceName'])
+  })
+})

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-http-call.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-http-call.spec.ts
@@ -1,0 +1,363 @@
+import {
+  describe, it, expect 
+} from 'vitest'
+import { Project } from 'ts-morph'
+import type {
+  ResolvedExtractionConfig, Module 
+} from '@living-architecture/riviere-extract-config'
+import type {
+  DraftComponent, GlobMatcher 
+} from '../component-extraction/extractor'
+import { enrichComponents } from './enrich-components'
+
+const sharedProject = new Project({ useInMemoryFileSystem: true })
+const counter = { value: 0 }
+
+function nextFile(path: string, content: string) {
+  counter.value++
+  const filePath = path.replace('.ts', `-http-${counter.value}.ts`)
+  sharedProject.createSourceFile(filePath, content)
+  return filePath
+}
+
+function alwaysMatchGlob(): GlobMatcher {
+  return () => true
+}
+
+function configWithModules(modules: Module[]): ResolvedExtractionConfig {
+  return { modules }
+}
+
+function notUsedModule(): Pick<Module, 'api' | 'useCase' | 'event' | 'ui'> {
+  return {
+    api: { notUsed: true },
+    useCase: { notUsed: true },
+    event: { notUsed: true },
+    ui: { notUsed: true },
+  }
+}
+
+describe('enrichComponents — httpCall metadata extraction', () => {
+  it('extracts class decorator arg for method-based custom component', () => {
+    const file = nextFile(
+      '/src/orders/http-client.ts',
+      `function HttpClient(_: string) { return () => {} }
+function HttpCall(_: string) { return () => {} }
+@HttpClient('Fraud Detection Service')
+export class FraudClient {
+  @HttpCall('/api/check')
+  check() {}
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'httpCall',
+        name: 'check',
+        location: {
+          file,
+          line: 5,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders',
+      glob: '**',
+      domainOp: { notUsed: true },
+      eventHandler: { notUsed: true },
+      customTypes: {
+        httpCall: {
+          find: 'methods',
+          where: {
+            and: [
+              { hasDecorator: { name: 'HttpCall' } },
+              { inClassWith: { hasDecorator: { name: 'HttpClient' } } },
+            ],
+          },
+          extract: {
+            serviceName: {
+              fromClassDecoratorArg: {
+                decorator: 'HttpClient',
+                position: 0,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const config = configWithModules([module])
+    const result = enrichComponents(drafts, config, sharedProject, alwaysMatchGlob(), '/')
+
+    expect(result.components[0]?.metadata).toStrictEqual({ serviceName: 'Fraud Detection Service' })
+    expect(result.failures).toStrictEqual([])
+  })
+
+  it('extracts method decorator positional arg with fromDecoratorArg', () => {
+    const file = nextFile(
+      '/src/orders/http-client.ts',
+      `function HttpCall(_: string) { return () => {} }
+export class FraudClient {
+  @HttpCall('/api/check')
+  check() {}
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'httpCall',
+        name: 'check',
+        location: {
+          file,
+          line: 3,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders',
+      glob: '**',
+      domainOp: { notUsed: true },
+      eventHandler: { notUsed: true },
+      customTypes: {
+        httpCall: {
+          find: 'methods',
+          where: { nameEndsWith: { suffix: 'check' } },
+          extract: {
+            route: {
+              fromDecoratorArg: {
+                decorator: 'HttpCall',
+                position: 0,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = enrichComponents(
+      drafts,
+      configWithModules([module]),
+      sharedProject,
+      alwaysMatchGlob(),
+      '/',
+    )
+
+    expect(result.components[0]?.metadata).toStrictEqual({ route: '/api/check' })
+    expect(result.failures).toStrictEqual([])
+  })
+
+  it('records failure when fromDecoratorArg decorator is missing on method', () => {
+    const file = nextFile(
+      '/src/orders/http-client.ts',
+      `export class FraudClient {
+  check() {}
+}`,
+    )
+
+    const draft: DraftComponent = {
+      type: 'httpCall',
+      name: 'check',
+      location: {
+        file,
+        line: 2,
+      },
+      domain: 'orders',
+    }
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders',
+      glob: '**',
+      domainOp: { notUsed: true },
+      eventHandler: { notUsed: true },
+      customTypes: {
+        httpCall: {
+          find: 'methods',
+          where: { nameEndsWith: { suffix: 'check' } },
+          extract: {
+            route: {
+              fromDecoratorArg: {
+                decorator: 'HttpCall',
+                position: 0,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = enrichComponents(
+      [draft],
+      configWithModules([module]),
+      sharedProject,
+      alwaysMatchGlob(),
+      '/',
+    )
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.field).toBe('route')
+    expect(result.components[0]?._missing).toStrictEqual(['route'])
+  })
+
+  it('records failure when fromDecoratorArg decorator name does not match method decorator', () => {
+    const file = nextFile(
+      '/src/orders/http-client.ts',
+      `function OtherCall(_: string) { return () => {} }
+export class FraudClient {
+  @OtherCall('/api/check')
+  check() {}
+}`,
+    )
+
+    const draft: DraftComponent = {
+      type: 'httpCall',
+      name: 'check',
+      location: {
+        file,
+        line: 3,
+      },
+      domain: 'orders',
+    }
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders',
+      glob: '**',
+      domainOp: { notUsed: true },
+      eventHandler: { notUsed: true },
+      customTypes: {
+        httpCall: {
+          find: 'methods',
+          where: { nameEndsWith: { suffix: 'check' } },
+          extract: {
+            route: {
+              fromDecoratorArg: {
+                decorator: 'HttpCall',
+                position: 0,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = enrichComponents(
+      [draft],
+      configWithModules([module]),
+      sharedProject,
+      alwaysMatchGlob(),
+      '/',
+    )
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.field).toBe('route')
+    expect(result.components[0]?._missing).toStrictEqual(['route'])
+  })
+
+  it('extracts first method decorator name with fromDecoratorName', () => {
+    const file = nextFile(
+      '/src/orders/http-client.ts',
+      `function HttpCall(_: string) { return () => {} }
+export class FraudClient {
+  @HttpCall('/api/check')
+  check() {}
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'httpCall',
+        name: 'check',
+        location: {
+          file,
+          line: 3,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders',
+      glob: '**',
+      domainOp: { notUsed: true },
+      eventHandler: { notUsed: true },
+      customTypes: {
+        httpCall: {
+          find: 'methods',
+          where: { nameEndsWith: { suffix: 'check' } },
+          extract: { decoratorName: { fromDecoratorName: true } },
+        },
+      },
+    }
+
+    const result = enrichComponents(
+      drafts,
+      configWithModules([module]),
+      sharedProject,
+      alwaysMatchGlob(),
+      '/',
+    )
+
+    expect(result.components[0]?.metadata).toStrictEqual({ decoratorName: 'HttpCall' })
+    expect(result.failures).toStrictEqual([])
+  })
+
+  it('records failure when fromDecoratorName is used on undecorated method', () => {
+    const file = nextFile(
+      '/src/orders/http-client.ts',
+      `export class FraudClient {
+  check() {}
+}`,
+    )
+
+    const draft: DraftComponent = {
+      type: 'httpCall',
+      name: 'check',
+      location: {
+        file,
+        line: 2,
+      },
+      domain: 'orders',
+    }
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders',
+      glob: '**',
+      domainOp: { notUsed: true },
+      eventHandler: { notUsed: true },
+      customTypes: {
+        httpCall: {
+          find: 'methods',
+          where: { nameEndsWith: { suffix: 'check' } },
+          extract: { decoratorName: { fromDecoratorName: true } },
+        },
+      },
+    }
+
+    const result = enrichComponents(
+      [draft],
+      configWithModules([module]),
+      sharedProject,
+      alwaysMatchGlob(),
+      '/',
+    )
+
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.field).toBe('decoratorName')
+    expect(result.components[0]?._missing).toStrictEqual(['decoratorName'])
+  })
+})

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-http-call.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-http-call.spec.ts
@@ -267,8 +267,10 @@ export class FraudClient {
   it('extracts first method decorator name with fromDecoratorName', () => {
     const file = nextFile(
       '/src/orders/http-client.ts',
-      `function HttpCall(_: string) { return () => {} }
+      `function First() { return () => {} }
+function HttpCall(_: string) { return () => {} }
 export class FraudClient {
+  @First()
   @HttpCall('/api/check')
   check() {}
 }`,
@@ -280,7 +282,7 @@ export class FraudClient {
         name: 'check',
         location: {
           file,
-          line: 3,
+          line: 4,
         },
         domain: 'orders',
       },
@@ -310,7 +312,7 @@ export class FraudClient {
       '/',
     )
 
-    expect(result.components[0]?.metadata).toStrictEqual({ decoratorName: 'HttpCall' })
+    expect(result.components[0]?.metadata).toStrictEqual({ decoratorName: 'First' })
     expect(result.failures).toStrictEqual([])
   })
 

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
@@ -19,6 +19,9 @@ import {
   evaluateFromFilePathRule,
   evaluateFromPropertyRule,
   evaluateFromMethodNameRule,
+  evaluateFromDecoratorArgRule,
+  evaluateFromDecoratorNameRule,
+  evaluateFromClassDecoratorArgRule,
 } from './evaluate-extraction-rule'
 import { evaluateFromGenericArgRule } from './evaluate-extraction-rule-generic'
 import { ExtractionError } from '../../../../platform/domain/ast-literals/literal-detection'
@@ -147,6 +150,47 @@ function findMethodAtLine(project: Project, draft: DraftComponent): MethodDeclar
   )
 }
 
+function findDecoratorOnMethod(
+  methodDecl: MethodDeclaration,
+  decoratorName?: string,
+): import('ts-morph').Decorator {
+  const decorators = methodDecl.getDecorators()
+  const sourceFile = methodDecl.getSourceFile()
+  const line = methodDecl.getStartLineNumber()
+
+  if (decorators.length === 0) {
+    throw new ExtractionError(
+      `No decorators found on method '${methodDecl.getName()}'`,
+      sourceFile.getFilePath(),
+      line,
+    )
+  }
+
+  if (decoratorName === undefined) {
+    const firstDecorator = decorators[0]
+    /* v8 ignore next -- @preserve: decorators.length > 0 guarantees first decorator exists */
+    if (firstDecorator === undefined) {
+      throw new ExtractionError(
+        `No decorators found on method '${methodDecl.getName()}'`,
+        sourceFile.getFilePath(),
+        line,
+      )
+    }
+    return firstDecorator
+  }
+
+  const decorator = decorators.find((candidate) => candidate.getName() === decoratorName)
+  if (decorator === undefined) {
+    throw new ExtractionError(
+      `Decorator '@${decoratorName}' not found on method '${methodDecl.getName()}'`,
+      sourceFile.getFilePath(),
+      line,
+    )
+  }
+
+  return decorator
+}
+
 function findContainingClass(project: Project, draft: DraftComponent): ClassDeclaration {
   const sourceFile = project.getSourceFile(draft.location.file)
   if (sourceFile === undefined) {
@@ -185,32 +229,31 @@ function evaluateClassRule(rule: ExtractionRule, classDecl: ClassDeclaration): E
   )
 }
 
-function evaluateRule(
+function evaluateMethodRule(
   rule: ExtractionRule,
   draft: DraftComponent,
   project: Project,
-): ExtractionResult {
-  if ('literal' in rule) {
-    return evaluateLiteralRule(rule)
-  }
-
-  if ('fromFilePath' in rule) {
-    return evaluateFromFilePathRule(rule, draft.location.file)
-  }
-
+): ExtractionResult | undefined {
   if ('fromMethodName' in rule) {
     const methodDecl = findMethodAtLine(project, draft)
     return evaluateFromMethodNameRule(rule, methodDecl)
   }
 
-  if ('fromGenericArg' in rule) {
-    const classDecl = findContainingClass(project, draft)
-    return evaluateFromGenericArgRule(rule, classDecl)
+  if ('fromDecoratorArg' in rule) {
+    const methodDecl = findMethodAtLine(project, draft)
+    const decorator = findDecoratorOnMethod(methodDecl, rule.fromDecoratorArg.decorator)
+    return evaluateFromDecoratorArgRule(rule, decorator)
   }
 
-  if ('fromProperty' in rule) {
-    const classDecl = findContainingClass(project, draft)
-    return evaluateFromPropertyRule(rule, classDecl)
+  if ('fromClassDecoratorArg' in rule) {
+    const methodDecl = findMethodAtLine(project, draft)
+    return evaluateFromClassDecoratorArgRule(rule, methodDecl)
+  }
+
+  if ('fromDecoratorName' in rule) {
+    const methodDecl = findMethodAtLine(project, draft)
+    const decorator = findDecoratorOnMethod(methodDecl)
+    return evaluateFromDecoratorNameRule(rule, decorator)
   }
 
   if ('fromParameterType' in rule) {
@@ -231,6 +274,37 @@ function evaluateRule(
       return { value: typeName }
     }
     return { value: applyTransforms(typeName, transform) }
+  }
+
+  return undefined
+}
+
+function evaluateRule(
+  rule: ExtractionRule,
+  draft: DraftComponent,
+  project: Project,
+): ExtractionResult {
+  if ('literal' in rule) {
+    return evaluateLiteralRule(rule)
+  }
+
+  if ('fromFilePath' in rule) {
+    return evaluateFromFilePathRule(rule, draft.location.file)
+  }
+
+  const methodRuleResult = evaluateMethodRule(rule, draft, project)
+  if (methodRuleResult !== undefined) {
+    return methodRuleResult
+  }
+
+  if ('fromGenericArg' in rule) {
+    const classDecl = findContainingClass(project, draft)
+    return evaluateFromGenericArgRule(rule, classDecl)
+  }
+
+  if ('fromProperty' in rule) {
+    const classDecl = findContainingClass(project, draft)
+    return evaluateFromPropertyRule(rule, classDecl)
   }
 
   const classDecl = findClassAtLine(project, draft)

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
@@ -150,6 +150,28 @@ function findMethodAtLine(project: Project, draft: DraftComponent): MethodDeclar
   )
 }
 
+function requireMethodForDecoratorRule(
+  project: Project,
+  draft: DraftComponent,
+  ruleName: 'fromDecoratorArg' | 'fromDecoratorName',
+): MethodDeclaration {
+  try {
+    return findMethodAtLine(project, draft)
+  } catch (error: unknown) {
+    if (
+      error instanceof ExtractionError &&
+      error.message.includes('No method declaration found at line')
+    ) {
+      throw new ExtractionError(
+        `Rule '${ruleName}' requires a method component. Use 'fromClassDecoratorArg' for class decorators.`,
+        draft.location.file,
+        draft.location.line,
+      )
+    }
+    throw error
+  }
+}
+
 function findDecoratorOnMethod(
   methodDecl: MethodDeclaration,
   decoratorName?: string,
@@ -240,7 +262,7 @@ function evaluateMethodRule(
   }
 
   if ('fromDecoratorArg' in rule) {
-    const methodDecl = findMethodAtLine(project, draft)
+    const methodDecl = requireMethodForDecoratorRule(project, draft, 'fromDecoratorArg')
     const decorator = findDecoratorOnMethod(methodDecl, rule.fromDecoratorArg.decorator)
     return evaluateFromDecoratorArgRule(rule, decorator)
   }
@@ -251,7 +273,7 @@ function evaluateMethodRule(
   }
 
   if ('fromDecoratorName' in rule) {
-    const methodDecl = findMethodAtLine(project, draft)
+    const methodDecl = requireMethodForDecoratorRule(project, draft, 'fromDecoratorName')
     const decorator = findDecoratorOnMethod(methodDecl)
     return evaluateFromDecoratorNameRule(rule, decorator)
   }

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule-class-decorator.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule-class-decorator.spec.ts
@@ -1,0 +1,125 @@
+import {
+  describe, it, expect 
+} from 'vitest'
+import {
+  Project, SyntaxKind 
+} from 'ts-morph'
+import { evaluateFromClassDecoratorArgRule } from './evaluate-extraction-rule'
+import {
+  ExtractionError,
+  TestFixtureError,
+} from '../../../../platform/domain/ast-literals/literal-detection'
+
+function createMethodFromClass(code: string) {
+  const project = new Project({ useInMemoryFileSystem: true })
+  const sf = project.createSourceFile('test-class.ts', code)
+  const classDecl = sf.getClasses()[0]
+  if (!classDecl) {
+    throw new TestFixtureError('No class found in test code')
+  }
+
+  const method = classDecl.getMethods()[0]
+  if (!method) {
+    throw new TestFixtureError('No method found in class')
+  }
+
+  return method
+}
+
+function createMethodFromObjectLiteral(code: string) {
+  const project = new Project({ useInMemoryFileSystem: true })
+  const sf = project.createSourceFile('test-object-literal.ts', code)
+  const method = sf.getDescendantsOfKind(SyntaxKind.MethodDeclaration)[0]
+
+  if (!method) {
+    throw new TestFixtureError('No method declaration found in object literal')
+  }
+
+  return method
+}
+
+describe('evaluateFromClassDecoratorArgRule coverage', () => {
+  it('throws ExtractionError when method is not declared in a class', () => {
+    const method = createMethodFromObjectLiteral(
+      `const obj = {
+  check() {}
+}`,
+    )
+
+    expect(() =>
+      evaluateFromClassDecoratorArgRule(
+        {
+          fromClassDecoratorArg: {
+            decorator: 'HttpClient',
+            position: 0,
+          },
+        },
+        method,
+      ),
+    ).toThrow(ExtractionError)
+  })
+
+  it('throws ExtractionError when containing class does not have expected decorator', () => {
+    const method = createMethodFromClass(
+      `function HttpClient(_: string) { return () => {} }
+class FraudClient {
+  check() {}
+}`,
+    )
+
+    expect(() =>
+      evaluateFromClassDecoratorArgRule(
+        {
+          fromClassDecoratorArg: {
+            decorator: 'HttpClient',
+            position: 0,
+          },
+        },
+        method,
+      ),
+    ).toThrow(ExtractionError)
+  })
+
+  it('throws ExtractionError with anonymous class context when decorator is missing', () => {
+    const method = createMethodFromClass(
+      `export default class {
+  check() {}
+}`,
+    )
+
+    expect(() =>
+      evaluateFromClassDecoratorArgRule(
+        {
+          fromClassDecoratorArg: {
+            decorator: 'HttpClient',
+            position: 0,
+          },
+        },
+        method,
+      ),
+    ).toThrow(ExtractionError)
+  })
+
+  it('extracts named class decorator arg and applies transform', () => {
+    const method = createMethodFromClass(
+      `function HttpClient(config: { name: string }) { return () => {} }
+@HttpClient({ name: 'Fraud Detection Service' })
+class FraudClient {
+  check() {}
+}`,
+    )
+
+    const result = evaluateFromClassDecoratorArgRule(
+      {
+        fromClassDecoratorArg: {
+          decorator: 'HttpClient',
+          name: 'name',
+          transform: { toUpperCase: true },
+        },
+      },
+      method,
+    )
+
+    expect(result.value).toBe('FRAUD DETECTION SERVICE')
+  })
+})

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule-decorator.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule-decorator.spec.ts
@@ -146,7 +146,7 @@ describe('evaluateFromDecoratorArgRule (positional)', () => {
         },
         decorator,
       ),
-    ).toThrow(ExtractionError)
+    ).toThrowError("Expected decorator '@Post', got '@Get'")
   })
 })
 

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule-decorator.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule-decorator.spec.ts
@@ -4,6 +4,7 @@ import {
 import { Project } from 'ts-morph'
 import {
   evaluateFromDecoratorArgRule,
+  evaluateFromClassDecoratorArgRule,
   evaluateFromDecoratorNameRule,
 } from './evaluate-extraction-rule'
 import {
@@ -27,6 +28,20 @@ function createDecoratorFromMethod(code: string) {
     throw new TestFixtureError('No decorator found on method')
   }
   return decorator
+}
+
+function createMethodFromClass(code: string) {
+  const project = new Project({ useInMemoryFileSystem: true })
+  const sf = project.createSourceFile('test-class.ts', code)
+  const classDecl = sf.getClasses()[0]
+  if (!classDecl) {
+    throw new TestFixtureError('No class found in test code')
+  }
+  const method = classDecl.getMethods()[0]
+  if (!method) {
+    throw new TestFixtureError('No method found in class')
+  }
+  return method
 }
 
 describe('evaluateFromDecoratorArgRule (positional)', () => {
@@ -111,6 +126,27 @@ describe('evaluateFromDecoratorArgRule (positional)', () => {
       decorator,
     )
     expect(result.value).toBe('/ORDERS')
+  })
+
+  it('throws ExtractionError when decorator qualifier does not match decorator', () => {
+    const decorator = createDecoratorFromMethod(`
+      function Get(path: string) { return () => {} }
+      class OrderController {
+        @Get('/orders')
+        list() {}
+      }
+    `)
+    expect(() =>
+      evaluateFromDecoratorArgRule(
+        {
+          fromDecoratorArg: {
+            decorator: 'Post',
+            position: 0,
+          },
+        },
+        decorator,
+      ),
+    ).toThrow(ExtractionError)
   })
 })
 
@@ -336,5 +372,29 @@ describe('evaluateFromDecoratorNameRule', () => {
       decorator,
     )
     expect(result.value).toBe('httpget')
+  })
+})
+
+describe('evaluateFromClassDecoratorArgRule', () => {
+  it('returns class decorator positional arg for containing method class', () => {
+    const method = createMethodFromClass(`
+      function HttpClient(_: string) { return () => {} }
+      @HttpClient('Fraud Detection Service')
+      class FraudClient {
+        check() {}
+      }
+    `)
+
+    const result = evaluateFromClassDecoratorArgRule(
+      {
+        fromClassDecoratorArg: {
+          decorator: 'HttpClient',
+          position: 0,
+        },
+      },
+      method,
+    )
+
+    expect(result.value).toBe('Fraud Detection Service')
   })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule.ts
@@ -5,6 +5,7 @@ import type {
   FromFilePathExtractionRule,
   FromPropertyExtractionRule,
   FromDecoratorArgExtractionRule,
+  FromClassDecoratorArgExtractionRule,
   FromDecoratorNameExtractionRule,
 } from '@living-architecture/riviere-extract-config'
 
@@ -17,15 +18,16 @@ export {
 } from './evaluate-extraction-rule-method'
 
 export { evaluateFromGenericArgRule } from './evaluate-extraction-rule-generic'
-import type {
-  ClassDeclaration, MethodDeclaration, Decorator 
-} from 'ts-morph'
 import { SyntaxKind } from 'ts-morph'
 import { applyTransforms } from '../../../../platform/domain/string-transforms/transforms'
 import {
   ExtractionError,
   extractLiteralValue,
 } from '../../../../platform/domain/ast-literals/literal-detection'
+
+type ClassDeclaration = import('ts-morph').ClassDeclaration
+type MethodDeclaration = import('ts-morph').MethodDeclaration
+type Decorator = import('ts-morph').Decorator
 
 /** @riviere-role value-object */
 export type ExtractionContext = { filePath: string }
@@ -92,9 +94,9 @@ export function evaluateFromFilePathRule(
   rule: FromFilePathExtractionRule,
   filePath: string,
 ): ExtractionResult {
-  const {
-    pattern, capture, transform 
-  } = rule.fromFilePath
+  const pattern = rule.fromFilePath.pattern
+  const capture = rule.fromFilePath.capture
+  const transform = rule.fromFilePath.transform
   const regex = new RegExp(pattern)
   const match = regex.exec(filePath)
 
@@ -162,9 +164,9 @@ export function evaluateFromPropertyRule(
   rule: FromPropertyExtractionRule,
   classDecl: ClassDeclaration,
 ): ExtractionResult {
-  const {
-    name, kind, transform 
-  } = rule.fromProperty
+  const name = rule.fromProperty.name
+  const kind = rule.fromProperty.kind
+  const transform = rule.fromProperty.transform
   const isStatic = kind === 'static'
 
   const propertyInfo = findPropertyInHierarchy(classDecl, name, isStatic)
@@ -199,6 +201,8 @@ type DecoratorLocation = {
   filePath: string
   line: number
 }
+
+type DecoratorArgRule = FromDecoratorArgExtractionRule['fromDecoratorArg']
 
 function getDecoratorLocation(decorator: Decorator): DecoratorLocation {
   const sourceFile = decorator.getSourceFile()
@@ -308,9 +312,19 @@ export function evaluateFromDecoratorArgRule(
   rule: FromDecoratorArgExtractionRule,
   decorator: Decorator,
 ): ExtractionResult {
-  const {
-    position, name, transform 
-  } = rule.fromDecoratorArg
+  const decoratorName = rule.fromDecoratorArg.decorator
+  const position = rule.fromDecoratorArg.position
+  const name = rule.fromDecoratorArg.name
+  const transform = rule.fromDecoratorArg.transform
+
+  if (decoratorName !== undefined && decorator.getName() !== decoratorName) {
+    const location = getDecoratorLocation(decorator)
+    throw new ExtractionError(
+      `Expected decorator '@${decoratorName}', got '@${decorator.getName()}'`,
+      location.filePath,
+      location.line,
+    )
+  }
 
   const extractValue = (): string => {
     if (position !== undefined) {
@@ -337,6 +351,57 @@ export function evaluateFromDecoratorArgRule(
 }
 
 /** @riviere-role domain-service */
+export function evaluateFromClassDecoratorArgRule(
+  rule: FromClassDecoratorArgExtractionRule,
+  methodDecl: MethodDeclaration,
+): ExtractionResult {
+  const classDecl = methodDecl.getParentIfKind(SyntaxKind.ClassDeclaration)
+  if (classDecl === undefined) {
+    const sourceFile = methodDecl.getSourceFile()
+    throw new ExtractionError(
+      `Expected method '${methodDecl.getName()}' to be declared inside a class`,
+      sourceFile.getFilePath(),
+      methodDecl.getStartLineNumber(),
+    )
+  }
+
+  const classDecorator = classDecl
+    .getDecorators()
+    .find((decorator) => decorator.getName() === rule.fromClassDecoratorArg.decorator)
+
+  if (classDecorator === undefined) {
+    const sourceFile = classDecl.getSourceFile()
+    throw new ExtractionError(
+      `Decorator '@${rule.fromClassDecoratorArg.decorator}' not found on containing class '${classDecl.getName() ?? 'anonymous'}'`,
+      sourceFile.getFilePath(),
+      classDecl.getStartLineNumber(),
+    )
+  }
+
+  const fromDecoratorArgRule: DecoratorArgRule = { decorator: rule.fromClassDecoratorArg.decorator }
+
+  if (rule.fromClassDecoratorArg.position === undefined) {
+    // default extraction uses name if provided
+  } else {
+    fromDecoratorArgRule.position = rule.fromClassDecoratorArg.position
+  }
+
+  if (rule.fromClassDecoratorArg.name === undefined) {
+    // default extraction uses positional argument when position is provided
+  } else {
+    fromDecoratorArgRule.name = rule.fromClassDecoratorArg.name
+  }
+
+  if (rule.fromClassDecoratorArg.transform === undefined) {
+    // no transform requested
+  } else {
+    fromDecoratorArgRule.transform = rule.fromClassDecoratorArg.transform
+  }
+
+  return evaluateFromDecoratorArgRule({ fromDecoratorArg: fromDecoratorArgRule }, classDecorator)
+}
+
+/** @riviere-role domain-service */
 export function evaluateFromDecoratorNameRule(
   rule: FromDecoratorNameExtractionRule,
   decorator: Decorator,
@@ -347,9 +412,8 @@ export function evaluateFromDecoratorNameRule(
     return { value: decoratorName }
   }
 
-  const {
-    mapping, transform 
-  } = rule.fromDecoratorName
+  const mapping = rule.fromDecoratorName.mapping
+  const transform = rule.fromDecoratorName.transform
 
   const mappedValue = mapping?.[decoratorName] ?? decoratorName
 

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/evaluate-extraction-rule.ts
@@ -378,24 +378,16 @@ export function evaluateFromClassDecoratorArgRule(
     )
   }
 
-  const fromDecoratorArgRule: DecoratorArgRule = { decorator: rule.fromClassDecoratorArg.decorator }
-
-  if (rule.fromClassDecoratorArg.position === undefined) {
-    // default extraction uses name if provided
-  } else {
-    fromDecoratorArgRule.position = rule.fromClassDecoratorArg.position
-  }
-
-  if (rule.fromClassDecoratorArg.name === undefined) {
-    // default extraction uses positional argument when position is provided
-  } else {
-    fromDecoratorArgRule.name = rule.fromClassDecoratorArg.name
-  }
-
-  if (rule.fromClassDecoratorArg.transform === undefined) {
-    // no transform requested
-  } else {
-    fromDecoratorArgRule.transform = rule.fromClassDecoratorArg.transform
+  const fromClassDecoratorArg = rule.fromClassDecoratorArg
+  const fromDecoratorArgRule: DecoratorArgRule = {
+    decorator: fromClassDecoratorArg.decorator,
+    ...(fromClassDecoratorArg.position === undefined
+      ? {}
+      : { position: fromClassDecoratorArg.position }),
+    ...(fromClassDecoratorArg.name === undefined ? {} : { name: fromClassDecoratorArg.name }),
+    ...(fromClassDecoratorArg.transform === undefined
+      ? {}
+      : { transform: fromClassDecoratorArg.transform }),
   }
 
   return evaluateFromDecoratorArgRule({ fromDecoratorArg: fromDecoratorArgRule }, classDecorator)

--- a/packages/riviere-extract-ts/src/index.ts
+++ b/packages/riviere-extract-ts/src/index.ts
@@ -26,6 +26,7 @@ export {
   detectPerModuleConnections,
   detectCrossModuleConnections,
   deduplicateCrossStrategy,
+  stripHttpCallComponents,
   type ConnectionDetectionOptions,
   type ConnectionDetectionResult,
   type ConnectionTimings,

--- a/packages/riviere-schema/riviere.schema.json
+++ b/packages/riviere-schema/riviere.schema.json
@@ -149,13 +149,27 @@
         "module": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
         "sourceLocation": { "$ref": "#/definitions/sourceLocation" },
-        "route": { "type": "string", "description": "URL route where UI component is rendered", "minLength": 1 }
+        "route": {
+          "type": "string",
+          "description": "URL route where UI component is rendered",
+          "minLength": 1
+        }
       },
       "additionalProperties": false
     },
     "apiRestComponent": {
       "type": "object",
-      "required": ["id", "type", "name", "domain", "module", "sourceLocation", "apiType", "httpMethod", "path"],
+      "required": [
+        "id",
+        "type",
+        "name",
+        "domain",
+        "module",
+        "sourceLocation",
+        "apiType",
+        "httpMethod",
+        "path"
+      ],
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "type": { "const": "API" },
@@ -165,14 +179,26 @@
         "description": { "type": "string" },
         "sourceLocation": { "$ref": "#/definitions/sourceLocation" },
         "apiType": { "const": "REST" },
-        "httpMethod": { "type": "string", "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] },
+        "httpMethod": {
+          "type": "string",
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+        },
         "path": { "type": "string", "description": "API path", "minLength": 3 }
       },
       "additionalProperties": false
     },
     "apiGraphqlComponent": {
       "type": "object",
-      "required": ["id", "type", "name", "domain", "module", "sourceLocation", "apiType", "operationName"],
+      "required": [
+        "id",
+        "type",
+        "name",
+        "domain",
+        "module",
+        "sourceLocation",
+        "apiType",
+        "operationName"
+      ],
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "type": { "const": "API" },
@@ -182,7 +208,11 @@
         "description": { "type": "string" },
         "sourceLocation": { "$ref": "#/definitions/sourceLocation" },
         "apiType": { "const": "GraphQL" },
-        "operationName": { "type": "string", "description": "GraphQL operation name", "minLength": 2 }
+        "operationName": {
+          "type": "string",
+          "description": "GraphQL operation name",
+          "minLength": 2
+        }
       },
       "additionalProperties": false
     },
@@ -262,7 +292,11 @@
         "module": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
         "sourceLocation": { "$ref": "#/definitions/sourceLocation" },
-        "subscribedEvents": { "type": "array", "items": { "type": "string" }, "description": "Events this handler subscribes to" }
+        "subscribedEvents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Events this handler subscribes to"
+        }
       },
       "additionalProperties": false
     },
@@ -277,7 +311,11 @@
         "module": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
         "sourceLocation": { "$ref": "#/definitions/sourceLocation" },
-        "customTypeName": { "type": "string", "description": "Name of the custom type (must match a key in metadata.customTypes)", "minLength": 1 }
+        "customTypeName": {
+          "type": "string",
+          "description": "Name of the custom type (must match a key in metadata.customTypes)",
+          "minLength": 1
+        }
       },
       "additionalProperties": true
     },
@@ -365,6 +403,11 @@
         "name": {
           "type": "string",
           "description": "Name of the external system",
+          "minLength": 1
+        },
+        "route": {
+          "type": "string",
+          "description": "Remote route/path for the external call",
           "minLength": 1
         },
         "domain": {

--- a/packages/riviere-schema/src/schema.spec.ts
+++ b/packages/riviere-schema/src/schema.spec.ts
@@ -141,6 +141,38 @@ describe('parseRiviereGraph()', () => {
     expect(() => parseRiviereGraph(input)).toThrow(RiviereSchemaValidationError)
     expect(() => parseRiviereGraph(input)).toThrow(/Invalid RiviereGraph/)
   })
+
+  it('parses external link target with optional route', () => {
+    const input = {
+      version: '1.0',
+      metadata: {
+        domains: {
+          test: {
+            description: 'Test',
+            systemType: 'domain',
+          },
+        },
+      },
+      components: [],
+      links: [],
+      externalLinks: [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: {
+            name: 'Fraud Detection Service',
+            route: '/api/check',
+          },
+        },
+      ],
+    }
+
+    const result = parseRiviereGraph(input)
+
+    expect(result.externalLinks?.[0]?.target).toStrictEqual({
+      name: 'Fraud Detection Service',
+      route: '/api/check',
+    })
+  })
 })
 
 describe('riviere-schema types', () => {

--- a/packages/riviere-schema/src/schema.ts
+++ b/packages/riviere-schema/src/schema.ts
@@ -127,6 +127,7 @@ export interface Link {
 
 export interface ExternalTarget {
   name: string
+  route?: string
   domain?: string
   repository?: string
   url?: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
   tools/dev-workflow-v2:
     dependencies:
       '@ntcoding/agentic-workflow-builder':
-        specifier: github:NTCoding/autonomous-claude-agent-team#d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab&path:packages/agentic-workflow-builder
-        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab#path:packages/agentic-workflow-builder(zod@3.25.76)
+        specifier: github:NTCoding/autonomous-claude-agent-team#e27e0ae67ba3b79fe0c64861b2eb8dfc14edbcca&path:packages/agentic-workflow-builder
+        version: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/e27e0ae67ba3b79fe0c64861b2eb8dfc14edbcca#path:packages/agentic-workflow-builder(zod@3.25.76)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1595,9 +1595,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab#path:packages/agentic-workflow-builder':
-    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab}
-    version: 0.6.3
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/e27e0ae67ba3b79fe0c64861b2eb8dfc14edbcca#path:packages/agentic-workflow-builder':
+    resolution: {path: packages/agentic-workflow-builder, tarball: https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/e27e0ae67ba3b79fe0c64861b2eb8dfc14edbcca}
+    version: 0.6.6
     peerDependencies:
       zod: ^3.23.0
 
@@ -8392,7 +8392,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab#path:packages/agentic-workflow-builder(zod@3.25.76)':
+  '@ntcoding/agentic-workflow-builder@https://codeload.github.com/NTCoding/autonomous-claude-agent-team/tar.gz/e27e0ae67ba3b79fe0c64861b2eb8dfc14edbcca#path:packages/agentic-workflow-builder(zod@3.25.76)':
     dependencies:
       '@opencode-ai/plugin': 1.4.3
       zod: 3.25.76

--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/package.json
+++ b/tools/dev-workflow-v2/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ntcoding/agentic-workflow-builder": "github:NTCoding/autonomous-claude-agent-team#d7c2ab785edda94cba9f4909e34ae3d5c4ef54ab&path:packages/agentic-workflow-builder",
+    "@ntcoding/agentic-workflow-builder": "github:NTCoding/autonomous-claude-agent-team#e27e0ae67ba3b79fe0c64861b2eb8dfc14edbcca&path:packages/agentic-workflow-builder",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes: https://github.com/NTCoding/living-architecture/issues/272

## Summary
- Add HTTP call extraction support that captures `serviceName` and `route`, rewrites HTTP call links into `externalLinks`, and strips intermediate `httpCall` components from the emitted graph.
- Extend extraction config/schema and defaults to support `fromClassDecoratorArg`, including generated docs updates and validation coverage.
- Add HTTP client convention decorators and five ESLint rules to enforce HTTP client and HTTP call usage patterns, with package tests/type checks aligned.

## Verification
- `pnpm verify` via pre-commit hook (including lint, typecheck, tests, build, docs checks) passed during commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HttpClient/HttpCall decorators, a class-decorator extraction rule, and externalLinks (with optional route) in extraction outputs.

* **Bug Fixes / Improvements**
  * HTTP-call links are rewritten to externalLinks and httpCall components are hidden from internal topology; new ESLint rules enforce correct decorator usage and import boundaries.

* **Tests**
  * Expanded test coverage for decorator extraction, http-call rewriting, and all new ESLint rules.

* **Documentation**
  * Extraction config schema and docs updated to document the class-decorator extraction rule and externalLink shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->