### PR TITLE
fix: resolve httpCall cross-module route fallback

### DIFF
--- a/packages/riviere-cli/src/features/extract/domain/detect-connections-per-module.spec.ts
+++ b/packages/riviere-cli/src/features/extract/domain/detect-connections-per-module.spec.ts
@@ -148,4 +148,62 @@ describe('ExtractionProject.extractDraftComponents', () => {
 
     expect(result.kind).toBe('draftOnly')
   })
+
+  it('passes configured connection patterns into per-module detection', () => {
+    const ctx = createModuleContext('orders')
+    const pattern = {
+      from: { component: 'useCase' },
+      to: { component: 'repository' },
+      kind: 'call' as const,
+    }
+
+    mockExtractComponents.mockReturnValue([
+      {
+        name: 'OrderService',
+        domain: 'orders',
+        type: 'useCase',
+        location: {
+          file: 'test.ts',
+          line: 1,
+        },
+      },
+    ])
+    mockEnrichComponents.mockReturnValue({
+      components: [
+        {
+          name: 'OrderService',
+          domain: 'orders',
+          type: 'useCase',
+          location: {
+            file: 'test.ts',
+            line: 1,
+          },
+          metadata: {},
+        },
+      ],
+      failures: [],
+    })
+
+    const project = new ExtractionProject(
+      '/config',
+      [ctx],
+      {
+        modules: [],
+        connections: { patterns: [pattern] },
+      },
+      'test-repo',
+    )
+
+    project.extractDraftComponents({
+      allowIncomplete: true,
+      includeConnections: true,
+    })
+
+    expect(mockDetectPerModule).toHaveBeenCalledWith(
+      ctx.project,
+      expect.any(Array),
+      expect.objectContaining({ patterns: [pattern] }),
+      mockMatchesGlob,
+    )
+  })
 })

--- a/packages/riviere-cli/src/features/extract/domain/detect-connections-per-module.spec.ts
+++ b/packages/riviere-cli/src/features/extract/domain/detect-connections-per-module.spec.ts
@@ -139,6 +139,26 @@ describe('ExtractionProject.extractDraftComponents', () => {
 
   it('returns no links when includeConnections is false', () => {
     const ctx = createModuleContext('orders')
+    mockExtractComponents.mockReturnValue([
+      {
+        name: 'checkFraud',
+        domain: 'orders',
+        type: 'httpCall',
+        location: {
+          file: 'test.ts',
+          line: 1,
+        },
+      },
+      {
+        name: 'OrderService',
+        domain: 'orders',
+        type: 'useCase',
+        location: {
+          file: 'test.ts',
+          line: 2,
+        },
+      },
+    ])
 
     const project = new ExtractionProject('/config', [ctx], { modules: [] }, 'test-repo')
     const result = project.extractDraftComponents({
@@ -147,6 +167,12 @@ describe('ExtractionProject.extractDraftComponents', () => {
     })
 
     expect(result.kind).toBe('draftOnly')
+    expect(result.components).toStrictEqual([
+      expect.objectContaining({
+        type: 'useCase',
+        name: 'OrderService',
+      }),
+    ])
   })
 
   it('passes configured connection patterns into per-module detection', () => {

--- a/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
+++ b/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
@@ -76,7 +76,7 @@ export class ExtractionProject {
     if (!options.includeConnections) {
       return {
         kind: 'draftOnly',
-        components: draftComponents,
+        components: stripDraftHttpCallComponents(draftComponents),
       }
     }
 
@@ -105,7 +105,7 @@ export class ExtractionProject {
     if (!options.includeConnections) {
       return {
         kind: 'draftOnly',
-        components: this.draftComponents,
+        components: stripDraftHttpCallComponents(this.draftComponents),
       }
     }
 
@@ -243,6 +243,10 @@ export class ExtractionProject {
       failedFields,
     }
   }
+}
+
+function stripDraftHttpCallComponents(components: DraftComponent[]): DraftComponent[] {
+  return components.filter((component) => component.type !== 'httpCall')
 }
 
 function assertAllDraftsMatchModules(

--- a/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
+++ b/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
@@ -158,6 +158,7 @@ export class ExtractionProject {
         moduleContext.project,
         moduleComponents,
         {
+          allComponents: enrichedComponents,
           allowIncomplete,
           moduleGlobs: [posix.join(moduleContext.module.path, moduleContext.module.glob)],
           repository: this.repositoryName,

--- a/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
+++ b/packages/riviere-cli/src/features/extract/domain/extraction-project.ts
@@ -161,6 +161,7 @@ export class ExtractionProject {
           allComponents: enrichedComponents,
           allowIncomplete,
           moduleGlobs: [posix.join(moduleContext.module.path, moduleContext.module.glob)],
+          patterns: this.resolvedConfig.connections?.patterns,
           repository: this.repositoryName,
         },
         matchesGlob,

--- a/packages/riviere-extract-conventions/src/decorators.spec.ts
+++ b/packages/riviere-extract-conventions/src/decorators.spec.ts
@@ -188,7 +188,7 @@ describe('Method-level decorators', () => {
     it('preserves method behavior when class and method are decorated', () => {
       @HttpClient('Fraud Detection Service')
       class FraudClient {
-        @HttpCall('/api/check')
+        @HttpCall('/api/check', 'POST')
         check(): string {
           return 'ok'
         }

--- a/packages/riviere-extract-conventions/src/decorators.spec.ts
+++ b/packages/riviere-extract-conventions/src/decorators.spec.ts
@@ -196,18 +196,6 @@ describe('Method-level decorators', () => {
 
       expect(new FraudClient().check()).toBe('ok')
     })
-
-    it('preserves method behavior when HttpCall uses the legacy single-argument signature', () => {
-      @HttpClient('Fraud Detection Service')
-      class FraudClient {
-        @HttpCall('/api/check')
-        check(): string {
-          return 'ok'
-        }
-      }
-
-      expect(new FraudClient().check()).toBe('ok')
-    })
   })
 })
 

--- a/packages/riviere-extract-conventions/src/decorators.spec.ts
+++ b/packages/riviere-extract-conventions/src/decorators.spec.ts
@@ -196,6 +196,18 @@ describe('Method-level decorators', () => {
 
       expect(new FraudClient().check()).toBe('ok')
     })
+
+    it('preserves method behavior when HttpCall uses the legacy single-argument signature', () => {
+      @HttpClient('Fraud Detection Service')
+      class FraudClient {
+        @HttpCall('/api/check')
+        check(): string {
+          return 'ok'
+        }
+      }
+
+      expect(new FraudClient().check()).toBe('ok')
+    })
   })
 })
 

--- a/packages/riviere-extract-conventions/src/decorators.ts
+++ b/packages/riviere-extract-conventions/src/decorators.ts
@@ -105,6 +105,7 @@ export function HttpClient(
  */
 export function HttpCall(
   _route: string,
+  _method: string,
 ): <T extends Method>(target: T, context: ClassMethodDecoratorContext) => T {
   return function <T extends Method>(target: T, _: ClassMethodDecoratorContext): T {
     return target

--- a/packages/riviere-extract-conventions/src/decorators.ts
+++ b/packages/riviere-extract-conventions/src/decorators.ts
@@ -105,7 +105,7 @@ export function HttpClient(
  */
 export function HttpCall(
   _route: string,
-  _method: string,
+  _method?: string,
 ): <T extends Method>(target: T, context: ClassMethodDecoratorContext) => T {
   return function <T extends Method>(target: T, _: ClassMethodDecoratorContext): T {
     return target

--- a/packages/riviere-extract-conventions/src/decorators.ts
+++ b/packages/riviere-extract-conventions/src/decorators.ts
@@ -105,7 +105,7 @@ export function HttpClient(
  */
 export function HttpCall(
   _route: string,
-  _method?: string,
+  _method: string,
 ): <T extends Method>(target: T, context: ClassMethodDecoratorContext) => T {
   return function <T extends Method>(target: T, _: ClassMethodDecoratorContext): T {
     return target

--- a/packages/riviere-extract-conventions/src/default-config.spec.ts
+++ b/packages/riviere-extract-conventions/src/default-config.spec.ts
@@ -207,6 +207,27 @@ describe('Default extraction config', () => {
   })
 
   describe('Extraction rules', () => {
+    it('api extracts apiType, route, and method from instance properties', () => {
+      const config = loadDefaultConfig()
+      const module = getFirstModule(config)
+
+      assertExtractionConfig(module.api, {
+        apiType: { literal: 'REST' },
+        route: {
+          fromProperty: {
+            name: 'route',
+            kind: 'instance',
+          },
+        },
+        method: {
+          fromProperty: {
+            name: 'method',
+            kind: 'instance',
+          },
+        },
+      })
+    })
+
     it('eventHandler extracts subscribedEvents from instance property', () => {
       const config = loadDefaultConfig()
       const module = getFirstModule(config)

--- a/packages/riviere-extract-conventions/src/default-config.spec.ts
+++ b/packages/riviere-extract-conventions/src/default-config.spec.ts
@@ -130,6 +130,12 @@ describe('Default extraction config', () => {
             position: 0,
           },
         },
+        method: {
+          fromDecoratorArg: {
+            decorator: 'HttpCall',
+            position: 1,
+          },
+        },
       },
     })
   })

--- a/packages/riviere-extract-conventions/src/default-extraction.config.json
+++ b/packages/riviere-extract-conventions/src/default-extraction.config.json
@@ -16,7 +16,9 @@
           }
         },
         "extract": {
-          "apiType": { "literal": "REST" }
+          "apiType": { "literal": "REST" },
+          "route": { "fromProperty": { "name": "route", "kind": "instance" } },
+          "method": { "fromProperty": { "name": "method", "kind": "instance" } }
         }
       },
       "useCase": {

--- a/packages/riviere-extract-conventions/src/default-extraction.config.json
+++ b/packages/riviere-extract-conventions/src/default-extraction.config.json
@@ -129,6 +129,12 @@
                 "decorator": "HttpCall",
                 "position": 0
               }
+            },
+            "method": {
+              "fromDecoratorArg": {
+                "decorator": "HttpCall",
+                "position": 1
+              }
             }
           }
         }

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.cjs
@@ -36,9 +36,6 @@ function getRouteViolation(decoratorExpression) {
 }
 
 function getMethodViolation(decoratorExpression) {
-  if (decoratorExpression.type === 'Identifier') {
-    return 'missingMethod'
-  }
   if (decoratorExpression.arguments.length < 2) {
     return 'missingMethod'
   }

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.cjs
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.cjs
@@ -35,15 +35,38 @@ function getRouteViolation(decoratorExpression) {
   return null
 }
 
+function getMethodViolation(decoratorExpression) {
+  if (decoratorExpression.type === 'Identifier') {
+    return 'missingMethod'
+  }
+  if (decoratorExpression.arguments.length < 2) {
+    return 'missingMethod'
+  }
+
+  const secondArgument = decoratorExpression.arguments[1]
+  if (secondArgument.type !== 'Literal' || typeof secondArgument.value !== 'string') {
+    return 'methodNotLiteral'
+  }
+
+  if (secondArgument.value.trim().length === 0) {
+    return 'emptyMethod'
+  }
+
+  return null
+}
+
 module.exports = {
   meta: {
     type: 'problem',
-    docs: { description: 'Require HttpCall decorator to include route' },
+    docs: { description: 'Require HttpCall decorator to include route and method' },
     schema: [],
     messages: {
       missingRoute: "Method '{{methodName}}' uses @HttpCall but is missing route argument",
+      missingMethod: "Method '{{methodName}}' uses @HttpCall but is missing method argument",
       routeNotLiteral: "Method '{{methodName}}' uses @HttpCall but route must be a string literal",
+      methodNotLiteral: "Method '{{methodName}}' uses @HttpCall but method must be a string literal",
       emptyRoute: "Method '{{methodName}}' uses @HttpCall but route must be non-empty",
+      emptyMethod: "Method '{{methodName}}' uses @HttpCall but method must be non-empty",
     },
   },
   create(context) {
@@ -60,6 +83,16 @@ module.exports = {
 
         const violation = getRouteViolation(decoratorExpression)
         if (!violation) {
+          const methodViolation = getMethodViolation(decoratorExpression)
+          if (!methodViolation) {
+            return
+          }
+
+          context.report({
+            node: node.key,
+            messageId: methodViolation,
+            data: { methodName: node.key.name },
+          })
           return
         }
 

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.spec.ts
@@ -30,6 +30,16 @@ const missingMethodError = (methodName: string) => ({
   data: { methodName },
 })
 
+const methodNotLiteralError = (methodName: string) => ({
+  messageId: 'methodNotLiteral' as const,
+  data: { methodName },
+})
+
+const emptyMethodError = (methodName: string) => ({
+  messageId: 'emptyMethod' as const,
+  data: { methodName },
+})
+
 describe('http-call-requires-route', () => {
   it('is a valid ESLint rule', () => {
     expect(rule).toBeDefined()
@@ -78,6 +88,16 @@ describe('http-call-requires-route', () => {
         name: 'reports when HttpCall route is an empty string literal',
         code: "class FraudClient { @HttpCall('', 'POST') checkFraud() {} }",
         errors: [emptyRouteError('checkFraud')],
+      },
+      {
+        name: 'reports when HttpCall method is not a string literal',
+        code: "const METHOD = 'POST'; class FraudClient { @HttpCall('/check', METHOD) checkFraud() {} }",
+        errors: [methodNotLiteralError('checkFraud')],
+      },
+      {
+        name: 'reports when HttpCall method is an empty string literal',
+        code: "class FraudClient { @HttpCall('/check', '') checkFraud() {} }",
+        errors: [emptyMethodError('checkFraud')],
       },
       {
         name: 'reports when HttpCall decorator is used without call syntax',

--- a/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.spec.ts
+++ b/packages/riviere-extract-conventions/src/eslint/http-call-requires-route.spec.ts
@@ -25,6 +25,11 @@ const emptyRouteError = (methodName: string) => ({
   data: { methodName },
 })
 
+const missingMethodError = (methodName: string) => ({
+  messageId: 'missingMethod' as const,
+  data: { methodName },
+})
+
 describe('http-call-requires-route', () => {
   it('is a valid ESLint rule', () => {
     expect(rule).toBeDefined()
@@ -37,8 +42,8 @@ describe('http-call-requires-route', () => {
         code: 'class FraudClient { checkFraud() {} }',
       },
       {
-        name: 'accepts HttpCall when route is non-empty string literal',
-        code: "class FraudClient { @HttpCall('/check') checkFraud() {} }",
+        name: 'accepts HttpCall when route and method are non-empty string literals',
+        code: "class FraudClient { @HttpCall('/check', 'POST') checkFraud() {} }",
       },
       {
         name: 'ignores non-call decorators that are not HttpCall',
@@ -50,7 +55,7 @@ describe('http-call-requires-route', () => {
       },
       {
         name: 'ignores methods with non-identifier keys',
-        code: "class FraudClient { @HttpCall('/check') ['checkFraud']() {} }",
+        code: "class FraudClient { @HttpCall('/check', 'POST') ['checkFraud']() {} }",
       },
     ],
     invalid: [
@@ -60,13 +65,18 @@ describe('http-call-requires-route', () => {
         errors: [missingRouteError('checkFraud')],
       },
       {
+        name: 'reports when HttpCall has no method argument',
+        code: "class FraudClient { @HttpCall('/check') checkFraud() {} }",
+        errors: [missingMethodError('checkFraud')],
+      },
+      {
         name: 'reports when HttpCall route is not a string literal',
-        code: "const ROUTE = '/fraud/check'; class FraudClient { @HttpCall(ROUTE) checkFraud() {} }",
+        code: "const ROUTE = '/fraud/check'; class FraudClient { @HttpCall(ROUTE, 'POST') checkFraud() {} }",
         errors: [routeNotLiteralError('checkFraud')],
       },
       {
         name: 'reports when HttpCall route is an empty string literal',
-        code: "class FraudClient { @HttpCall('') checkFraud() {} }",
+        code: "class FraudClient { @HttpCall('', 'POST') checkFraud() {} }",
         errors: [emptyRouteError('checkFraud')],
       },
       {

--- a/packages/riviere-extract-conventions/src/eslint/index.d.ts
+++ b/packages/riviere-extract-conventions/src/eslint/index.d.ts
@@ -27,7 +27,12 @@ interface Plugin {
       'missingServiceName' | 'serviceNameNotLiteral' | 'emptyServiceName'
     >
     'http-call-requires-route': TSESLint.RuleModule<
-      'missingRoute' | 'routeNotLiteral' | 'emptyRoute'
+      | 'missingRoute'
+      | 'missingMethod'
+      | 'routeNotLiteral'
+      | 'methodNotLiteral'
+      | 'emptyRoute'
+      | 'emptyMethod'
     >
     'http-call-requires-http-client-container': TSESLint.RuleModule<'missingHttpClientContainer'>
     'http-client-public-methods-require-http-call': TSESLint.RuleModule<'missingHttpCall'>

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
@@ -109,7 +109,8 @@ export function detectPerModuleConnections(
   globMatcher: GlobMatcher,
 ): PerModuleDetectionResult {
   const setupStart = performance.now()
-  const componentIndex = new ComponentIndex(components)
+  const visibleComponents = options.allComponents ?? components
+  const componentIndex = new ComponentIndex(visibleComponents)
   const sourceFilePaths = computeFilteredFilePaths(project, options.moduleGlobs, globMatcher)
   const setupMs = performance.now() - setupStart
 
@@ -130,16 +131,13 @@ export function detectPerModuleConnections(
   } = runConfigurableDetection(
     project,
     patterns,
-    components,
+    visibleComponents,
     componentIndex,
     strict,
     repository,
   )
 
-  const rewritten = rewriteHttpCallLinks(
-    [...syncLinks, ...configurableLinks],
-    options.allComponents ?? components,
-  )
+  const rewritten = rewriteHttpCallLinks([...syncLinks, ...configurableLinks], visibleComponents)
 
   return {
     links: rewritten.links,

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
@@ -80,7 +80,7 @@ export function stripHttpCallComponents(
 
 /** @riviere-role value-object */
 export interface PerModuleConnectionOptions {
-  allComponents?: readonly EnrichedComponent[]
+  allComponents: readonly EnrichedComponent[]
   allowIncomplete?: boolean
   moduleGlobs: string[]
   patterns?: ConnectionPattern[]
@@ -109,7 +109,7 @@ export function detectPerModuleConnections(
   globMatcher: GlobMatcher,
 ): PerModuleDetectionResult {
   const setupStart = performance.now()
-  const visibleComponents = options.allComponents ?? components
+  const visibleComponents = options.allComponents
   const componentIndex = new ComponentIndex(visibleComponents)
   const sourceFilePaths = computeFilteredFilePaths(project, options.moduleGlobs, globMatcher)
   const setupMs = performance.now() - setupStart
@@ -131,7 +131,7 @@ export function detectPerModuleConnections(
   } = runConfigurableDetection(
     project,
     patterns,
-    visibleComponents,
+    components,
     componentIndex,
     strict,
     repository,

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
@@ -80,6 +80,7 @@ export function stripHttpCallComponents(
 
 /** @riviere-role value-object */
 export interface PerModuleConnectionOptions {
+  allComponents?: readonly EnrichedComponent[]
   allowIncomplete?: boolean
   moduleGlobs: string[]
   patterns?: ConnectionPattern[]
@@ -135,7 +136,10 @@ export function detectPerModuleConnections(
     repository,
   )
 
-  const rewritten = rewriteHttpCallLinks([...syncLinks, ...configurableLinks], components)
+  const rewritten = rewriteHttpCallLinks(
+    [...syncLinks, ...configurableLinks],
+    options.allComponents ?? components,
+  )
 
   return {
     links: rewritten.links,

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-connections.ts
@@ -80,7 +80,7 @@ export function stripHttpCallComponents(
 
 /** @riviere-role value-object */
 export interface PerModuleConnectionOptions {
-  allComponents: readonly EnrichedComponent[]
+  allComponents?: readonly EnrichedComponent[]
   allowIncomplete?: boolean
   moduleGlobs: string[]
   patterns?: ConnectionPattern[]
@@ -109,7 +109,7 @@ export function detectPerModuleConnections(
   globMatcher: GlobMatcher,
 ): PerModuleDetectionResult {
   const setupStart = performance.now()
-  const visibleComponents = options.allComponents
+  const visibleComponents = options.allComponents ?? components
   const componentIndex = new ComponentIndex(visibleComponents)
   const sourceFilePaths = computeFilteredFilePaths(project, options.moduleGlobs, globMatcher)
   const setupMs = performance.now() - setupStart

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.dedup.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.dedup.spec.ts
@@ -1,0 +1,75 @@
+import {
+  describe, expect, it 
+} from 'vitest'
+import { Project } from 'ts-morph'
+import { buildComponent } from './call-graph/call-graph-fixtures'
+import { detectPerModuleConnections } from './detect-connections'
+
+function matchesGlob(filePath: string, pattern: string): boolean {
+  const normalizedPattern = pattern.replace('**/*', '').replace('**', '')
+  return filePath.startsWith(normalizedPattern.replace('*', ''))
+}
+
+describe('detectPerModuleConnections deduplication', () => {
+  it('deduplicates external links when call graph and configurable detection find the same httpCall edge', () => {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const filePath = '/src/orders/http.ts'
+    project.createSourceFile(
+      filePath,
+      `
+class Check {
+  Check(): void {}
+}
+
+class PlaceOrder {
+  private checkClient: Check
+  constructor(checkClient: Check) { this.checkClient = checkClient }
+  execute(): void {
+    this.checkClient.Check()
+  }
+}
+`,
+    )
+
+    const useCase = buildComponent('PlaceOrder', filePath, 6)
+    const httpCall = buildComponent('Check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'Fraud Detection Service',
+        route: '/api/check',
+        method: 'POST',
+      },
+    })
+
+    const result = detectPerModuleConnections(
+      project,
+      [useCase, httpCall],
+      {
+        repository: 'test-repo',
+        moduleGlobs: ['/src/orders/**/*.ts'],
+        allComponents: [useCase, httpCall],
+        patterns: [
+          {
+            name: 'same-http-call-edge',
+            find: 'methodCalls',
+            where: { methodName: 'Check' },
+            linkType: 'sync',
+          },
+        ],
+      },
+      matchesGlob,
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      expect.objectContaining({
+        source: 'orders:useCase:PlaceOrder',
+        target: {
+          name: 'Fraud Detection Service',
+          route: '/api/check',
+        },
+        type: 'sync',
+      }),
+    ])
+  })
+})

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.dedup.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.dedup.spec.ts
@@ -4,11 +4,7 @@ import {
 import { Project } from 'ts-morph'
 import { buildComponent } from './call-graph/call-graph-fixtures'
 import { detectPerModuleConnections } from './detect-connections'
-
-function matchesGlob(filePath: string, pattern: string): boolean {
-  const normalizedPattern = pattern.replace('**/*', '').replace('**', '')
-  return filePath.startsWith(normalizedPattern.replace('*', ''))
-}
+import { matchesGlob } from '../../../../platform/infra/external-clients/minimatch/minimatch-glob'
 
 describe('detectPerModuleConnections deduplication', () => {
   it('deduplicates external links when call graph and configurable detection find the same httpCall edge', () => {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
@@ -57,6 +57,47 @@ class PlaceOrder {
     ])
   })
 
+  it('supports module-local detection without allComponents option', () => {
+    const project = createProject()
+    const filePath = '/src/local-only.ts'
+    project.createSourceFile(
+      filePath,
+      `
+class OrderRepository {
+  save(): void {}
+}
+
+class PlaceOrder {
+  private repo: OrderRepository
+  constructor(repo: OrderRepository) { this.repo = repo }
+  execute(): void {
+    this.repo.save()
+  }
+}
+`,
+    )
+    const repo = buildComponent('OrderRepository', filePath, 2, { type: 'repository' })
+    const useCase = buildComponent('PlaceOrder', filePath, 6)
+
+    const result = detectPerModuleConnections(
+      project,
+      [repo, useCase],
+      {
+        repository: 'test-repo',
+        moduleGlobs: ['/src/**/*.ts'],
+      },
+      matchesGlob,
+    )
+
+    expect(result.links).toStrictEqual([
+      expect.objectContaining({
+        source: 'orders:useCase:PlaceOrder',
+        target: 'orders:repository:OrderRepository',
+        type: 'sync',
+      }),
+    ])
+  })
+
   it('returns empty links for empty components array', () => {
     const project = createProject()
     project.createSourceFile('/src/empty-per-module.ts', '')

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
@@ -43,6 +43,7 @@ class PlaceOrder {
       {
         repository: 'test-repo',
         moduleGlobs: ['/src/**/*.ts'],
+        allComponents: [repo, useCase, event, handler],
       },
       matchesGlob,
     )
@@ -66,6 +67,7 @@ class PlaceOrder {
       {
         repository: 'test-repo',
         moduleGlobs: ['/src/**/*.ts'],
+        allComponents: [],
       },
       matchesGlob,
     )
@@ -83,6 +85,7 @@ class PlaceOrder {
       {
         repository: 'test-repo',
         moduleGlobs: ['/src/**/*.ts'],
+        allComponents: [],
       },
       matchesGlob,
     )
@@ -133,6 +136,7 @@ class ExcludedUseCase {
       {
         repository: 'test-repo',
         moduleGlobs: ['/src/included/**/*.ts'],
+        allComponents: [repo, useCase],
       },
       matchesGlob,
     )
@@ -180,6 +184,7 @@ class PlaceOrder {
       {
         repository: 'test-repo',
         moduleGlobs: ['/src/**/*.ts'],
+        allComponents: [useCase, httpCall],
       },
       matchesGlob,
     )
@@ -298,5 +303,62 @@ class PlaceOrder {
         type: 'sync',
       }),
     ])
+  })
+
+  it('ignores configurable matches from source components outside moduleGlobs', () => {
+    const project = createProject()
+    project.createSourceFile(
+      '/src/bff/place-order.ts',
+      `
+class PlaceOrder {
+  execute(): void {}
+}
+`,
+    )
+    project.createSourceFile(
+      '/src/orders/create-order.ts',
+      `
+class OrderRepo {
+  save(): void {}
+}
+
+class CreateOrder {
+  private repo: OrderRepo
+  constructor(repo: OrderRepo) { this.repo = repo }
+  execute(): void {
+    this.repo.save()
+  }
+}
+`,
+    )
+
+    const bffUseCase = buildComponent('PlaceOrder', '/src/bff/place-order.ts', 2, { domain: 'bff' })
+    const ordersUseCase = buildComponent('CreateOrder', '/src/orders/create-order.ts', 6, {domain: 'orders',})
+    const orderRepo = buildComponent('OrderRepo', '/src/orders/create-order.ts', 2, {
+      type: 'repository',
+      domain: 'orders',
+    })
+
+    const result = detectPerModuleConnections(
+      project,
+      [bffUseCase],
+      {
+        repository: 'test-repo',
+        moduleGlobs: ['/src/bff/**/*.ts'],
+        allComponents: [bffUseCase, ordersUseCase, orderRepo],
+        patterns: [
+          {
+            name: 'repo-save-pattern',
+            find: 'methodCalls',
+            where: { methodName: 'save' },
+            linkType: 'sync',
+          },
+        ],
+      },
+      matchesGlob,
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([])
   })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
@@ -196,4 +196,56 @@ class PlaceOrder {
       }),
     ])
   })
+
+  it('keeps internal link when matching api component exists in another module', () => {
+    const project = createProject()
+    const filePath = '/src/bff/http.ts'
+    project.createSourceFile(
+      filePath,
+      `
+class InventoryClient {
+  checkStock(): void {}
+}
+
+class CheckStockAvailability {
+  private inventory: InventoryClient
+  constructor(inventory: InventoryClient) { this.inventory = inventory }
+  execute(): void {
+    this.inventory.checkStock()
+  }
+}
+`,
+    )
+
+    const useCase = buildComponent('CheckStockAvailability', filePath, 6, { domain: 'bff' })
+    const httpCall = buildComponent('checkStock', filePath, 3, {
+      type: 'httpCall',
+      domain: 'bff',
+      metadata: {
+        serviceName: 'inventory',
+        route: '/inventory/:sku',
+      },
+    })
+    const inventoryApi = buildComponent('CheckStockEndpoint', '/src/inventory/api.ts', 1, {
+      type: 'api',
+      domain: 'inventory',
+      metadata: { route: '/inventory/:sku' },
+    })
+    const options = {
+      repository: 'test-repo',
+      moduleGlobs: ['/src/bff/**/*.ts'],
+      allComponents: [useCase, httpCall, inventoryApi],
+    }
+
+    const result = detectPerModuleConnections(project, [useCase, httpCall], options, matchesGlob)
+
+    expect(result.links).toStrictEqual([
+      expect.objectContaining({
+        source: 'bff:useCase:CheckStockAvailability',
+        target: 'inventory:api:CheckStockEndpoint',
+        type: 'sync',
+      }),
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/detect-per-module-connections.spec.ts
@@ -248,4 +248,55 @@ class CheckStockAvailability {
     ])
     expect(result.externalLinks).toStrictEqual([])
   })
+
+  it('returns sync link to component in another module when allComponents includes target', () => {
+    const project = createProject()
+    project.createSourceFile(
+      '/src/orders/repository.ts',
+      `
+export class OrdersRepository {
+  save(): void {}
+}
+`,
+    )
+    project.createSourceFile(
+      '/src/bff/use-case.ts',
+      `
+import { OrdersRepository } from '../orders/repository'
+
+class PlaceOrder {
+  private repo: OrdersRepository
+  constructor(repo: OrdersRepository) { this.repo = repo }
+  execute(): void {
+    this.repo.save()
+  }
+}
+`,
+    )
+
+    const useCase = buildComponent('PlaceOrder', '/src/bff/use-case.ts', 4, { domain: 'bff' })
+    const repository = buildComponent('OrdersRepository', '/src/orders/repository.ts', 2, {
+      type: 'repository',
+      domain: 'orders',
+    })
+
+    const result = detectPerModuleConnections(
+      project,
+      [useCase],
+      {
+        repository: 'test-repo',
+        moduleGlobs: ['/src/bff/**/*.ts'],
+        allComponents: [useCase, repository],
+      },
+      matchesGlob,
+    )
+
+    expect(result.links).toStrictEqual([
+      expect.objectContaining({
+        source: 'bff:useCase:PlaceOrder',
+        target: 'orders:repository:OrdersRepository',
+        type: 'sync',
+      }),
+    ])
+  })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
@@ -1,0 +1,114 @@
+import {
+  describe, expect, it 
+} from 'vitest'
+import { buildComponent } from './call-graph/call-graph-fixtures'
+import { rewriteHttpCallLinks } from './http-call-link-rewrite'
+
+describe('rewriteHttpCallLinks - api resolution safety', () => {
+  it('rewrites link to external when httpCall serviceName matches a non-api internal component name', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'FraudGateway',
+        route: '/api/check',
+      },
+    })
+    const internalTarget = buildComponent('FraudGateway', filePath, 3, { type: 'repository' })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalTarget],
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: {
+          name: 'FraudGateway',
+          route: '/api/check',
+        },
+        type: 'sync',
+      },
+    ])
+  })
+
+  it('keeps internal link when httpCall serviceName matches a unique internal api component name', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'FraudGateway',
+        route: '/api/check',
+      },
+    })
+    const internalApi = buildComponent('FraudGateway', filePath, 3, { type: 'api' })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalApi],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: 'orders:api:FraudGateway',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('keeps internal link when normalized serviceName label matches an internal domain route', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
+    const httpCall = buildComponent('placeOrder', filePath, 2, {
+      type: 'httpCall',
+      domain: 'bff',
+      metadata: {
+        serviceName: 'Inventory Service',
+        route: '/inventory/:sku',
+      },
+    })
+    const inventoryApi = buildComponent('CheckStockEndpoint', '/src/inventory/api.ts', 3, {
+      type: 'api',
+      domain: 'inventory',
+      metadata: { route: '/inventory/:sku' },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'bff:useCase:PlaceOrderBFFUseCase',
+          target: 'bff:httpCall:placeOrder',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, inventoryApi],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'bff:useCase:PlaceOrderBFFUseCase',
+        target: 'inventory:api:CheckStockEndpoint',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+})

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
@@ -118,51 +118,6 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
-  it('rewrites link to external when serviceName is a label instead of the internal domain key', () => {
-    const filePath = '/src/http.ts'
-    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
-    const httpCall = buildComponent('placeOrder', filePath, 2, {
-      type: 'httpCall',
-      domain: 'bff',
-      metadata: {
-        serviceName: 'Inventory Service',
-        route: '/inventory/:sku',
-        method: 'GET',
-      },
-    })
-    const inventoryApi = buildComponent('CheckStockEndpoint', '/src/inventory/api.ts', 3, {
-      type: 'api',
-      domain: 'inventory',
-      metadata: {
-        route: '/inventory/:sku',
-        method: 'GET',
-      },
-    })
-
-    const result = rewriteHttpCallLinks(
-      [
-        {
-          source: 'bff:useCase:PlaceOrderBFFUseCase',
-          target: 'bff:httpCall:placeOrder',
-          type: 'sync',
-        },
-      ],
-      [source, httpCall, inventoryApi],
-    )
-
-    expect(result.links).toStrictEqual([])
-    expect(result.externalLinks).toStrictEqual([
-      {
-        source: 'bff:useCase:PlaceOrderBFFUseCase',
-        target: {
-          name: 'Inventory Service',
-          route: '/inventory/:sku',
-        },
-        type: 'sync',
-      },
-    ])
-  })
-
   it('rewrites link to external when serviceName matches api name but route metadata contradicts it', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
@@ -1,6 +1,7 @@
 import {
   describe, expect, it 
 } from 'vitest'
+import { ConnectionDetectionError } from './connection-detection-error'
 import { buildComponent } from './call-graph/call-graph-fixtures'
 import { rewriteHttpCallLinks } from './http-call-link-rewrite'
 
@@ -74,7 +75,7 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
-  it('keeps internal link when normalized serviceName label matches an internal domain route', () => {
+  it('rewrites link to external when serviceName is a label instead of the internal domain key', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
     const httpCall = buildComponent('placeOrder', filePath, 2, {
@@ -83,12 +84,16 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
       metadata: {
         serviceName: 'Inventory Service',
         route: '/inventory/:sku',
+        method: 'GET',
       },
     })
     const inventoryApi = buildComponent('CheckStockEndpoint', '/src/inventory/api.ts', 3, {
       type: 'api',
       domain: 'inventory',
-      metadata: { route: '/inventory/:sku' },
+      metadata: {
+        route: '/inventory/:sku',
+        method: 'GET',
+      },
     })
 
     const result = rewriteHttpCallLinks(
@@ -102,10 +107,124 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
       [source, httpCall, inventoryApi],
     )
 
-    expect(result.links).toStrictEqual([
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
       {
         source: 'bff:useCase:PlaceOrderBFFUseCase',
-        target: 'inventory:api:CheckStockEndpoint',
+        target: {
+          name: 'Inventory Service',
+          route: '/inventory/:sku',
+        },
+        type: 'sync',
+      },
+    ])
+  })
+
+  it('rewrites link to external when serviceName matches api name but route metadata contradicts it', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'FraudGateway',
+        route: '/api/check',
+        method: 'POST',
+      },
+    })
+    const internalApi = buildComponent('FraudGateway', filePath, 3, {
+      type: 'api',
+      metadata: {
+        route: '/different-route',
+        method: 'POST',
+      },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalApi],
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: {
+          name: 'FraudGateway',
+          route: '/api/check',
+        },
+        type: 'sync',
+      },
+    ])
+  })
+
+  it('throws when httpCall method metadata is invalid', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const target = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'Fraud Detection Service',
+        method: 123,
+      },
+    })
+
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, target],
+      ),
+    ).toThrowError(/method/)
+    expect(() =>
+      rewriteHttpCallLinks(
+        [
+          {
+            source: 'orders:useCase:PlaceOrder',
+            target: 'orders:httpCall:check',
+            type: 'sync',
+          },
+        ],
+        [source, target],
+      ),
+    ).toThrow(ConnectionDetectionError)
+  })
+
+  it('deduplicates identical kept internal links', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const target = buildComponent('FraudGateway', filePath, 2, { type: 'api' })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:api:FraudGateway',
+          type: 'sync',
+        },
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:api:FraudGateway',
+          type: 'sync',
+        },
+      ],
+      [source, target],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: 'orders:api:FraudGateway',
         type: 'sync',
       },
     ])

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-api-resolution.spec.ts
@@ -42,7 +42,7 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
     ])
   })
 
-  it('keeps internal link when httpCall serviceName matches a unique internal api component name', () => {
+  it('rewrites link to external when api-name fallback candidate has no route or method metadata', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)
     const httpCall = buildComponent('check', filePath, 2, {
@@ -53,6 +53,49 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
       },
     })
     const internalApi = buildComponent('FraudGateway', filePath, 3, { type: 'api' })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalApi],
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: {
+          name: 'FraudGateway',
+          route: '/api/check',
+        },
+        type: 'sync',
+      },
+    ])
+  })
+
+  it('keeps internal link when api-name fallback candidate matches route and method metadata', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'FraudGateway',
+        route: '/api/check',
+        method: 'POST',
+      },
+    })
+    const internalApi = buildComponent('FraudGateway', filePath, 3, {
+      type: 'api',
+      metadata: {
+        route: '/api/check',
+        method: 'POST',
+      },
+    })
 
     const result = rewriteHttpCallLinks(
       [
@@ -163,6 +206,76 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
     ])
   })
 
+  it('keeps internal link when route uniquely matches an api without method metadata', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
+    const httpCall = buildComponent('placeOrder', filePath, 2, {
+      type: 'httpCall',
+      domain: 'bff',
+      metadata: {
+        serviceName: 'orders',
+        route: '/orders',
+        method: 'POST',
+      },
+    })
+    const internalTarget = buildComponent('handle', filePath, 3, {
+      type: 'api',
+      domain: 'orders',
+      metadata: { route: '/orders' },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'bff:useCase:PlaceOrderBFFUseCase',
+          target: 'bff:httpCall:placeOrder',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalTarget],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'bff:useCase:PlaceOrderBFFUseCase',
+        target: 'orders:api:handle',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('rewrites link to external when httpCall serviceName matches multiple internal api components', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: { serviceName: 'FraudGateway' },
+    })
+    const firstApiTarget = buildComponent('FraudGateway', filePath, 3, { type: 'api' })
+    const secondApiTarget = buildComponent('FraudGateway', filePath, 4, { type: 'api' })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, firstApiTarget, secondApiTarget],
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: { name: 'FraudGateway' },
+        type: 'sync',
+      },
+    ])
+  })
+
   it('throws when httpCall method metadata is invalid', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)
@@ -229,5 +342,58 @@ describe('rewriteHttpCallLinks - api resolution safety', () => {
       },
     ])
     expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('rewrites link to external when multiple apis share the same route and method', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
+    const httpCall = buildComponent('placeOrder', filePath, 2, {
+      type: 'httpCall',
+      domain: 'bff',
+      metadata: {
+        serviceName: 'orders',
+        route: '/orders',
+        method: 'POST',
+      },
+    })
+    const firstApi = buildComponent('createOrder', filePath, 3, {
+      type: 'api',
+      domain: 'orders',
+      metadata: {
+        route: '/orders',
+        method: 'POST',
+      },
+    })
+    const secondApi = buildComponent('submitOrder', filePath, 4, {
+      type: 'api',
+      domain: 'orders',
+      metadata: {
+        route: '/orders',
+        method: 'POST',
+      },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'bff:useCase:PlaceOrderBFFUseCase',
+          target: 'bff:httpCall:placeOrder',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, firstApi, secondApi],
+    )
+
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
+      {
+        source: 'bff:useCase:PlaceOrderBFFUseCase',
+        target: {
+          name: 'orders',
+          route: '/orders',
+        },
+        type: 'sync',
+      },
+    ])
   })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-global-resolution.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-global-resolution.spec.ts
@@ -71,7 +71,7 @@ describe('rewriteHttpCallLinks - global and fallback resolution', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
-  it('keeps internal link when route and method uniquely match an internal api even when serviceName is only a label', () => {
+  it('rewrites link to external when serviceName is only a label even if route and method match an internal api', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
     const httpCall = buildComponent('placeOrder', filePath, 2, {
@@ -103,13 +103,16 @@ describe('rewriteHttpCallLinks - global and fallback resolution', () => {
       [source, httpCall, inventoryApi],
     )
 
-    expect(result.links).toStrictEqual([
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
       {
         source: 'bff:useCase:PlaceOrderBFFUseCase',
-        target: 'inventory:api:CheckStockEndpoint',
+        target: {
+          name: 'Inventory Service',
+          route: '/inventory/:sku',
+        },
         type: 'sync',
       },
     ])
-    expect(result.externalLinks).toStrictEqual([])
   })
 })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-global-resolution.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite-global-resolution.spec.ts
@@ -1,0 +1,115 @@
+import {
+  describe, expect, it 
+} from 'vitest'
+import { buildComponent } from './call-graph/call-graph-fixtures'
+import { rewriteHttpCallLinks } from './http-call-link-rewrite'
+
+describe('rewriteHttpCallLinks - global and fallback resolution', () => {
+  it('keeps internal link when httpCall has only serviceName and api name matches uniquely', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: { serviceName: 'FraudGateway' },
+    })
+    const internalApi = buildComponent('FraudGateway', filePath, 3, { type: 'api' })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalApi],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: 'orders:api:FraudGateway',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('keeps internal link when api-name fallback matches on method and route is absent', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrder', filePath, 1)
+    const httpCall = buildComponent('check', filePath, 2, {
+      type: 'httpCall',
+      metadata: {
+        serviceName: 'FraudGateway',
+        method: 'POST',
+      },
+    })
+    const internalApi = buildComponent('FraudGateway', filePath, 3, {
+      type: 'api',
+      metadata: { method: 'POST' },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'orders:useCase:PlaceOrder',
+          target: 'orders:httpCall:check',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, internalApi],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'orders:useCase:PlaceOrder',
+        target: 'orders:api:FraudGateway',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('keeps internal link when route and method uniquely match an internal api even when serviceName is only a label', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
+    const httpCall = buildComponent('placeOrder', filePath, 2, {
+      type: 'httpCall',
+      domain: 'bff',
+      metadata: {
+        serviceName: 'Inventory Service',
+        route: '/inventory/:sku',
+        method: 'GET',
+      },
+    })
+    const inventoryApi = buildComponent('CheckStockEndpoint', '/src/inventory/api.ts', 3, {
+      type: 'api',
+      domain: 'inventory',
+      metadata: {
+        route: '/inventory/:sku',
+        method: 'GET',
+      },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'bff:useCase:PlaceOrderBFFUseCase',
+          target: 'bff:httpCall:placeOrder',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, inventoryApi],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'bff:useCase:PlaceOrderBFFUseCase',
+        target: 'inventory:api:CheckStockEndpoint',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+})

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -62,42 +62,6 @@ describe('rewriteHttpCallLinks', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
-  it('rewrites link to external when httpCall serviceName matches a non-api internal component name', () => {
-    const filePath = '/src/http.ts'
-    const source = buildComponent('PlaceOrder', filePath, 1)
-    const httpCall = buildComponent('check', filePath, 2, {
-      type: 'httpCall',
-      metadata: {
-        serviceName: 'FraudGateway',
-        route: '/api/check',
-      },
-    })
-    const internalTarget = buildComponent('FraudGateway', filePath, 3, { type: 'repository' })
-
-    const result = rewriteHttpCallLinks(
-      [
-        {
-          source: 'orders:useCase:PlaceOrder',
-          target: 'orders:httpCall:check',
-          type: 'sync',
-        },
-      ],
-      [source, httpCall, internalTarget],
-    )
-
-    expect(result.links).toStrictEqual([])
-    expect(result.externalLinks).toStrictEqual([
-      {
-        source: 'orders:useCase:PlaceOrder',
-        target: {
-          name: 'FraudGateway',
-          route: '/api/check',
-        },
-        type: 'sync',
-      },
-    ])
-  })
-
   it('keeps internal link when httpCall serviceName matches internal domain and route matches a unique api component', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
@@ -226,44 +190,6 @@ describe('rewriteHttpCallLinks', () => {
         type: 'sync',
       },
     ])
-  })
-
-  it('keeps internal link when normalized serviceName label matches an internal domain route', () => {
-    const filePath = '/src/http.ts'
-    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
-    const httpCall = buildComponent('placeOrder', filePath, 2, {
-      type: 'httpCall',
-      domain: 'bff',
-      metadata: {
-        serviceName: 'Inventory Service',
-        route: '/inventory/:sku',
-      },
-    })
-    const inventoryApi = buildComponent('CheckStockEndpoint', '/src/inventory/api.ts', 3, {
-      type: 'api',
-      domain: 'inventory',
-      metadata: { route: '/inventory/:sku' },
-    })
-
-    const result = rewriteHttpCallLinks(
-      [
-        {
-          source: 'bff:useCase:PlaceOrderBFFUseCase',
-          target: 'bff:httpCall:placeOrder',
-          type: 'sync',
-        },
-      ],
-      [source, httpCall, inventoryApi],
-    )
-
-    expect(result.links).toStrictEqual([
-      {
-        source: 'bff:useCase:PlaceOrderBFFUseCase',
-        target: 'inventory:api:CheckStockEndpoint',
-        type: 'sync',
-      },
-    ])
-    expect(result.externalLinks).toStrictEqual([])
   })
 
   it('throws when httpCall serviceName matches multiple internal api components', () => {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -246,42 +246,6 @@ describe('rewriteHttpCallLinks', () => {
     ])
   })
 
-  it('throws when httpCall serviceName matches multiple internal api components', () => {
-    const filePath = '/src/http.ts'
-    const source = buildComponent('PlaceOrder', filePath, 1)
-    const httpCall = buildComponent('check', filePath, 2, {
-      type: 'httpCall',
-      metadata: { serviceName: 'FraudGateway' },
-    })
-    const firstApiTarget = buildComponent('FraudGateway', filePath, 3, { type: 'api' })
-    const secondApiTarget = buildComponent('FraudGateway', filePath, 4, { type: 'api' })
-
-    expect(() =>
-      rewriteHttpCallLinks(
-        [
-          {
-            source: 'orders:useCase:PlaceOrder',
-            target: 'orders:httpCall:check',
-            type: 'sync',
-          },
-        ],
-        [source, httpCall, firstApiTarget, secondApiTarget],
-      ),
-    ).toThrowError(/exactly one internal api component/)
-    expect(() =>
-      rewriteHttpCallLinks(
-        [
-          {
-            source: 'orders:useCase:PlaceOrder',
-            target: 'orders:httpCall:check',
-            type: 'sync',
-          },
-        ],
-        [source, httpCall, firstApiTarget, secondApiTarget],
-      ),
-    ).toThrow(ConnectionDetectionError)
-  })
-
   it('throws when httpCall serviceName metadata is missing', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -225,6 +225,44 @@ describe('rewriteHttpCallLinks', () => {
     ])
   })
 
+  it('keeps internal link when route matches a unique api component globally and serviceName is only a label', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
+    const httpCall = buildComponent('placeOrder', filePath, 2, {
+      type: 'httpCall',
+      domain: 'bff',
+      metadata: {
+        serviceName: 'Inventory Service',
+        route: '/inventory/:sku',
+      },
+    })
+    const inventoryApi = buildComponent('CheckStockEndpoint', '/src/inventory/api.ts', 3, {
+      type: 'api',
+      domain: 'inventory',
+      metadata: { route: '/inventory/:sku' },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'bff:useCase:PlaceOrderBFFUseCase',
+          target: 'bff:httpCall:placeOrder',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, inventoryApi],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'bff:useCase:PlaceOrderBFFUseCase',
+        target: 'inventory:api:CheckStockEndpoint',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
   it('throws when httpCall serviceName matches multiple internal components', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -62,7 +62,7 @@ describe('rewriteHttpCallLinks', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
-  it('keeps internal link when httpCall serviceName matches internal domain and route matches a unique api component', () => {
+  it('keeps internal link when httpCall serviceName matches internal domain and route plus method match a unique api component', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
     const httpCall = buildComponent('placeOrder', filePath, 2, {
@@ -71,12 +71,16 @@ describe('rewriteHttpCallLinks', () => {
       metadata: {
         serviceName: 'orders',
         route: '/orders',
+        method: 'POST',
       },
     })
     const internalTarget = buildComponent('handle', filePath, 3, {
       type: 'api',
       domain: 'orders',
-      metadata: { route: '/orders' },
+      metadata: {
+        route: '/orders',
+        method: 'POST',
+      },
     })
 
     const result = rewriteHttpCallLinks(
@@ -94,6 +98,56 @@ describe('rewriteHttpCallLinks', () => {
       {
         source: 'bff:useCase:PlaceOrderBFFUseCase',
         target: 'orders:api:handle',
+        type: 'sync',
+      },
+    ])
+    expect(result.externalLinks).toStrictEqual([])
+  })
+
+  it('keeps internal link to the api with matching method when multiple apis share a route', () => {
+    const filePath = '/src/http.ts'
+    const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
+    const httpCall = buildComponent('placeOrder', filePath, 2, {
+      type: 'httpCall',
+      domain: 'bff',
+      metadata: {
+        serviceName: 'orders',
+        route: '/orders',
+        method: 'POST',
+      },
+    })
+    const getOrdersApi = buildComponent('listOrders', filePath, 3, {
+      type: 'api',
+      domain: 'orders',
+      metadata: {
+        route: '/orders',
+        method: 'GET',
+      },
+    })
+    const createOrderApi = buildComponent('createOrder', filePath, 4, {
+      type: 'api',
+      domain: 'orders',
+      metadata: {
+        route: '/orders',
+        method: 'POST',
+      },
+    })
+
+    const result = rewriteHttpCallLinks(
+      [
+        {
+          source: 'bff:useCase:PlaceOrderBFFUseCase',
+          target: 'bff:httpCall:placeOrder',
+          type: 'sync',
+        },
+      ],
+      [source, httpCall, getOrdersApi, createOrderApi],
+    )
+
+    expect(result.links).toStrictEqual([
+      {
+        source: 'bff:useCase:PlaceOrderBFFUseCase',
+        target: 'orders:api:createOrder',
         type: 'sync',
       },
     ])

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.spec.ts
@@ -62,7 +62,7 @@ describe('rewriteHttpCallLinks', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
-  it('keeps internal link when httpCall serviceName matches internal component name', () => {
+  it('rewrites link to external when httpCall serviceName matches a non-api internal component name', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)
     const httpCall = buildComponent('check', filePath, 2, {
@@ -85,14 +85,17 @@ describe('rewriteHttpCallLinks', () => {
       [source, httpCall, internalTarget],
     )
 
-    expect(result.links).toStrictEqual([
+    expect(result.links).toStrictEqual([])
+    expect(result.externalLinks).toStrictEqual([
       {
         source: 'orders:useCase:PlaceOrder',
-        target: 'orders:repository:FraudGateway',
+        target: {
+          name: 'FraudGateway',
+          route: '/api/check',
+        },
         type: 'sync',
       },
     ])
-    expect(result.externalLinks).toStrictEqual([])
   })
 
   it('keeps internal link when httpCall serviceName matches internal domain and route matches a unique api component', () => {
@@ -225,7 +228,7 @@ describe('rewriteHttpCallLinks', () => {
     ])
   })
 
-  it('keeps internal link when route matches a unique api component globally and serviceName is only a label', () => {
+  it('keeps internal link when normalized serviceName label matches an internal domain route', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrderBFFUseCase', filePath, 1, { domain: 'bff' })
     const httpCall = buildComponent('placeOrder', filePath, 2, {
@@ -263,15 +266,15 @@ describe('rewriteHttpCallLinks', () => {
     expect(result.externalLinks).toStrictEqual([])
   })
 
-  it('throws when httpCall serviceName matches multiple internal components', () => {
+  it('throws when httpCall serviceName matches multiple internal api components', () => {
     const filePath = '/src/http.ts'
     const source = buildComponent('PlaceOrder', filePath, 1)
     const httpCall = buildComponent('check', filePath, 2, {
       type: 'httpCall',
       metadata: { serviceName: 'FraudGateway' },
     })
-    const repositoryTarget = buildComponent('FraudGateway', filePath, 3, { type: 'repository' })
-    const useCaseTarget = buildComponent('FraudGateway', filePath, 4, { type: 'useCase' })
+    const firstApiTarget = buildComponent('FraudGateway', filePath, 3, { type: 'api' })
+    const secondApiTarget = buildComponent('FraudGateway', filePath, 4, { type: 'api' })
 
     expect(() =>
       rewriteHttpCallLinks(
@@ -282,9 +285,9 @@ describe('rewriteHttpCallLinks', () => {
             type: 'sync',
           },
         ],
-        [source, httpCall, repositoryTarget, useCaseTarget],
+        [source, httpCall, firstApiTarget, secondApiTarget],
       ),
-    ).toThrowError(/exactly one internal component/)
+    ).toThrowError(/exactly one internal api component/)
     expect(() =>
       rewriteHttpCallLinks(
         [
@@ -294,7 +297,7 @@ describe('rewriteHttpCallLinks', () => {
             type: 'sync',
           },
         ],
-        [source, httpCall, repositoryTarget, useCaseTarget],
+        [source, httpCall, firstApiTarget, secondApiTarget],
       ),
     ).toThrow(ConnectionDetectionError)
   })

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -39,9 +39,8 @@ function mapInternalApiComponentsByName(
   return byName
 }
 
-function findUniqueApiComponentInDomainMatchingRoute(
+function findUniqueApiComponentMatchingRoute(
   components: readonly EnrichedComponent[],
-  domainName: string,
   route: string | undefined,
   method: string | undefined,
 ): EnrichedComponent | undefined {
@@ -50,10 +49,7 @@ function findUniqueApiComponentInDomainMatchingRoute(
   }
 
   const routeMatchedApiComponents = components.filter(
-    (component) =>
-      component.type === 'api' &&
-      component.domain === domainName &&
-      component.metadata['route'] === route,
+    (component) => component.type === 'api' && component.metadata['route'] === route,
   )
 
   if (method === undefined) {
@@ -85,6 +81,19 @@ function findUniqueApiComponentInDomainMatchingRoute(
   }
 
   return methodlessApiComponents[0]
+}
+
+function findUniqueApiComponentInDomainMatchingRoute(
+  components: readonly EnrichedComponent[],
+  domainName: string,
+  route: string | undefined,
+  method: string | undefined,
+): EnrichedComponent | undefined {
+  return findUniqueApiComponentMatchingRoute(
+    components.filter((component) => component.domain === domainName),
+    route,
+    method,
+  )
 }
 
 function parseServiceName(httpCallComponent: EnrichedComponent): string {
@@ -239,6 +248,16 @@ export function rewriteHttpCallLinks(
       linksToKeep.push({
         ...link,
         target: componentIdentity(uniqueApiTargetInDomain),
+      })
+      continue
+    }
+
+    const uniqueApiTargetGlobally = findUniqueApiComponentMatchingRoute(components, route, method)
+
+    if (uniqueApiTargetGlobally !== undefined) {
+      linksToKeep.push({
+        ...link,
+        target: componentIdentity(uniqueApiTargetGlobally),
       })
       continue
     }

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -252,16 +252,6 @@ export function rewriteHttpCallLinks(
       continue
     }
 
-    const uniqueApiTargetGlobally = findUniqueApiComponentMatchingRoute(components, route, method)
-
-    if (uniqueApiTargetGlobally !== undefined) {
-      linksToKeep.push({
-        ...link,
-        target: componentIdentity(uniqueApiTargetGlobally),
-      })
-      continue
-    }
-
     const matchedInternalApis = internalApiComponentsByName.get(serviceName) ?? []
     const matchedInternalApiCount = matchedInternalApis.length
     if (matchedInternalApiCount > 1) {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -20,12 +20,12 @@ function mapComponentsByIdentity(
   return byIdentity
 }
 
-function mapInternalComponentsByName(
+function mapInternalApiComponentsByName(
   components: readonly EnrichedComponent[],
 ): ReadonlyMap<string, readonly EnrichedComponent[]> {
   const byName = new Map<string, EnrichedComponent[]>()
   for (const component of components) {
-    if (component.type === 'httpCall') {
+    if (component.type !== 'api') {
       continue
     }
 
@@ -62,25 +62,6 @@ function findUniqueApiComponentInDomainMatchingRoute(
   return matchedApiComponents[0]
 }
 
-function findUniqueApiComponentMatchingRoute(
-  components: readonly EnrichedComponent[],
-  route: string | undefined,
-): EnrichedComponent | undefined {
-  if (route === undefined) {
-    return undefined
-  }
-
-  const matchedApiComponents = components.filter(
-    (component) => component.type === 'api' && component.metadata['route'] === route,
-  )
-
-  if (matchedApiComponents.length !== 1) {
-    return undefined
-  }
-
-  return matchedApiComponents[0]
-}
-
 function parseServiceName(httpCallComponent: EnrichedComponent): string {
   const rawServiceName = httpCallComponent.metadata['serviceName']
   if (typeof rawServiceName === 'string' && rawServiceName.trim().length > 0) {
@@ -93,6 +74,16 @@ function parseServiceName(httpCallComponent: EnrichedComponent): string {
     typeName: componentIdentity(httpCallComponent),
     reason: `Expected metadata.serviceName to be a non-empty string, got ${JSON.stringify(rawServiceName)}`,
   })
+}
+
+function normalizeServiceNameToDomainName(serviceName: string): string {
+  const lowercaseServiceName = serviceName.trim().toLowerCase()
+  const withoutSuffix = lowercaseServiceName.replaceAll(' service', '').replaceAll(' api', '')
+
+  return withoutSuffix
+    .split(/[^a-z0-9]+/)
+    .filter((part) => part.length > 0)
+    .join('-')
 }
 
 function parseRoute(httpCallComponent: EnrichedComponent): string | undefined {
@@ -137,7 +128,7 @@ export function rewriteHttpCallLinks(
   const linksToKeep: ExtractedLink[] = []
   const externalLinks: ExternalLink[] = []
   const componentsByIdentity = mapComponentsByIdentity(components)
-  const internalComponentsByName = mapInternalComponentsByName(components)
+  const internalApiComponentsByName = mapInternalApiComponentsByName(components)
 
   for (const link of links) {
     const targetComponent = componentsByIdentity.get(link.target)
@@ -147,32 +138,12 @@ export function rewriteHttpCallLinks(
     }
 
     const serviceName = parseServiceName(targetComponent)
-    const matchedInternalComponents = internalComponentsByName.get(serviceName) ?? []
-    const matchedInternalCount = matchedInternalComponents.length
-    if (matchedInternalCount > 1) {
-      throw new ConnectionDetectionError({
-        file: targetComponent.location.file,
-        line: targetComponent.location.line,
-        typeName: componentIdentity(targetComponent),
-        reason: `Expected metadata.serviceName to match exactly one internal component name, got ${matchedInternalCount} matches for ${JSON.stringify(serviceName)}`,
-      })
-    }
-
-    const [uniqueInternalTarget] = matchedInternalComponents
-
-    if (uniqueInternalTarget !== undefined) {
-      linksToKeep.push({
-        ...link,
-        target: componentIdentity(uniqueInternalTarget),
-      })
-      continue
-    }
-
     const route = parseRoute(targetComponent)
+    const normalizedDomainName = normalizeServiceNameToDomainName(serviceName)
 
     const uniqueApiTargetInDomain = findUniqueApiComponentInDomainMatchingRoute(
       components,
-      serviceName,
+      normalizedDomainName,
       route,
     )
 
@@ -184,12 +155,23 @@ export function rewriteHttpCallLinks(
       continue
     }
 
-    const uniqueApiTargetByRoute = findUniqueApiComponentMatchingRoute(components, route)
+    const matchedInternalApis = internalApiComponentsByName.get(serviceName) ?? []
+    const matchedInternalApiCount = matchedInternalApis.length
+    if (matchedInternalApiCount > 1) {
+      throw new ConnectionDetectionError({
+        file: targetComponent.location.file,
+        line: targetComponent.location.line,
+        typeName: componentIdentity(targetComponent),
+        reason: `Expected metadata.serviceName to match exactly one internal api component name, got ${matchedInternalApiCount} matches for ${JSON.stringify(serviceName)}`,
+      })
+    }
 
-    if (uniqueApiTargetByRoute !== undefined) {
+    const [uniqueInternalTarget] = matchedInternalApis
+
+    if (uniqueInternalTarget !== undefined) {
       linksToKeep.push({
         ...link,
-        target: componentIdentity(uniqueApiTargetByRoute),
+        target: componentIdentity(uniqueInternalTarget),
       })
       continue
     }

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -49,19 +49,42 @@ function findUniqueApiComponentInDomainMatchingRoute(
     return undefined
   }
 
-  const matchedApiComponents = components.filter(
+  const routeMatchedApiComponents = components.filter(
     (component) =>
       component.type === 'api' &&
       component.domain === domainName &&
-      component.metadata['route'] === route &&
-      (method === undefined || component.metadata['method'] === method),
+      component.metadata['route'] === route,
   )
 
-  if (matchedApiComponents.length !== 1) {
+  if (method === undefined) {
+    if (routeMatchedApiComponents.length !== 1) {
+      return undefined
+    }
+
+    return routeMatchedApiComponents[0]
+  }
+
+  const exactMethodMatchedApiComponents = routeMatchedApiComponents.filter(
+    (component) => component.metadata['method'] === method,
+  )
+
+  if (exactMethodMatchedApiComponents.length === 1) {
+    return exactMethodMatchedApiComponents[0]
+  }
+
+  if (exactMethodMatchedApiComponents.length > 1) {
     return undefined
   }
 
-  return matchedApiComponents[0]
+  const methodlessApiComponents = routeMatchedApiComponents.filter(
+    (component) => component.metadata['method'] === undefined,
+  )
+
+  if (routeMatchedApiComponents.length !== 1 || methodlessApiComponents.length !== 1) {
+    return undefined
+  }
+
+  return methodlessApiComponents[0]
 }
 
 function parseServiceName(httpCallComponent: EnrichedComponent): string {
@@ -136,7 +159,9 @@ function canUseApiNameFallback(
 ): boolean {
   return (
     matchesOptionalMetadata(route, apiComponent.metadata['route']) &&
-    matchesOptionalMetadata(method, apiComponent.metadata['method'])
+    matchesOptionalMetadata(method, apiComponent.metadata['method']) &&
+    (route === undefined || apiComponent.metadata['route'] !== undefined) &&
+    (method === undefined || apiComponent.metadata['method'] !== undefined)
   )
 }
 
@@ -221,12 +246,8 @@ export function rewriteHttpCallLinks(
     const matchedInternalApis = internalApiComponentsByName.get(serviceName) ?? []
     const matchedInternalApiCount = matchedInternalApis.length
     if (matchedInternalApiCount > 1) {
-      throw new ConnectionDetectionError({
-        file: targetComponent.location.file,
-        line: targetComponent.location.line,
-        typeName: componentIdentity(targetComponent),
-        reason: `Expected metadata.serviceName to match exactly one internal api component name, got ${matchedInternalApiCount} matches for ${JSON.stringify(serviceName)}`,
-      })
+      externalLinks.push(toExternalLink(link, serviceName, route))
+      continue
     }
 
     const [uniqueInternalTarget] = matchedInternalApis

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -62,6 +62,25 @@ function findUniqueApiComponentInDomainMatchingRoute(
   return matchedApiComponents[0]
 }
 
+function findUniqueApiComponentMatchingRoute(
+  components: readonly EnrichedComponent[],
+  route: string | undefined,
+): EnrichedComponent | undefined {
+  if (route === undefined) {
+    return undefined
+  }
+
+  const matchedApiComponents = components.filter(
+    (component) => component.type === 'api' && component.metadata['route'] === route,
+  )
+
+  if (matchedApiComponents.length !== 1) {
+    return undefined
+  }
+
+  return matchedApiComponents[0]
+}
+
 function parseServiceName(httpCallComponent: EnrichedComponent): string {
   const rawServiceName = httpCallComponent.metadata['serviceName']
   if (typeof rawServiceName === 'string' && rawServiceName.trim().length > 0) {
@@ -161,6 +180,16 @@ export function rewriteHttpCallLinks(
       linksToKeep.push({
         ...link,
         target: componentIdentity(uniqueApiTargetInDomain),
+      })
+      continue
+    }
+
+    const uniqueApiTargetByRoute = findUniqueApiComponentMatchingRoute(components, route)
+
+    if (uniqueApiTargetByRoute !== undefined) {
+      linksToKeep.push({
+        ...link,
+        target: componentIdentity(uniqueApiTargetByRoute),
       })
       continue
     }

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/http-call-link-rewrite.ts
@@ -43,6 +43,7 @@ function findUniqueApiComponentInDomainMatchingRoute(
   components: readonly EnrichedComponent[],
   domainName: string,
   route: string | undefined,
+  method: string | undefined,
 ): EnrichedComponent | undefined {
   if (route === undefined) {
     return undefined
@@ -52,7 +53,8 @@ function findUniqueApiComponentInDomainMatchingRoute(
     (component) =>
       component.type === 'api' &&
       component.domain === domainName &&
-      component.metadata['route'] === route,
+      component.metadata['route'] === route &&
+      (method === undefined || component.metadata['method'] === method),
   )
 
   if (matchedApiComponents.length !== 1) {
@@ -76,16 +78,6 @@ function parseServiceName(httpCallComponent: EnrichedComponent): string {
   })
 }
 
-function normalizeServiceNameToDomainName(serviceName: string): string {
-  const lowercaseServiceName = serviceName.trim().toLowerCase()
-  const withoutSuffix = lowercaseServiceName.replaceAll(' service', '').replaceAll(' api', '')
-
-  return withoutSuffix
-    .split(/[^a-z0-9]+/)
-    .filter((part) => part.length > 0)
-    .join('-')
-}
-
 function parseRoute(httpCallComponent: EnrichedComponent): string | undefined {
   const rawRoute = httpCallComponent.metadata['route']
   if (rawRoute === undefined) {
@@ -102,6 +94,76 @@ function parseRoute(httpCallComponent: EnrichedComponent): string | undefined {
     typeName: componentIdentity(httpCallComponent),
     reason: `Expected metadata.route to be a non-empty string when provided, got ${JSON.stringify(rawRoute)}`,
   })
+}
+
+function parseMethod(httpCallComponent: EnrichedComponent): string | undefined {
+  const rawMethod = httpCallComponent.metadata['method']
+  if (rawMethod === undefined) {
+    return undefined
+  }
+
+  if (typeof rawMethod === 'string' && rawMethod.trim().length > 0) {
+    return rawMethod
+  }
+
+  throw new ConnectionDetectionError({
+    file: httpCallComponent.location.file,
+    line: httpCallComponent.location.line,
+    typeName: componentIdentity(httpCallComponent),
+    reason: `Expected metadata.method to be a non-empty string when provided, got ${JSON.stringify(rawMethod)}`,
+  })
+}
+
+function matchesOptionalMetadata(
+  expectedValue: string | undefined,
+  candidateValue: unknown,
+): boolean {
+  if (expectedValue === undefined) {
+    return true
+  }
+
+  if (candidateValue === undefined) {
+    return true
+  }
+
+  return candidateValue === expectedValue
+}
+
+function canUseApiNameFallback(
+  apiComponent: EnrichedComponent,
+  route: string | undefined,
+  method: string | undefined,
+): boolean {
+  return (
+    matchesOptionalMetadata(route, apiComponent.metadata['route']) &&
+    matchesOptionalMetadata(method, apiComponent.metadata['method'])
+  )
+}
+
+function deduplicateExtractedLinks(links: readonly ExtractedLink[]): ExtractedLink[] {
+  const byKey = new Map<string, ExtractedLink>()
+
+  for (const link of links) {
+    const key = JSON.stringify(link)
+    if (!byKey.has(key)) {
+      byKey.set(key, link)
+    }
+  }
+
+  return [...byKey.values()]
+}
+
+function deduplicateExternalLinks(links: readonly ExternalLink[]): ExternalLink[] {
+  const byKey = new Map<string, ExternalLink>()
+
+  for (const link of links) {
+    const key = JSON.stringify(link)
+    if (!byKey.has(key)) {
+      byKey.set(key, link)
+    }
+  }
+
+  return [...byKey.values()]
 }
 
 function toExternalLink(
@@ -139,12 +201,13 @@ export function rewriteHttpCallLinks(
 
     const serviceName = parseServiceName(targetComponent)
     const route = parseRoute(targetComponent)
-    const normalizedDomainName = normalizeServiceNameToDomainName(serviceName)
+    const method = parseMethod(targetComponent)
 
     const uniqueApiTargetInDomain = findUniqueApiComponentInDomainMatchingRoute(
       components,
-      normalizedDomainName,
+      serviceName,
       route,
+      method,
     )
 
     if (uniqueApiTargetInDomain !== undefined) {
@@ -168,7 +231,10 @@ export function rewriteHttpCallLinks(
 
     const [uniqueInternalTarget] = matchedInternalApis
 
-    if (uniqueInternalTarget !== undefined) {
+    if (
+      uniqueInternalTarget !== undefined &&
+      canUseApiNameFallback(uniqueInternalTarget, route, method)
+    ) {
       linksToKeep.push({
         ...link,
         target: componentIdentity(uniqueInternalTarget),
@@ -180,8 +246,8 @@ export function rewriteHttpCallLinks(
   }
 
   return {
-    links: linksToKeep,
-    externalLinks,
+    links: deduplicateExtractedLinks(linksToKeep),
+    externalLinks: deduplicateExternalLinks(externalLinks),
   }
 }
 

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-http-call.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components-http-call.spec.ts
@@ -97,10 +97,76 @@ export class FraudClient {
     expect(result.failures).toStrictEqual([])
   })
 
-  it('extracts method decorator positional arg with fromDecoratorArg', () => {
+  it('extracts route and method decorator positional args with fromDecoratorArg', () => {
     const file = nextFile(
       '/src/orders/http-client.ts',
-      `function HttpCall(_: string) { return () => {} }
+      `function HttpCall(_: string, __: string) { return () => {} }
+export class FraudClient {
+  @HttpCall('/api/check', 'POST')
+  check() {}
+}`,
+    )
+
+    const drafts: DraftComponent[] = [
+      {
+        type: 'httpCall',
+        name: 'check',
+        location: {
+          file,
+          line: 3,
+        },
+        domain: 'orders',
+      },
+    ]
+
+    const module: Module = {
+      ...notUsedModule(),
+      name: 'orders',
+      path: '/src/orders',
+      glob: '**',
+      domainOp: { notUsed: true },
+      eventHandler: { notUsed: true },
+      customTypes: {
+        httpCall: {
+          find: 'methods',
+          where: { nameEndsWith: { suffix: 'check' } },
+          extract: {
+            route: {
+              fromDecoratorArg: {
+                decorator: 'HttpCall',
+                position: 0,
+              },
+            },
+            method: {
+              fromDecoratorArg: {
+                decorator: 'HttpCall',
+                position: 1,
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = enrichComponents(
+      drafts,
+      configWithModules([module]),
+      sharedProject,
+      alwaysMatchGlob(),
+      '/',
+    )
+
+    expect(result.components[0]?.metadata).toStrictEqual({
+      route: '/api/check',
+      method: 'POST',
+    })
+    expect(result.failures).toStrictEqual([])
+  })
+
+  it('records failure when HttpCall method argument is missing', () => {
+    const file = nextFile(
+      '/src/orders/http-client.ts',
+      `function HttpCall(_: string, __?: string) { return () => {} }
 export class FraudClient {
   @HttpCall('/api/check')
   check() {}
@@ -137,6 +203,12 @@ export class FraudClient {
                 position: 0,
               },
             },
+            method: {
+              fromDecoratorArg: {
+                decorator: 'HttpCall',
+                position: 1,
+              },
+            },
           },
         },
       },
@@ -150,8 +222,9 @@ export class FraudClient {
       '/',
     )
 
-    expect(result.components[0]?.metadata).toStrictEqual({ route: '/api/check' })
-    expect(result.failures).toStrictEqual([])
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.field).toBe('method')
+    expect(result.components[0]?._missing).toStrictEqual(['method'])
   })
 
   it('records failure when fromDecoratorArg decorator is missing on method', () => {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.spec.ts
@@ -244,6 +244,36 @@ describe('enrichComponents', () => {
       expect(result.components[0]?._missing).toStrictEqual(['path'])
       expect(result.failures).toHaveLength(1)
     })
+
+    it('does not record failure when api route and method properties are missing', () => {
+      const file = nextFile('/src/orders/order.controller.ts', 'export class OrderController {}')
+      const d = draft('api', 'OrderController', file, 1)
+      const module = moduleWith('api', {
+        find: 'classes',
+        where: { nameEndsWith: { suffix: 'Controller' } },
+        extract: {
+          apiType: { literal: 'REST' },
+          route: {
+            fromProperty: {
+              name: 'route',
+              kind: 'instance',
+            },
+          },
+          method: {
+            fromProperty: {
+              name: 'method',
+              kind: 'instance',
+            },
+          },
+        },
+      })
+
+      const result = enrich([d], [module])
+
+      expect(result.components[0]?.metadata).toStrictEqual({ apiType: 'REST' })
+      expect(result.components[0]?._missing).toBeUndefined()
+      expect(result.failures).toStrictEqual([])
+    })
   })
 
   describe('handles components with no matching module', () => {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.spec.ts
@@ -274,6 +274,22 @@ describe('enrichComponents', () => {
       expect(result.components[0]?._missing).toBeUndefined()
       expect(result.failures).toStrictEqual([])
     })
+
+    it('still records failure when api route extraction uses an invalid rule', () => {
+      const file = nextFile('/src/orders/order.controller.ts', 'export class OrderController {}')
+      const d = draft('api', 'OrderController', file, 1)
+      const module = moduleWith('api', {
+        find: 'classes',
+        where: { nameEndsWith: { suffix: 'Controller' } },
+        extract: { route: { fromMethodSignature: true } },
+      })
+
+      const result = enrich([d], [module])
+
+      expect(result.failures).toHaveLength(1)
+      expect(result.failures[0]?.field).toBe('route')
+      expect(result.components[0]?._missing).toStrictEqual(['route'])
+    })
   })
 
   describe('handles components with no matching module', () => {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
@@ -348,8 +348,18 @@ function componentWithEmptyMetadata(draft: DraftComponent): SingleComponentResul
   }
 }
 
-function shouldIgnoreMissingMetadataField(draft: DraftComponent, fieldName: string): boolean {
-  return draft.type === 'api' && (fieldName === 'route' || fieldName === 'method')
+function shouldIgnoreMissingMetadataField(
+  draft: DraftComponent,
+  fieldName: string,
+  extractionRule: ExtractionRule,
+  errorMessage: string,
+): boolean {
+  return (
+    draft.type === 'api' &&
+    (fieldName === 'route' || fieldName === 'method') &&
+    'fromProperty' in extractionRule &&
+    errorMessage.includes(`Property '${fieldName}' not found on class`)
+  )
 }
 
 function extractMetadataFields(
@@ -369,12 +379,13 @@ function extractMetadataFields(
     try {
       metadata[fieldName] = evaluateRule(extractionRule, draft, project).value
     } catch (error: unknown) {
-      if (shouldIgnoreMissingMetadataField(draft, fieldName)) {
+      /* istanbul ignore next -- @preserve: catch always receives Error instances from ExtractionError */
+      const errorMessage = error instanceof Error ? error.message : String(error)
+
+      if (shouldIgnoreMissingMetadataField(draft, fieldName, extractionRule, errorMessage)) {
         continue
       }
 
-      /* istanbul ignore next -- @preserve: catch always receives Error instances from ExtractionError */
-      const errorMessage = error instanceof Error ? error.message : String(error)
       failures.push({
         component: draft,
         field: fieldName,

--- a/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/value-extraction/enrich-components.ts
@@ -348,6 +348,10 @@ function componentWithEmptyMetadata(draft: DraftComponent): SingleComponentResul
   }
 }
 
+function shouldIgnoreMissingMetadataField(draft: DraftComponent, fieldName: string): boolean {
+  return draft.type === 'api' && (fieldName === 'route' || fieldName === 'method')
+}
+
 function extractMetadataFields(
   extractBlock: Record<string, ExtractionRule>,
   draft: DraftComponent,
@@ -365,6 +369,10 @@ function extractMetadataFields(
     try {
       metadata[fieldName] = evaluateRule(extractionRule, draft, project).value
     } catch (error: unknown) {
+      if (shouldIgnoreMissingMetadataField(draft, fieldName)) {
+        continue
+      }
+
       /* istanbul ignore next -- @preserve: catch always receives Error instances from ExtractionError */
       const errorMessage = error instanceof Error ? error.message : String(error)
       failures.push({


### PR DESCRIPTION
## Summary
- fix cross-module `httpCall` rewriting so internal API targets can be resolved across modules without leaking duplicate external links
- require and extract `httpCall.method`, then use route and method together when matching internal API targets
- add regression coverage for cross-module detection, rewrite safety, and conventions enforcement around `HttpCall`

## Verification
- `pnpm nx test riviere-extract-ts`
- `pnpm nx run-many -t lint --projects=riviere-extract-conventions,riviere-extract-ts`
- `pnpm nx run-many -t build --projects=riviere-extract-conventions,riviere-extract-ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extract HTTP method alongside route for API metadata.
  * ESLint rule now requires a non-empty method argument for HTTP-call decorators.

* **Improvements**
  * Better connection detection: cross-module API resolution, method-aware matching, and deduplication of links.
  * Extraction config and enrichment now handle method metadata and suppress certain benign missing-field errors.

* **Tests**
  * Expanded test coverage for connection detection, HTTP-call rewriting, enrichment, and decorator extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->