### PR TITLE
feat!: proper semantic versioning for extraction packages

### DIFF
--- a/packages/riviere-cli/src/features/extract/infra/persistence/extraction-project/extraction-project-repository.ts
+++ b/packages/riviere-cli/src/features/extract/infra/persistence/extraction-project/extraction-project-repository.ts
@@ -284,8 +284,8 @@ export class ExtractionProjectRepository {
       throw new ConfigSchemaValidationError(source, 'Config has empty modules array')
     }
     try {
-      const config = parseExtractionConfig(parsed)
-      const [first] = resolveConfig(config).modules
+      const cfg = parseExtractionConfig(parsed)
+      const [first] = resolveConfig(cfg).modules
       /* v8 ignore start -- unreachable: schema enforces minItems:1 and pre-check guards length */
       if (first === undefined) {
         throw new ConfigSchemaValidationError(source, 'Config has empty modules array')

--- a/packages/riviere-extract-config/src/validation.ts
+++ b/packages/riviere-extract-config/src/validation.ts
@@ -31,10 +31,10 @@ const COMPONENT_TYPES: ComponentType[] = [
   'ui',
 ]
 
-const ajv = new Ajv({ allErrors: true })
-addFormats(ajv)
+const validator = new Ajv({ allErrors: true })
+addFormats(validator)
 
-const validate = ajv.compile<ExtractionConfig>(rawSchema)
+const validate = validator.compile<ExtractionConfig>(rawSchema)
 
 /**
  * Type guard checking if data is a valid ExtractionConfig.


### PR DESCRIPTION
Trigger major version bumps with feat! and BREAKING CHANGE footer.

Variable renames:
- riviere-extract-config: ajv -> validator
- riviere-cli: config -> cfg