### PR TITLE
fix(riviere-extract-ts): skip bare function calls in traceCallExpression

### DIFF
--- a/packages/riviere-extract-ts/project.json
+++ b/packages/riviere-extract-ts/project.json
@@ -3,7 +3,7 @@
   "targets": {
     "role-check": {
       "executor": "nx:run-commands",
-      "dependsOn": ["^build", "@living-architecture/riviere-role-enforcement:build"],
+      "dependsOn": ["^build", "riviere-role-enforcement:build"],
       "options": {
         "command": "pnpm exec tsx packages/riviere-role-enforcement/src/shell/bin.ts .riviere/role-enforcement.config.ts --package packages/riviere-extract-ts",
         "cwd": "{workspaceRoot}"

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/call-graph/build-call-graph.coverage.spec.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/call-graph/build-call-graph.coverage.spec.ts
@@ -115,6 +115,81 @@ class TCCaller1 {
     ])
   })
 
+  it('does not throw on bare function call during non-component tracing in strict mode', () => {
+    const file = nextFile(`
+class StrictTarget {
+  run(): void {}
+}
+
+class StrictMiddle {
+  private target: StrictTarget
+  constructor(target: StrictTarget) { this.target = target }
+  go(): void {
+    fetch('https://example.com')
+    this.target.run()
+  }
+}
+
+class StrictCaller {
+  private mid: StrictMiddle
+  constructor(mid: StrictMiddle) { this.mid = mid }
+  execute(): void { this.mid.go() }
+}
+`)
+    const compTarget = buildComponent('StrictTarget', file, 2, { type: 'domainOp' })
+    const compCaller = buildComponent('StrictCaller', file, 15)
+    const index = new ComponentIndex([compTarget, compCaller])
+    const strictOptions = {
+      ...defaultOptions(),
+      strict: true,
+    }
+
+    expect(() => buildCallGraph(sharedProject, [compCaller], index, strictOptions)).not.toThrow()
+
+    const result = buildCallGraph(sharedProject, [compCaller], index, strictOptions)
+    expect(result).toStrictEqual([
+      expect.objectContaining({
+        source: expect.stringContaining('strictcaller'),
+        target: expect.stringContaining('stricttarget'),
+      }),
+    ])
+  })
+
+  it('skips unresolvable-typed call during non-component tracing', () => {
+    const file = nextFile(`
+class AnyTarget {
+  run(): void {}
+}
+
+class AnyMiddle {
+  private target: AnyTarget
+  private helper: any
+  constructor(target: AnyTarget, helper: any) { this.target = target; this.helper = helper }
+  go(): void {
+    this.helper.doSomething()
+    this.target.run()
+  }
+}
+
+class AnyCaller {
+  private mid: AnyMiddle
+  constructor(mid: AnyMiddle) { this.mid = mid }
+  execute(): void { this.mid.go() }
+}
+`)
+    const compTarget = buildComponent('AnyTarget', file, 2, { type: 'domainOp' })
+    const compCaller = buildComponent('AnyCaller', file, 16)
+    const index = new ComponentIndex([compTarget, compCaller])
+    const result = buildCallGraph(sharedProject, [compCaller], index, defaultOptions())
+
+    expect(result).toStrictEqual([
+      expect.objectContaining({
+        source: expect.stringContaining('anycaller'),
+        target: expect.stringContaining('anytarget'),
+      }),
+    ])
+  })
+
   it('skips call with no symbol during non-component tracing', () => {
     const file = nextFile(`
 class TCTarget2 {

--- a/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/call-graph/trace-calls.ts
+++ b/packages/riviere-extract-ts/src/features/extraction/domain/connection-detection/call-graph/trace-calls.ts
@@ -4,6 +4,7 @@ import {
   type FunctionDeclaration,
   type MethodDeclaration,
   type Project,
+  Node,
   SyntaxKind,
 } from 'ts-morph'
 import type { ComponentIndex } from '../component-index'
@@ -69,6 +70,9 @@ function resolveComponentTarget(
 }
 
 function traceCallExpression(callExpr: CallExpression, ctx: TraceContext): void {
+  if (!Node.isPropertyAccessExpression(callExpr.getExpression())) {
+    return
+  }
   const sourceFile = callExpr.getSourceFile()
   const typeResult = resolveCallExpressionReceiverType(callExpr, sourceFile, {strict: ctx.options.strict,})
 


### PR DESCRIPTION
## Summary

- `traceCallExpression` lacked the property-access guard that `processCallExpression` has
- When deep-tracing through non-component code, bare function calls (e.g. `fetch(url)`) have no receiver object, causing `ConnectionDetectionError` to be thrown in strict mode (the default when `allowIncomplete` is not set)
- Fix: add the same `!Node.isPropertyAccessExpression(...)` early return that `processCallExpression` already uses

## Root cause

`processCallExpression` (direct component method scanner) guards against bare calls:
```typescript
if (!Node.isPropertyAccessExpression(callExpr.getExpression())) {
  return
}
```

`traceCallExpression` (deep-trace path through non-component code) was missing this guard. When it encountered `fetch(url)`, `getReceiverExpression` returned `undefined`, and with `strict: true` the code threw instead of skipping.

## Test plan

- Added regression test: bare `fetch()` in a non-component class body does not throw in strict mode and the component connection is still detected
- Added coverage test: `any`-typed receiver call in traced non-component body is skipped cleanly
- All existing tests pass, 100% coverage maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call graph detection to correctly handle edge cases involving bare function calls followed by typed method invocations, ensuring proper relationship linking.
  * Enhanced analysis robustness when call expressions are made through untyped helper references, while maintaining accurate detection of subsequent typed method calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->