### PR TITLE
feat(riviere-builder): support upsert merge for canonical components

### DIFF
--- a/packages/riviere-builder/src/features/building/domain/builder-facade.ts
+++ b/packages/riviere-builder/src/features/building/domain/builder-facade.ts
@@ -22,6 +22,7 @@ import type {
   DomainOpInput,
   EventHandlerInput,
   EventInput,
+  UpsertOptions,
   UIInput,
   UseCaseInput,
 } from './construction/construction-types'
@@ -57,6 +58,7 @@ export type {
   NearMatchOptions,
   NearMatchQuery,
   NearMatchResult,
+  UpsertOptions,
   UIInput,
   UseCaseInput,
 }
@@ -129,6 +131,16 @@ export class RiviereBuilder {
     return this.delegate.construction.addUI(input)
   }
 
+  upsertUI(
+    input: UIInput,
+    options?: UpsertOptions,
+  ): {
+    component: UIComponent
+    created: boolean
+  } {
+    return this.delegate.construction.upsertUI(input, options)
+  }
+
   /**
    * Adds an API component to the graph.
    *
@@ -137,6 +149,16 @@ export class RiviereBuilder {
    */
   addApi(input: APIInput): APIComponent {
     return this.delegate.construction.addApi(input)
+  }
+
+  upsertApi(
+    input: APIInput,
+    options?: UpsertOptions,
+  ): {
+    component: APIComponent
+    created: boolean
+  } {
+    return this.delegate.construction.upsertApi(input, options)
   }
 
   /**
@@ -149,6 +171,16 @@ export class RiviereBuilder {
     return this.delegate.construction.addUseCase(input)
   }
 
+  upsertUseCase(
+    input: UseCaseInput,
+    options?: UpsertOptions,
+  ): {
+    component: UseCaseComponent
+    created: boolean
+  } {
+    return this.delegate.construction.upsertUseCase(input, options)
+  }
+
   /**
    * Adds a DomainOp component to the graph.
    *
@@ -157,6 +189,16 @@ export class RiviereBuilder {
    */
   addDomainOp(input: DomainOpInput): DomainOpComponent {
     return this.delegate.construction.addDomainOp(input)
+  }
+
+  upsertDomainOp(
+    input: DomainOpInput,
+    options?: UpsertOptions,
+  ): {
+    component: DomainOpComponent
+    created: boolean
+  } {
+    return this.delegate.construction.upsertDomainOp(input, options)
   }
 
   /**
@@ -169,6 +211,16 @@ export class RiviereBuilder {
     return this.delegate.construction.addEvent(input)
   }
 
+  upsertEvent(
+    input: EventInput,
+    options?: UpsertOptions,
+  ): {
+    component: EventComponent
+    created: boolean
+  } {
+    return this.delegate.construction.upsertEvent(input, options)
+  }
+
   /**
    * Adds an EventHandler component to the graph.
    *
@@ -177,6 +229,16 @@ export class RiviereBuilder {
    */
   addEventHandler(input: EventHandlerInput): EventHandlerComponent {
     return this.delegate.construction.addEventHandler(input)
+  }
+
+  upsertEventHandler(
+    input: EventHandlerInput,
+    options?: UpsertOptions,
+  ): {
+    component: EventHandlerComponent
+    created: boolean
+  } {
+    return this.delegate.construction.upsertEventHandler(input, options)
   }
 
   /**
@@ -196,6 +258,16 @@ export class RiviereBuilder {
    */
   addCustom(input: CustomInput): CustomComponent {
     return this.delegate.construction.addCustom(input)
+  }
+
+  upsertCustom(
+    input: CustomInput,
+    options?: UpsertOptions,
+  ): {
+    component: CustomComponent
+    created: boolean
+  } {
+    return this.delegate.construction.upsertCustom(input, options)
   }
 
   /**

--- a/packages/riviere-builder/src/features/building/domain/builder-upsert-nested.spec.ts
+++ b/packages/riviere-builder/src/features/building/domain/builder-upsert-nested.spec.ts
@@ -1,0 +1,271 @@
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import {
+  RiviereBuilder, type BuilderOptions 
+} from './index'
+
+function createValidOptions(): BuilderOptions {
+  return {
+    sources: [
+      {
+        repository: 'test/repo',
+        commit: 'abc123',
+      },
+    ],
+    domains: {
+      orders: {
+        description: 'Order domain',
+        systemType: 'domain',
+      },
+    },
+  }
+}
+
+function sourceLocation() {
+  return {
+    repository: 'test/repo',
+    filePath: 'src/test.ts',
+  }
+}
+
+describe('RiviereBuilder upsert nested merge behavior', () => {
+  it('recursively merges nested custom metadata objects and arrays', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    builder.defineCustomType({ name: 'Queue' })
+
+    builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: {
+        settings: {
+          limits: { maxRetries: 3 },
+          tags: ['critical'],
+        },
+      },
+    })
+
+    const merged = builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: {
+        settings: {
+          limits: { timeoutMs: 1000 },
+          tags: ['internal', 'critical'],
+        },
+      },
+    })
+
+    expect(merged.component['settings']).toStrictEqual({
+      limits: {
+        maxRetries: 3,
+        timeoutMs: 1000,
+      },
+      tags: ['critical', 'internal'],
+    })
+  })
+
+  it('preserves nested custom metadata scalars with noOverwrite', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    builder.defineCustomType({ name: 'Queue' })
+
+    builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { settings: { limits: { maxRetries: 3 } } },
+    })
+
+    const merged = builder.upsertCustom(
+      {
+        customTypeName: 'Queue',
+        name: 'Outbox Queue',
+        domain: 'orders',
+        module: 'infra',
+        sourceLocation: sourceLocation(),
+        metadata: { settings: { limits: { maxRetries: 10 } } },
+      },
+      { noOverwrite: true },
+    )
+
+    expect(merged.component['settings']).toStrictEqual({ limits: { maxRetries: 3 } })
+  })
+
+  it('treats nested null metadata values as no-op during merge', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    builder.defineCustomType({ name: 'Queue' })
+
+    builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { settings: { limits: { maxRetries: 3 } } },
+    })
+
+    const merged = builder.upsertCustom(
+      JSON.parse(`{
+      "customTypeName": "Queue",
+      "name": "Outbox Queue",
+      "domain": "orders",
+      "module": "infra",
+      "sourceLocation": {
+        "repository": "test/repo",
+        "filePath": "src/test.ts"
+      },
+      "metadata": {
+        "settings": {
+          "limits": {
+            "maxRetries": null,
+            "timeoutMs": 1000
+          }
+        }
+      }
+    }`),
+    )
+
+    expect(merged.component['settings']).toStrictEqual({
+      limits: {
+        maxRetries: 3,
+        timeoutMs: 1000,
+      },
+    })
+  })
+
+  it('handles non-record DomainOp behavior from resumed malformed graph', () => {
+    const malformedGraph: RiviereGraph = JSON.parse(`{
+      "version": "1.0",
+      "metadata": {
+        "sources": [{ "repository": "test/repo", "commit": "abc123" }],
+        "domains": {
+          "orders": {
+            "description": "Order domain",
+            "systemType": "domain"
+          }
+        }
+      },
+      "components": [
+        {
+          "id": "orders:domain:domainop:place-order",
+          "type": "DomainOp",
+          "name": "Place Order",
+          "domain": "orders",
+          "module": "domain",
+          "operationName": "placeOrder",
+          "behavior": ["invalid-shape"],
+          "sourceLocation": {
+            "repository": "test/repo",
+            "filePath": "src/test.ts"
+          }
+        }
+      ],
+      "links": []
+    }`)
+
+    const builder = RiviereBuilder.resume(malformedGraph)
+
+    const merged = builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      behavior: { reads: ['inventory'] },
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(merged.component.behavior).toStrictEqual({ reads: ['inventory'] })
+  })
+
+  it('handles DomainOp behavior records without reads array', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      behavior: { reads: ['inventory'] },
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertDomainOp(
+      JSON.parse(`{
+      "name": "Place Order",
+      "domain": "orders",
+      "module": "domain",
+      "operationName": "placeOrder",
+      "behavior": {
+        "validates": ["payment"],
+        "modifies": ["orders"]
+      },
+      "sourceLocation": {
+        "repository": "test/repo",
+        "filePath": "src/test.ts"
+      }
+    }`),
+    )
+
+    expect(merged.component.behavior).toStrictEqual({
+      reads: ['inventory'],
+      validates: ['payment'],
+      modifies: ['orders'],
+    })
+  })
+
+  it('merges nested object into previously undefined custom metadata field', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    builder.defineCustomType({ name: 'Queue' })
+
+    builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { owner: 'team-a' },
+    })
+
+    const merged = builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { settings: { retries: { max: 3 } } },
+    })
+
+    expect(merged.component['settings']).toStrictEqual({ retries: { max: 3 } })
+  })
+
+  it('replaces primitive custom metadata field with object and merges recursively', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    builder.defineCustomType({ name: 'Queue' })
+
+    builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { settings: 'legacy-settings' },
+    })
+
+    const merged = builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { settings: { retries: { max: 5 } } },
+    })
+
+    expect(merged.component['settings']).toStrictEqual({ retries: { max: 5 } })
+  })
+})

--- a/packages/riviere-builder/src/features/building/domain/builder-upsert-warnings.spec.ts
+++ b/packages/riviere-builder/src/features/building/domain/builder-upsert-warnings.spec.ts
@@ -1,0 +1,209 @@
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import {
+  ComponentTypeMismatchError, RiviereBuilder, type BuilderOptions 
+} from './index'
+
+function createValidOptions(): BuilderOptions {
+  return {
+    sources: [
+      {
+        repository: 'test/repo',
+        commit: 'abc123',
+      },
+    ],
+    domains: {
+      orders: {
+        description: 'Order domain',
+        systemType: 'domain',
+      },
+    },
+  }
+}
+
+function sourceLocation() {
+  return {
+    repository: 'test/repo',
+    filePath: 'src/test.ts',
+  }
+}
+
+describe('RiviereBuilder upsert warnings', () => {
+  it('emits SCALAR_OVERWRITE warning for changed scalar fields only', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertUI({
+      name: 'Checkout Page',
+      domain: 'orders',
+      module: 'checkout',
+      route: '/checkout',
+      description: 'first',
+      sourceLocation: sourceLocation(),
+    })
+
+    builder.upsertUI({
+      name: 'Checkout Page',
+      domain: 'orders',
+      module: 'checkout',
+      route: '/checkout-v2',
+      description: 'second',
+      sourceLocation: sourceLocation(),
+    })
+
+    const overwriteWarnings = builder
+      .warnings()
+      .filter((warning) => warning.code === 'SCALAR_OVERWRITE')
+
+    expect(overwriteWarnings).toHaveLength(2)
+    expect(overwriteWarnings).toContainEqual({
+      code: 'SCALAR_OVERWRITE',
+      message: "Scalar field 'route' on component 'orders:checkout:ui:checkout-page' overwritten",
+      componentId: 'orders:checkout:ui:checkout-page',
+      field: 'route',
+      oldValue: '/checkout',
+      newValue: '/checkout-v2',
+    })
+    expect(overwriteWarnings).toContainEqual({
+      code: 'SCALAR_OVERWRITE',
+      message:
+        "Scalar field 'description' on component 'orders:checkout:ui:checkout-page' overwritten",
+      componentId: 'orders:checkout:ui:checkout-page',
+      field: 'description',
+      oldValue: 'first',
+      newValue: 'second',
+    })
+  })
+
+  it('does not emit SCALAR_OVERWRITE for unchanged value or noOverwrite skip', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertUseCase({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      description: 'same',
+      sourceLocation: sourceLocation(),
+    })
+
+    builder.upsertUseCase({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      description: 'same',
+      sourceLocation: sourceLocation(),
+    })
+
+    builder.upsertUseCase(
+      {
+        name: 'Place Order',
+        domain: 'orders',
+        module: 'checkout',
+        description: 'different',
+        sourceLocation: sourceLocation(),
+      },
+      { noOverwrite: true },
+    )
+
+    expect(
+      builder.warnings().filter((warning) => warning.code === 'SCALAR_OVERWRITE'),
+    ).toHaveLength(0)
+  })
+
+  it('throws ComponentTypeMismatchError when existing component type differs for the same id', () => {
+    const malformedGraph: RiviereGraph = {
+      version: '1.0',
+      metadata: {
+        sources: [
+          {
+            repository: 'test/repo',
+            commit: 'abc123',
+          },
+        ],
+        domains: {
+          orders: {
+            description: 'Order domain',
+            systemType: 'domain',
+          },
+        },
+      },
+      components: [
+        {
+          id: 'orders:checkout:ui:checkout-page',
+          type: 'API',
+          name: 'Checkout Page',
+          domain: 'orders',
+          module: 'checkout',
+          apiType: 'REST',
+          sourceLocation: sourceLocation(),
+        },
+      ],
+      links: [],
+    }
+
+    const builder = RiviereBuilder.resume(malformedGraph)
+
+    expect(() =>
+      builder.upsertUI({
+        name: 'Checkout Page',
+        domain: 'orders',
+        module: 'checkout',
+        route: '/checkout',
+        sourceLocation: sourceLocation(),
+      }),
+    ).toThrow(ComponentTypeMismatchError)
+
+    expect(() =>
+      builder.upsertUI({
+        name: 'Checkout Page',
+        domain: 'orders',
+        module: 'checkout',
+        route: '/checkout',
+        sourceLocation: sourceLocation(),
+      }),
+    ).toThrow(
+      "Component 'orders:checkout:ui:checkout-page' already exists as type 'API'; cannot upsert as 'UI'",
+    )
+  })
+
+  it('throws ComponentTypeMismatchError with unknown existing type for malformed resumed graph', () => {
+    const malformedGraph = JSON.parse(`{
+      "version": "1.0",
+      "metadata": {
+        "sources": [{ "repository": "test/repo", "commit": "abc123" }],
+        "domains": {
+          "orders": {
+            "description": "Order domain",
+            "systemType": "domain"
+          }
+        }
+      },
+      "components": [
+        {
+          "id": "orders:checkout:ui:checkout-page",
+          "name": "Checkout Page",
+          "domain": "orders",
+          "module": "checkout",
+          "route": "/checkout",
+          "sourceLocation": {
+            "repository": "test/repo",
+            "filePath": "src/test.ts"
+          }
+        }
+      ],
+      "links": []
+    }`)
+
+    const builder = RiviereBuilder.resume(malformedGraph)
+
+    expect(() =>
+      builder.upsertUI({
+        name: 'Checkout Page',
+        domain: 'orders',
+        module: 'checkout',
+        route: '/checkout-v2',
+        sourceLocation: sourceLocation(),
+      }),
+    ).toThrow(
+      "Component 'orders:checkout:ui:checkout-page' already exists as type 'unknown'; cannot upsert as 'UI'",
+    )
+  })
+})

--- a/packages/riviere-builder/src/features/building/domain/builder-upsert.spec.ts
+++ b/packages/riviere-builder/src/features/building/domain/builder-upsert.spec.ts
@@ -1,0 +1,412 @@
+import {
+  RiviereBuilder, type BuilderOptions 
+} from './index'
+
+function createValidOptions(): BuilderOptions {
+  return {
+    sources: [
+      {
+        repository: 'test/repo',
+        commit: 'abc123',
+      },
+    ],
+    domains: {
+      orders: {
+        description: 'Order domain',
+        systemType: 'domain',
+      },
+    },
+  }
+}
+
+function sourceLocation() {
+  return {
+    repository: 'test/repo',
+    filePath: 'src/test.ts',
+  }
+}
+
+describe('RiviereBuilder upsert', () => {
+  it('upsertUI creates then merges and returns created flag', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    const created = builder.upsertUI({
+      name: 'Checkout Page',
+      domain: 'orders',
+      module: 'checkout',
+      route: '/checkout',
+      description: 'first',
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertUI({
+      name: 'Checkout Page',
+      domain: 'orders',
+      module: 'checkout',
+      route: '/checkout-v2',
+      description: 'second',
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(created.created).toBe(true)
+    expect(merged.created).toBe(false)
+    expect(merged.component.route).toBe('/checkout-v2')
+    expect(merged.component.description).toBe('second')
+  })
+
+  it('upsertApi creates then merges and returns created flag', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    const created = builder.upsertApi({
+      name: 'Create Order',
+      domain: 'orders',
+      module: 'api',
+      apiType: 'REST',
+      path: '/orders',
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertApi({
+      name: 'Create Order',
+      domain: 'orders',
+      module: 'api',
+      apiType: 'REST',
+      path: '/v2/orders',
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(created.created).toBe(true)
+    expect(merged.created).toBe(false)
+    expect(merged.component.path).toBe('/v2/orders')
+  })
+
+  it('upsertUseCase creates then merges and returns created flag', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    const created = builder.upsertUseCase({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertUseCase({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'checkout',
+      description: 'new description',
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(created.created).toBe(true)
+    expect(merged.created).toBe(false)
+    expect(merged.component.description).toBe('new description')
+  })
+
+  it('upsertDomainOp creates then merges and returns created flag', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    const created = builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrderV2',
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(created.created).toBe(true)
+    expect(merged.created).toBe(false)
+    expect(merged.component.operationName).toBe('placeOrderV2')
+  })
+
+  it('upsertEvent creates then merges and returns created flag', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    const created = builder.upsertEvent({
+      name: 'Order Created',
+      domain: 'orders',
+      module: 'events',
+      eventName: 'OrderCreated',
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertEvent({
+      name: 'Order Created',
+      domain: 'orders',
+      module: 'events',
+      eventName: 'OrderCreatedV2',
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(created.created).toBe(true)
+    expect(merged.created).toBe(false)
+    expect(merged.component.eventName).toBe('OrderCreatedV2')
+  })
+
+  it('upsertEventHandler unions subscribed events', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertEventHandler({
+      name: 'Notify',
+      domain: 'orders',
+      module: 'handlers',
+      subscribedEvents: ['OrderCreated'],
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertEventHandler({
+      name: 'Notify',
+      domain: 'orders',
+      module: 'handlers',
+      subscribedEvents: ['OrderCancelled', 'OrderCreated'],
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(merged.created).toBe(false)
+    expect(merged.component.subscribedEvents).toStrictEqual(['OrderCreated', 'OrderCancelled'])
+  })
+
+  it('upsertCustom creates then merges and returns created flag', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+    builder.defineCustomType({ name: 'Queue' })
+
+    const created = builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { partition: 2 },
+    })
+
+    const merged = builder.upsertCustom({
+      customTypeName: 'Queue',
+      name: 'Outbox Queue',
+      domain: 'orders',
+      module: 'infra',
+      sourceLocation: sourceLocation(),
+      metadata: { partition: 3 },
+    })
+
+    expect(created.created).toBe(true)
+    expect(merged.created).toBe(false)
+    expect(merged.component['partition']).toBe(3)
+  })
+
+  it('upsertDomainOp unions arrays and mergeBehavior arrays', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      stateChanges: [
+        {
+          from: 'draft',
+          to: 'placed',
+        },
+      ],
+      businessRules: ['must have items'],
+      behavior: {
+        reads: ['inventory'],
+        emits: ['OrderCreated'],
+      },
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      stateChanges: [
+        {
+          from: 'placed',
+          to: 'confirmed',
+        },
+        {
+          from: 'draft',
+          to: 'placed',
+        },
+      ],
+      businessRules: ['must have items', 'must be paid'],
+      behavior: {
+        reads: ['inventory', 'customer-profile'],
+        validates: ['payment'],
+        modifies: ['orders'],
+      },
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(merged.component.stateChanges).toStrictEqual([
+      {
+        from: 'draft',
+        to: 'placed',
+      },
+      {
+        from: 'placed',
+        to: 'confirmed',
+      },
+    ])
+    expect(merged.component.businessRules).toStrictEqual(['must have items', 'must be paid'])
+    expect(merged.component.behavior).toStrictEqual({
+      reads: ['inventory', 'customer-profile'],
+      emits: ['OrderCreated'],
+      validates: ['payment'],
+      modifies: ['orders'],
+    })
+  })
+
+  it('treats empty incoming arrays as no-op', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertEventHandler({
+      name: 'Notify',
+      domain: 'orders',
+      module: 'handlers',
+      subscribedEvents: ['OrderCreated'],
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertEventHandler({
+      name: 'Notify',
+      domain: 'orders',
+      module: 'handlers',
+      subscribedEvents: [],
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(merged.component.subscribedEvents).toStrictEqual(['OrderCreated'])
+  })
+
+  it('does not overwrite with undefined or null values', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertUI({
+      name: 'Checkout Page',
+      domain: 'orders',
+      module: 'checkout',
+      route: '/checkout',
+      description: 'first',
+      sourceLocation: sourceLocation(),
+    })
+
+    const incomingWithUndefinedDescription = {
+      name: 'Checkout Page',
+      domain: 'orders',
+      module: 'checkout',
+      route: '/checkout',
+      sourceLocation: sourceLocation(),
+    }
+
+    Reflect.set(incomingWithUndefinedDescription, 'description', undefined)
+
+    const merged = builder.upsertUI(incomingWithUndefinedDescription)
+
+    const mergedNull = builder.upsertUI(
+      JSON.parse(`{
+      "name": "Checkout Page",
+      "domain": "orders",
+      "module": "checkout",
+      "route": "/checkout",
+      "description": null,
+      "sourceLocation": {
+        "repository": "test/repo",
+        "filePath": "src/test.ts"
+      }
+    }`),
+    )
+
+    expect(merged.component.description).toBe('first')
+    expect(mergedNull.component.description).toBe('first')
+  })
+
+  it('supports noOverwrite for scalars while still unioning arrays', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      description: 'deterministic value',
+      businessRules: ['must have items'],
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertDomainOp(
+      {
+        name: 'Place Order',
+        domain: 'orders',
+        module: 'domain',
+        operationName: 'ai-suggested-name',
+        description: 'ai value',
+        businessRules: ['must be paid'],
+        sourceLocation: sourceLocation(),
+      },
+      { noOverwrite: true },
+    )
+
+    expect(merged.component.description).toBe('deterministic value')
+    expect(merged.component.operationName).toBe('placeOrder')
+    expect(merged.component.businessRules).toStrictEqual(['must have items', 'must be paid'])
+  })
+
+  it('fills missing scalar values with noOverwrite', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertApi({
+      name: 'Create Order',
+      domain: 'orders',
+      module: 'api',
+      apiType: 'REST',
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertApi(
+      {
+        name: 'Create Order',
+        domain: 'orders',
+        module: 'api',
+        apiType: 'REST',
+        path: '/orders',
+        sourceLocation: sourceLocation(),
+      },
+      { noOverwrite: true },
+    )
+
+    expect(merged.component.path).toBe('/orders')
+  })
+
+  it('fills missing array values during merge', () => {
+    const builder = RiviereBuilder.new(createValidOptions())
+
+    builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      sourceLocation: sourceLocation(),
+    })
+
+    const merged = builder.upsertDomainOp({
+      name: 'Place Order',
+      domain: 'orders',
+      module: 'domain',
+      operationName: 'placeOrder',
+      businessRules: ['must have items'],
+      sourceLocation: sourceLocation(),
+    })
+
+    expect(merged.component.businessRules).toStrictEqual(['must have items'])
+  })
+})

--- a/packages/riviere-builder/src/features/building/domain/builder.spec.ts
+++ b/packages/riviere-builder/src/features/building/domain/builder.spec.ts
@@ -136,6 +136,28 @@ describe('RiviereBuilder', () => {
 
       expect(parseGraph(builder).metadata.sources).toContainEqual({ repository: 'no-commit-repo' })
     })
+
+    it('is idempotent when adding an identical source', () => {
+      const builder = RiviereBuilder.new(createValidOptions())
+
+      builder.addSource({
+        repository: 'my-org/my-repo',
+        commit: 'abc123',
+      })
+
+      expect(parseGraph(builder).metadata.sources).toHaveLength(1)
+    })
+
+    it('throws when same repository has different source metadata', () => {
+      const builder = RiviereBuilder.new(createValidOptions())
+
+      expect(() =>
+        builder.addSource({
+          repository: 'my-org/my-repo',
+          commit: 'different-sha',
+        }),
+      ).toThrow("Source 'my-org/my-repo' already exists with different values")
+    })
   })
 
   describe('addDomain', () => {
@@ -154,7 +176,22 @@ describe('RiviereBuilder', () => {
       })
     })
 
-    it('throws when domain name already exists', () => {
+    it('is idempotent when domain name already exists with identical metadata', () => {
+      const builder = RiviereBuilder.new(createValidOptions())
+
+      builder.addDomain({
+        name: 'orders',
+        description: 'Order management',
+        systemType: 'domain',
+      })
+
+      expect(parseGraph(builder).metadata.domains['orders']).toStrictEqual({
+        description: 'Order management',
+        systemType: 'domain',
+      })
+    })
+
+    it('throws when domain name already exists with different metadata', () => {
       const builder = RiviereBuilder.new(createValidOptions())
 
       expect(() =>

--- a/packages/riviere-builder/src/features/building/domain/construction/construction-errors.ts
+++ b/packages/riviere-builder/src/features/building/domain/construction/construction-errors.ts
@@ -10,6 +10,17 @@ export class DuplicateDomainError extends Error {
 }
 
 /** @riviere-role domain-error */
+export class SourceConflictError extends Error {
+  readonly repository: string
+
+  constructor(repository: string) {
+    super(`Source '${repository}' already exists with different values`)
+    this.name = 'SourceConflictError'
+    this.repository = repository
+  }
+}
+
+/** @riviere-role domain-error */
 export class DomainNotFoundError extends Error {
   readonly domainName: string
 
@@ -45,6 +56,23 @@ export class DuplicateComponentError extends Error {
     super(`Component with ID '${componentId}' already exists`)
     this.name = 'DuplicateComponentError'
     this.componentId = componentId
+  }
+}
+
+/** @riviere-role domain-error */
+export class ComponentTypeMismatchError extends Error {
+  readonly componentId: string
+  readonly existingType: string
+  readonly incomingType: string
+
+  constructor(componentId: string, existingType: string, incomingType: string) {
+    super(
+      `Component '${componentId}' already exists as type '${existingType}'; cannot upsert as '${incomingType}'`,
+    )
+    this.name = 'ComponentTypeMismatchError'
+    this.componentId = componentId
+    this.existingType = existingType
+    this.incomingType = incomingType
   }
 }
 

--- a/packages/riviere-builder/src/features/building/domain/construction/construction-types.ts
+++ b/packages/riviere-builder/src/features/building/domain/construction/construction-types.ts
@@ -27,6 +27,9 @@ export interface DomainInput {
 }
 
 /** @riviere-role value-object */
+export interface UpsertOptions {noOverwrite?: boolean}
+
+/** @riviere-role value-object */
 export interface UIInput {
   name: string
   domain: string

--- a/packages/riviere-builder/src/features/building/domain/construction/errors.spec.ts
+++ b/packages/riviere-builder/src/features/building/domain/construction/errors.spec.ts
@@ -7,6 +7,8 @@ import {
   DomainNotFoundError,
   DuplicateComponentError,
   DuplicateDomainError,
+  SourceConflictError,
+  ComponentTypeMismatchError,
   CustomTypeAlreadyDefinedError,
   MissingRequiredPropertiesError,
   InvalidGraphError,
@@ -24,6 +26,16 @@ describe('errors', () => {
       expect(error.message).toBe("Domain 'orders' already exists")
       expect(error.domainName).toBe('orders')
       expect(error.name).toBe('DuplicateDomainError')
+    })
+  })
+
+  describe('SourceConflictError', () => {
+    it('includes repository in message', () => {
+      const error = new SourceConflictError('test/repo')
+
+      expect(error.message).toBe("Source 'test/repo' already exists with different values")
+      expect(error.repository).toBe('test/repo')
+      expect(error.name).toBe('SourceConflictError')
     })
   })
 
@@ -65,6 +77,19 @@ describe('errors', () => {
       )
       expect(error.componentId).toBe('orders:checkout:api:create-order')
       expect(error.name).toBe('DuplicateComponentError')
+    })
+  })
+
+  describe('ComponentTypeMismatchError', () => {
+    it('includes component identity and types in message', () => {
+      const error = new ComponentTypeMismatchError('orders:checkout:ui:checkout-page', 'UI', 'API')
+
+      expect(error.message).toBe(
+        "Component 'orders:checkout:ui:checkout-page' already exists as type 'UI'; cannot upsert as 'API'",
+      )
+      expect(error.componentId).toBe('orders:checkout:ui:checkout-page')
+      expect(error.existingType).toBe('UI')
+      expect(error.incomingType).toBe('API')
     })
   })
 

--- a/packages/riviere-builder/src/features/building/domain/construction/graph-construction.ts
+++ b/packages/riviere-builder/src/features/building/domain/construction/graph-construction.ts
@@ -18,13 +18,16 @@ import type {
   DomainOpInput,
   EventHandlerInput,
   EventInput,
+  UpsertOptions,
   UIInput,
   UseCaseInput,
 } from './construction-types'
 import {
+  ComponentTypeMismatchError,
   CustomTypeAlreadyDefinedError,
   DuplicateComponentError,
   DuplicateDomainError,
+  SourceConflictError,
 } from './construction-errors'
 import {
   generateComponentId,
@@ -32,21 +35,41 @@ import {
   validateDomainExists,
   validateRequiredProperties,
 } from './builder-internals'
+import { mergeComponentForUpsert } from '../enrichment/upsert-merge'
+import type { BuilderWarning } from '../inspection/inspection-types'
 
 /** @riviere-role domain-service */
 export class GraphConstruction {
   private readonly graph: BuilderGraph
+  private readonly operationWarnings: BuilderWarning[]
 
-  constructor(graph: BuilderGraph) {
+  constructor(graph: BuilderGraph, operationWarnings: BuilderWarning[]) {
     this.graph = graph
+    this.operationWarnings = operationWarnings
   }
 
   addSource(source: SourceInfo): void {
+    const existing = this.graph.metadata.sources.find(
+      (item) => item.repository === source.repository,
+    )
+    if (existing) {
+      if (areSourcesEqual(existing, source)) {
+        return
+      }
+
+      throw new SourceConflictError(source.repository)
+    }
+
     this.graph.metadata.sources.push(source)
   }
 
   addDomain(input: DomainInput): void {
-    if (this.graph.metadata.domains[input.name]) {
+    const existing = this.graph.metadata.domains[input.name]
+    if (existing) {
+      if (existing.description === input.description && existing.systemType === input.systemType) {
+        return
+      }
+
       throw new DuplicateDomainError(input.name)
     }
 
@@ -57,113 +80,87 @@ export class GraphConstruction {
   }
 
   addUI(input: UIInput): UIComponent {
-    validateDomainExists(this.graph.metadata.domains, input.domain)
-    const id = generateComponentId(input.domain, input.module, 'ui', input.name)
+    return this.registerComponent(this.buildUIComponent(input))
+  }
 
-    const component: UIComponent = {
-      id,
-      type: 'UI',
-      name: input.name,
-      domain: input.domain,
-      module: input.module,
-      route: input.route,
-      sourceLocation: input.sourceLocation,
-      ...(input.description !== undefined && { description: input.description }),
-    }
-    return this.registerComponent(component)
+  upsertUI(
+    input: UIInput,
+    options?: UpsertOptions,
+  ): {
+    component: UIComponent
+    created: boolean
+  } {
+    return this.upsertTypedComponent(this.buildUIComponent(input), options)
   }
 
   addApi(input: APIInput): APIComponent {
-    validateDomainExists(this.graph.metadata.domains, input.domain)
-    const id = generateComponentId(input.domain, input.module, 'api', input.name)
+    return this.registerComponent(this.buildAPIComponent(input))
+  }
 
-    const component: APIComponent = {
-      id,
-      type: 'API',
-      name: input.name,
-      domain: input.domain,
-      module: input.module,
-      apiType: input.apiType,
-      sourceLocation: input.sourceLocation,
-      ...(input.httpMethod !== undefined && { httpMethod: input.httpMethod }),
-      ...(input.path !== undefined && { path: input.path }),
-      ...(input.operationName !== undefined && { operationName: input.operationName }),
-      ...(input.description !== undefined && { description: input.description }),
-    }
-    return this.registerComponent(component)
+  upsertApi(
+    input: APIInput,
+    options?: UpsertOptions,
+  ): {
+    component: APIComponent
+    created: boolean
+  } {
+    return this.upsertTypedComponent(this.buildAPIComponent(input), options)
   }
 
   addUseCase(input: UseCaseInput): UseCaseComponent {
-    validateDomainExists(this.graph.metadata.domains, input.domain)
-    const id = generateComponentId(input.domain, input.module, 'usecase', input.name)
+    return this.registerComponent(this.buildUseCaseComponent(input))
+  }
 
-    const component: UseCaseComponent = {
-      id,
-      type: 'UseCase',
-      name: input.name,
-      domain: input.domain,
-      module: input.module,
-      sourceLocation: input.sourceLocation,
-      ...(input.description !== undefined && { description: input.description }),
-    }
-    return this.registerComponent(component)
+  upsertUseCase(
+    input: UseCaseInput,
+    options?: UpsertOptions,
+  ): {
+    component: UseCaseComponent
+    created: boolean
+  } {
+    return this.upsertTypedComponent(this.buildUseCaseComponent(input), options)
   }
 
   addDomainOp(input: DomainOpInput): DomainOpComponent {
-    validateDomainExists(this.graph.metadata.domains, input.domain)
-    const id = generateComponentId(input.domain, input.module, 'domainop', input.name)
+    return this.registerComponent(this.buildDomainOpComponent(input))
+  }
 
-    const component: DomainOpComponent = {
-      id,
-      type: 'DomainOp',
-      name: input.name,
-      domain: input.domain,
-      module: input.module,
-      operationName: input.operationName,
-      sourceLocation: input.sourceLocation,
-      ...(input.entity !== undefined && { entity: input.entity }),
-      ...(input.signature !== undefined && { signature: input.signature }),
-      ...(input.behavior !== undefined && { behavior: input.behavior }),
-      ...(input.stateChanges !== undefined && { stateChanges: input.stateChanges }),
-      ...(input.businessRules !== undefined && { businessRules: input.businessRules }),
-      ...(input.description !== undefined && { description: input.description }),
-    }
-    return this.registerComponent(component)
+  upsertDomainOp(
+    input: DomainOpInput,
+    options?: UpsertOptions,
+  ): {
+    component: DomainOpComponent
+    created: boolean
+  } {
+    return this.upsertTypedComponent(this.buildDomainOpComponent(input), options)
   }
 
   addEvent(input: EventInput): EventComponent {
-    validateDomainExists(this.graph.metadata.domains, input.domain)
-    const id = generateComponentId(input.domain, input.module, 'event', input.name)
+    return this.registerComponent(this.buildEventComponent(input))
+  }
 
-    const component: EventComponent = {
-      id,
-      type: 'Event',
-      name: input.name,
-      domain: input.domain,
-      module: input.module,
-      eventName: input.eventName,
-      sourceLocation: input.sourceLocation,
-      ...(input.eventSchema !== undefined && { eventSchema: input.eventSchema }),
-      ...(input.description !== undefined && { description: input.description }),
-    }
-    return this.registerComponent(component)
+  upsertEvent(
+    input: EventInput,
+    options?: UpsertOptions,
+  ): {
+    component: EventComponent
+    created: boolean
+  } {
+    return this.upsertTypedComponent(this.buildEventComponent(input), options)
   }
 
   addEventHandler(input: EventHandlerInput): EventHandlerComponent {
-    validateDomainExists(this.graph.metadata.domains, input.domain)
-    const id = generateComponentId(input.domain, input.module, 'eventhandler', input.name)
+    return this.registerComponent(this.buildEventHandlerComponent(input))
+  }
 
-    const component: EventHandlerComponent = {
-      id,
-      type: 'EventHandler',
-      name: input.name,
-      domain: input.domain,
-      module: input.module,
-      subscribedEvents: input.subscribedEvents,
-      sourceLocation: input.sourceLocation,
-      ...(input.description !== undefined && { description: input.description }),
-    }
-    return this.registerComponent(component)
+  upsertEventHandler(
+    input: EventHandlerInput,
+    options?: UpsertOptions,
+  ): {
+    component: EventHandlerComponent
+    created: boolean
+  } {
+    return this.upsertTypedComponent(this.buildEventHandlerComponent(input), options)
   }
 
   defineCustomType(input: CustomTypeInput): void {
@@ -181,6 +178,124 @@ export class GraphConstruction {
   }
 
   addCustom(input: CustomInput): CustomComponent {
+    return this.registerComponent(this.buildCustomComponent(input))
+  }
+
+  upsertCustom(
+    input: CustomInput,
+    options?: UpsertOptions,
+  ): {
+    component: CustomComponent
+    created: boolean
+  } {
+    return this.upsertTypedComponent(this.buildCustomComponent(input), options)
+  }
+
+  private buildUIComponent(input: UIInput): UIComponent {
+    validateDomainExists(this.graph.metadata.domains, input.domain)
+    const id = generateComponentId(input.domain, input.module, 'ui', input.name)
+
+    return {
+      id,
+      type: 'UI',
+      name: input.name,
+      domain: input.domain,
+      module: input.module,
+      route: input.route,
+      sourceLocation: input.sourceLocation,
+      ...(input.description !== undefined && { description: input.description }),
+    }
+  }
+
+  private buildAPIComponent(input: APIInput): APIComponent {
+    validateDomainExists(this.graph.metadata.domains, input.domain)
+    const id = generateComponentId(input.domain, input.module, 'api', input.name)
+
+    return {
+      id,
+      type: 'API',
+      name: input.name,
+      domain: input.domain,
+      module: input.module,
+      apiType: input.apiType,
+      sourceLocation: input.sourceLocation,
+      ...(input.httpMethod !== undefined && { httpMethod: input.httpMethod }),
+      ...(input.path !== undefined && { path: input.path }),
+      ...(input.operationName !== undefined && { operationName: input.operationName }),
+      ...(input.description !== undefined && { description: input.description }),
+    }
+  }
+
+  private buildUseCaseComponent(input: UseCaseInput): UseCaseComponent {
+    validateDomainExists(this.graph.metadata.domains, input.domain)
+    const id = generateComponentId(input.domain, input.module, 'usecase', input.name)
+
+    return {
+      id,
+      type: 'UseCase',
+      name: input.name,
+      domain: input.domain,
+      module: input.module,
+      sourceLocation: input.sourceLocation,
+      ...(input.description !== undefined && { description: input.description }),
+    }
+  }
+
+  private buildDomainOpComponent(input: DomainOpInput): DomainOpComponent {
+    validateDomainExists(this.graph.metadata.domains, input.domain)
+    const id = generateComponentId(input.domain, input.module, 'domainop', input.name)
+
+    return {
+      id,
+      type: 'DomainOp',
+      name: input.name,
+      domain: input.domain,
+      module: input.module,
+      operationName: input.operationName,
+      sourceLocation: input.sourceLocation,
+      ...(input.entity !== undefined && { entity: input.entity }),
+      ...(input.signature !== undefined && { signature: input.signature }),
+      ...(input.behavior !== undefined && { behavior: input.behavior }),
+      ...(input.stateChanges !== undefined && { stateChanges: input.stateChanges }),
+      ...(input.businessRules !== undefined && { businessRules: input.businessRules }),
+      ...(input.description !== undefined && { description: input.description }),
+    }
+  }
+
+  private buildEventComponent(input: EventInput): EventComponent {
+    validateDomainExists(this.graph.metadata.domains, input.domain)
+    const id = generateComponentId(input.domain, input.module, 'event', input.name)
+
+    return {
+      id,
+      type: 'Event',
+      name: input.name,
+      domain: input.domain,
+      module: input.module,
+      eventName: input.eventName,
+      sourceLocation: input.sourceLocation,
+      ...(input.eventSchema !== undefined && { eventSchema: input.eventSchema }),
+      ...(input.description !== undefined && { description: input.description }),
+    }
+  }
+
+  private buildEventHandlerComponent(input: EventHandlerInput): EventHandlerComponent {
+    validateDomainExists(this.graph.metadata.domains, input.domain)
+    const id = generateComponentId(input.domain, input.module, 'eventhandler', input.name)
+
+    return {
+      id,
+      type: 'EventHandler',
+      name: input.name,
+      domain: input.domain,
+      module: input.module,
+      subscribedEvents: input.subscribedEvents,
+      sourceLocation: input.sourceLocation,
+      ...(input.description !== undefined && { description: input.description }),
+    }
+  }
+
+  private buildCustomComponent(input: CustomInput): CustomComponent {
     validateDomainExists(this.graph.metadata.domains, input.domain)
     validateCustomType(this.graph.metadata.customTypes, input.customTypeName)
     validateRequiredProperties(
@@ -201,7 +316,8 @@ export class GraphConstruction {
       ...(input.description !== undefined && { description: input.description }),
       ...input.metadata,
     }
-    return this.registerComponent(component)
+
+    return component
   }
 
   private registerComponent<T extends Component>(component: T): T {
@@ -211,4 +327,53 @@ export class GraphConstruction {
     this.graph.components.push(component)
     return component
   }
+
+  private upsertTypedComponent<T extends Component>(
+    incoming: T,
+    options?: UpsertOptions,
+  ): {
+    component: T
+    created: boolean
+  } {
+    const existingIndex = this.graph.components.findIndex(
+      (component) => component.id === incoming.id,
+    )
+    if (existingIndex === -1) {
+      this.graph.components.push(incoming)
+      return {
+        component: incoming,
+        created: true,
+      }
+    }
+
+    const existing = this.graph.components[existingIndex]
+
+    if (!isSameTypeComponent(existing, incoming)) {
+      throw new ComponentTypeMismatchError(incoming.id, existing?.type ?? 'unknown', incoming.type)
+    }
+
+    const merged = mergeComponentForUpsert(existing, incoming, options, this.operationWarnings)
+
+    this.graph.components[existingIndex] = merged
+
+    return {
+      component: merged,
+      created: false,
+    }
+  }
+}
+
+function areSourcesEqual(existing: SourceInfo, incoming: SourceInfo): boolean {
+  return (
+    existing.repository === incoming.repository &&
+    existing.commit === incoming.commit &&
+    existing.extractedAt === incoming.extractedAt
+  )
+}
+
+function isSameTypeComponent<T extends Component>(
+  existing: Component | undefined,
+  incoming: T,
+): existing is T {
+  return existing?.type === incoming.type
 }

--- a/packages/riviere-builder/src/features/building/domain/enrichment/upsert-merge.ts
+++ b/packages/riviere-builder/src/features/building/domain/enrichment/upsert-merge.ts
@@ -1,0 +1,331 @@
+import type {
+  Component,
+  CustomComponent,
+  OperationBehavior,
+} from '@living-architecture/riviere-schema'
+import type { UpsertOptions } from '../construction/construction-types'
+import type { BuilderWarning } from '../inspection/inspection-types'
+import { mergeBehavior } from './merge-behavior'
+
+type Primitive = string | number | boolean
+
+const IDENTITY_FIELDS = new Set(['id', 'type', 'name', 'domain', 'module'])
+const CUSTOM_BASE_FIELDS = new Set([
+  'id',
+  'type',
+  'customTypeName',
+  'name',
+  'domain',
+  'module',
+  'description',
+  'sourceLocation',
+])
+
+/** @riviere-role domain-service */
+export function mergeComponentForUpsert<T extends Component>(
+  existing: T,
+  incoming: T,
+  options: UpsertOptions | undefined,
+  warnings: BuilderWarning[],
+): T {
+  const merged: T = { ...existing }
+
+  for (const [field, incomingValue] of Object.entries(incoming)) {
+    if (shouldSkipTopLevelField(field, incomingValue)) {
+      continue
+    }
+
+    mergeTopLevelField(merged, existing.id, field, incomingValue, options, warnings)
+  }
+
+  if (isCustomComponent(existing) && isCustomComponent(incoming)) {
+    const mergedMetadata = mergeCustomMetadata(existing, incoming, options, warnings)
+    for (const [key, value] of Object.entries(mergedMetadata)) {
+      setField(merged, key, value)
+    }
+  }
+
+  return merged
+}
+
+function mergeTopLevelField(
+  target: object,
+  componentId: string,
+  field: string,
+  incomingValue: unknown,
+  options: UpsertOptions | undefined,
+  warnings: BuilderWarning[],
+): void {
+  if (Array.isArray(incomingValue)) {
+    mergeArrayField(target, field, incomingValue)
+    return
+  }
+
+  if (field === 'behavior' && isRecord(incomingValue)) {
+    mergeBehaviorField(target, incomingValue)
+    return
+  }
+
+  if (isRecord(incomingValue) && shouldRecursivelyMergeTopLevelObject(field)) {
+    const existingValue = getField(target, field)
+    const existingRecord = isRecord(existingValue) ? existingValue : undefined
+    setField(
+      target,
+      field,
+      mergeNestedObject(existingRecord, incomingValue, options, warnings, componentId, field),
+    )
+    return
+  }
+
+  mergeScalarLikeField(target, field, incomingValue, options, warnings, componentId)
+}
+
+function mergeCustomMetadata(
+  existing: CustomComponent,
+  incoming: CustomComponent,
+  options: UpsertOptions | undefined,
+  warnings: BuilderWarning[],
+): Record<string, unknown> {
+  const existingMetadata = extractCustomMetadata(existing)
+  const incomingMetadata = extractCustomMetadata(incoming)
+
+  return mergeNestedObject(
+    existingMetadata,
+    incomingMetadata,
+    options,
+    warnings,
+    existing.id,
+    'metadata',
+  )
+}
+
+function extractCustomMetadata(component: CustomComponent): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(component)) {
+    if (CUSTOM_BASE_FIELDS.has(key)) {
+      continue
+    }
+
+    metadata[key] = value
+  }
+
+  return metadata
+}
+
+function shouldSkipTopLevelField(field: string, value: unknown): boolean {
+  return IDENTITY_FIELDS.has(field) || !isDefined(value)
+}
+
+function shouldRecursivelyMergeTopLevelObject(field: string): boolean {
+  return field !== 'sourceLocation' && field !== 'signature'
+}
+
+function mergeArrayField(target: object, field: string, incomingValue: readonly unknown[]): void {
+  if (incomingValue.length === 0) {
+    return
+  }
+
+  const existingValue = getField(target, field)
+  const existingArray = Array.isArray(existingValue) ? existingValue : []
+  setField(target, field, mergeArrayUnion(existingArray, incomingValue))
+}
+
+function mergeBehaviorField(target: object, incomingValue: Record<string, unknown>): void {
+  const existingValue = getField(target, 'behavior')
+  const existingBehavior = toOperationBehavior(existingValue)
+  const incomingBehavior = toOperationBehaviorFromRecord(incomingValue)
+
+  setField(target, 'behavior', mergeBehavior(existingBehavior, incomingBehavior))
+}
+
+function mergeScalarLikeField(
+  target: object,
+  field: string,
+  incomingValue: unknown,
+  options: UpsertOptions | undefined,
+  warnings: BuilderWarning[],
+  componentId: string,
+): void {
+  const existingValue = getField(target, field)
+
+  if (options?.noOverwrite && isDefined(existingValue)) {
+    return
+  }
+
+  maybePushScalarOverwriteWarning(warnings, componentId, field, existingValue, incomingValue)
+
+  setField(target, field, incomingValue)
+}
+
+function maybePushScalarOverwriteWarning(
+  warnings: BuilderWarning[],
+  componentId: string,
+  field: string,
+  existingValue: unknown,
+  incomingValue: unknown,
+): void {
+  if (
+    !isPrimitive(existingValue) ||
+    !isPrimitive(incomingValue) ||
+    existingValue === incomingValue
+  ) {
+    return
+  }
+
+  warnings.push({
+    code: 'SCALAR_OVERWRITE',
+    message: `Scalar field '${field}' on component '${componentId}' overwritten`,
+    componentId,
+    field,
+    oldValue: existingValue,
+    newValue: incomingValue,
+  })
+}
+
+function mergeNestedObject(
+  existing: Record<string, unknown> | undefined,
+  incoming: Record<string, unknown>,
+  options: UpsertOptions | undefined,
+  warnings: BuilderWarning[],
+  componentId: string,
+  pathPrefix: string,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...(existing ?? {}) }
+
+  for (const [field, incomingValue] of Object.entries(incoming)) {
+    if (!isDefined(incomingValue)) {
+      continue
+    }
+
+    if (Array.isArray(incomingValue)) {
+      mergeArrayField(merged, field, incomingValue)
+      continue
+    }
+
+    if (isRecord(incomingValue)) {
+      const existingValue = merged[field]
+      const existingRecord = isRecord(existingValue) ? existingValue : undefined
+      merged[field] = mergeNestedObject(
+        existingRecord,
+        incomingValue,
+        options,
+        warnings,
+        componentId,
+        `${pathPrefix}.${field}`,
+      )
+      continue
+    }
+
+    if (options?.noOverwrite && isDefined(merged[field])) {
+      continue
+    }
+
+    maybePushScalarOverwriteWarning(
+      warnings,
+      componentId,
+      `${pathPrefix}.${field}`,
+      merged[field],
+      incomingValue,
+    )
+
+    merged[field] = incomingValue
+  }
+
+  return merged
+}
+
+function toOperationBehavior(value: unknown): OperationBehavior | undefined {
+  if (!isRecord(value)) {
+    return undefined
+  }
+
+  return toOperationBehaviorFromRecord(value)
+}
+
+function toOperationBehaviorFromRecord(value: Record<string, unknown>): OperationBehavior {
+  const behavior: OperationBehavior = {}
+
+  const reads = toStringArray(value['reads'])
+  if (reads !== undefined) {
+    behavior.reads = reads
+  }
+
+  const validates = toStringArray(value['validates'])
+  if (validates !== undefined) {
+    behavior.validates = validates
+  }
+
+  const modifies = toStringArray(value['modifies'])
+  if (modifies !== undefined) {
+    behavior.modifies = modifies
+  }
+
+  const emits = toStringArray(value['emits'])
+  if (emits !== undefined) {
+    behavior.emits = emits
+  }
+
+  return behavior
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  return value.filter(isString)
+}
+
+function mergeArrayUnion<T>(existing: readonly T[], incoming: readonly T[]): T[] {
+  const merged = [...existing]
+  const seen = new Set(existing.map((item) => toStableKey(item)))
+
+  for (const item of incoming) {
+    const key = toStableKey(item)
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    merged.push(item)
+  }
+
+  return merged
+}
+
+function getField(target: object, field: string): unknown {
+  return Reflect.get(target, field)
+}
+
+function setField(target: object, field: string, value: unknown): void {
+  Reflect.set(target, field, value)
+}
+
+function toStableKey(value: unknown): string {
+  if (isPrimitive(value)) {
+    return `${typeof value}:${String(value)}`
+  }
+
+  return `json:${JSON.stringify(value)}`
+}
+
+function isDefined(value: unknown): boolean {
+  return value !== undefined && value !== null
+}
+
+function isPrimitive(value: unknown): value is Primitive {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string'
+}
+
+function isCustomComponent(component: Component): component is CustomComponent {
+  return component.type === 'Custom'
+}

--- a/packages/riviere-builder/src/features/building/domain/index.ts
+++ b/packages/riviere-builder/src/features/building/domain/index.ts
@@ -4,9 +4,11 @@ export {
 } from '@living-architecture/riviere-schema'
 export {
   DuplicateDomainError,
+  SourceConflictError,
   DomainNotFoundError,
   CustomTypeNotFoundError,
   DuplicateComponentError,
+  ComponentTypeMismatchError,
   ComponentNotFoundError,
   CustomTypeAlreadyDefinedError,
   MissingRequiredPropertiesError,

--- a/packages/riviere-builder/src/features/building/domain/inspection/graph-inspection.ts
+++ b/packages/riviere-builder/src/features/building/domain/inspection/graph-inspection.ts
@@ -15,13 +15,15 @@ import {
 /** @riviere-role domain-service */
 export class GraphInspection {
   private readonly graph: BuilderGraph
+  private readonly operationWarnings: readonly BuilderWarning[]
 
-  constructor(graph: BuilderGraph) {
+  constructor(graph: BuilderGraph, operationWarnings: readonly BuilderWarning[]) {
     this.graph = graph
+    this.operationWarnings = operationWarnings
   }
 
   warnings(): BuilderWarning[] {
-    return findWarnings(this.graph)
+    return [...findWarnings(this.graph), ...this.operationWarnings]
   }
 
   stats(): BuilderStats {

--- a/packages/riviere-builder/src/features/building/domain/inspection/inspection-types.ts
+++ b/packages/riviere-builder/src/features/building/domain/inspection/inspection-types.ts
@@ -16,7 +16,11 @@ export interface BuilderStats {
 }
 
 /** @riviere-role value-object */
-export type WarningCode = 'ORPHAN_COMPONENT' | 'UNUSED_DOMAIN'
+export type WarningCode =
+  | 'ORPHAN_COMPONENT'
+  | 'UNUSED_DOMAIN'
+  | 'SCALAR_OVERWRITE'
+  | 'DUPLICATE_LINK_SKIPPED'
 
 /** @riviere-role value-object */
 export interface BuilderWarning {
@@ -24,4 +28,12 @@ export interface BuilderWarning {
   message: string
   componentId?: string
   domainName?: string
+  field?: string
+  oldValue?: string | number | boolean
+  newValue?: string | number | boolean
+  source?: string
+  target?: string
+  linkType?: string
+  targetRepository?: string
+  targetName?: string
 }

--- a/packages/riviere-builder/src/features/building/domain/linking/builder-links.spec.ts
+++ b/packages/riviere-builder/src/features/building/domain/linking/builder-links.spec.ts
@@ -175,6 +175,72 @@ describe('RiviereBuilder', () => {
 
       expect(link.type).toBeUndefined()
     })
+
+    it('deduplicates duplicate links and records DUPLICATE_LINK_SKIPPED warning', () => {
+      const builder = RiviereBuilder.new(createValidOptions())
+
+      const source = builder.addUseCase({
+        name: 'Create Order',
+        domain: 'orders',
+        module: 'checkout',
+        sourceLocation: {
+          repository: 'test/repo',
+          filePath: 'src/create-order.ts',
+        },
+      })
+
+      builder.link({
+        from: source.id,
+        to: 'any:target:id',
+        type: 'sync',
+      })
+
+      builder.link({
+        from: source.id,
+        to: 'any:target:id',
+        type: 'sync',
+      })
+
+      expect(builder.stats().linkCount).toBe(1)
+      expect(builder.warnings()).toContainEqual({
+        code: 'DUPLICATE_LINK_SKIPPED',
+        message: `Duplicate link '${source.id}' -> 'any:target:id' (sync) skipped`,
+        source: source.id,
+        target: 'any:target:id',
+        linkType: 'sync',
+      })
+    })
+
+    it('uses unspecified marker for duplicate links without explicit type', () => {
+      const builder = RiviereBuilder.new(createValidOptions())
+
+      const source = builder.addUseCase({
+        name: 'Create Order',
+        domain: 'orders',
+        module: 'checkout',
+        sourceLocation: {
+          repository: 'test/repo',
+          filePath: 'src/create-order.ts',
+        },
+      })
+
+      builder.link({
+        from: source.id,
+        to: 'any:target:id',
+      })
+
+      builder.link({
+        from: source.id,
+        to: 'any:target:id',
+      })
+
+      expect(builder.warnings()).toContainEqual({
+        code: 'DUPLICATE_LINK_SKIPPED',
+        message: `Duplicate link '${source.id}' -> 'any:target:id' (unspecified) skipped`,
+        source: source.id,
+        target: 'any:target:id',
+      })
+    })
   })
 
   describe('linkExternal', () => {
@@ -278,6 +344,88 @@ describe('RiviereBuilder', () => {
       expect(externalLink.sourceLocation).toStrictEqual({
         repository: 'test/repo',
         filePath: 'src/stripe.ts',
+      })
+    })
+
+    it('deduplicates duplicate external links and records DUPLICATE_LINK_SKIPPED warning', () => {
+      const builder = RiviereBuilder.new(createValidOptions())
+
+      const source = builder.addUseCase({
+        name: 'Create Order',
+        domain: 'orders',
+        module: 'checkout',
+        sourceLocation: {
+          repository: 'test/repo',
+          filePath: 'src/create-order.ts',
+        },
+      })
+
+      builder.linkExternal({
+        from: source.id,
+        target: {
+          repository: 'acme/payments',
+          name: 'Stripe API',
+        },
+        type: 'async',
+      })
+
+      builder.linkExternal({
+        from: source.id,
+        target: {
+          repository: 'acme/payments',
+          name: 'Stripe API',
+        },
+        type: 'async',
+      })
+
+      expect(builder.stats().externalLinkCount).toBe(1)
+      expect(builder.warnings()).toContainEqual({
+        code: 'DUPLICATE_LINK_SKIPPED',
+        message: `Duplicate external link '${source.id}' -> 'Stripe API' (async) skipped`,
+        source: source.id,
+        target: 'Stripe API',
+        linkType: 'async',
+        targetRepository: 'acme/payments',
+        targetName: 'Stripe API',
+      })
+    })
+
+    it('uses unspecified marker for duplicate external links without explicit type', () => {
+      const builder = RiviereBuilder.new(createValidOptions())
+
+      const source = builder.addUseCase({
+        name: 'Create Order',
+        domain: 'orders',
+        module: 'checkout',
+        sourceLocation: {
+          repository: 'test/repo',
+          filePath: 'src/create-order.ts',
+        },
+      })
+
+      builder.linkExternal({
+        from: source.id,
+        target: {
+          repository: 'acme/payments',
+          name: 'Stripe API',
+        },
+      })
+
+      builder.linkExternal({
+        from: source.id,
+        target: {
+          repository: 'acme/payments',
+          name: 'Stripe API',
+        },
+      })
+
+      expect(builder.warnings()).toContainEqual({
+        code: 'DUPLICATE_LINK_SKIPPED',
+        message: `Duplicate external link '${source.id}' -> 'Stripe API' (unspecified) skipped`,
+        source: source.id,
+        target: 'Stripe API',
+        targetRepository: 'acme/payments',
+        targetName: 'Stripe API',
       })
     })
   })

--- a/packages/riviere-builder/src/features/building/domain/linking/graph-linking.ts
+++ b/packages/riviere-builder/src/features/building/domain/linking/graph-linking.ts
@@ -2,6 +2,7 @@ import type {
   ExternalLink, Link 
 } from '@living-architecture/riviere-schema'
 import type { BuilderGraph } from '../builder-graph'
+import type { BuilderWarning } from '../inspection/inspection-types'
 import type {
   ExternalLinkInput, LinkInput 
 } from './linking-types'
@@ -10,15 +11,33 @@ import { createComponentNotFoundError } from '../construction/builder-internals'
 /** @riviere-role domain-service */
 export class GraphLinking {
   private readonly graph: BuilderGraph
+  private readonly operationWarnings: BuilderWarning[]
 
-  constructor(graph: BuilderGraph) {
+  constructor(graph: BuilderGraph, operationWarnings: BuilderWarning[]) {
     this.graph = graph
+    this.operationWarnings = operationWarnings
   }
 
   link(input: LinkInput): Link {
     const sourceExists = this.graph.components.some((c) => c.id === input.from)
     if (!sourceExists) {
       throw createComponentNotFoundError(this.graph.components, input.from)
+    }
+
+    const duplicate = this.graph.links.find(
+      (link) => link.source === input.from && link.target === input.to && link.type === input.type,
+    )
+
+    if (duplicate) {
+      this.operationWarnings.push({
+        code: 'DUPLICATE_LINK_SKIPPED',
+        message: `Duplicate link '${input.from}' -> '${input.to}' (${input.type ?? 'unspecified'}) skipped`,
+        source: input.from,
+        target: input.to,
+        ...(input.type !== undefined && { linkType: input.type }),
+      })
+
+      return duplicate
     }
 
     const link: Link = {
@@ -34,6 +53,28 @@ export class GraphLinking {
     const sourceExists = this.graph.components.some((c) => c.id === input.from)
     if (!sourceExists) {
       throw createComponentNotFoundError(this.graph.components, input.from)
+    }
+
+    const duplicate = this.graph.externalLinks.find(
+      (link) =>
+        link.source === input.from &&
+        link.target.repository === input.target.repository &&
+        link.target.name === input.target.name &&
+        link.type === input.type,
+    )
+
+    if (duplicate) {
+      this.operationWarnings.push({
+        code: 'DUPLICATE_LINK_SKIPPED',
+        message: `Duplicate external link '${input.from}' -> '${input.target.name}' (${input.type ?? 'unspecified'}) skipped`,
+        source: input.from,
+        target: input.target.name,
+        ...(input.type !== undefined && { linkType: input.type }),
+        ...(input.target.repository !== undefined && { targetRepository: input.target.repository }),
+        targetName: input.target.name,
+      })
+
+      return duplicate
     }
 
     const externalLink: ExternalLink = {

--- a/packages/riviere-builder/src/features/building/domain/riviere-builder.ts
+++ b/packages/riviere-builder/src/features/building/domain/riviere-builder.ts
@@ -6,6 +6,7 @@ import { GraphLinking } from './linking/graph-linking'
 import { GraphInspection } from './inspection/graph-inspection'
 import { NearMatch } from './error-recovery/near-match'
 import type { BuilderOptions } from './construction/construction-types'
+import type { BuilderWarning } from './inspection/inspection-types'
 import {
   BuildValidationError,
   InvalidGraphError,
@@ -28,10 +29,11 @@ export class RiviereBuilder {
   private constructor(graph: BuilderGraph, graphPath: string) {
     this.graph = graph
     this.graphPath = graphPath
-    this.construction = new GraphConstruction(graph)
+    const operationWarnings: BuilderWarning[] = []
+    this.construction = new GraphConstruction(graph, operationWarnings)
     this.enrichment = new GraphEnrichment(graph)
-    this.linking = new GraphLinking(graph)
-    this.inspection = new GraphInspection(graph)
+    this.linking = new GraphLinking(graph, operationWarnings)
+    this.inspection = new GraphInspection(graph, operationWarnings)
     this.errorRecovery = new NearMatch(graph)
   }
 


### PR DESCRIPTION
Closes: https://github.com/NTCoding/living-architecture/issues/336

## Summary
- add typed `upsert*` methods to `RiviereBuilder` for UI/API/UseCase/DomainOp/Event/EventHandler/Custom components with shared merge semantics
- implement deterministic merge behavior for multi-source canonical components, including `noOverwrite`, array unions, nested object merges, type mismatch errors, and idempotent source/domain registration
- add duplicate-link and scalar-overwrite warning support, plus comprehensive tests covering merge paths, warnings, and strict 100% builder coverage

## Validation
- pnpm nx typecheck riviere-builder
- pnpm nx test riviere-builder
- pre-commit verify hook suite passed during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added upsert methods for all component types (UI, API, UseCase, DomainOp, Event, EventHandler, Custom) with intelligent data merging.
  * New `noOverwrite` option to prevent scalar value updates during upsert operations.
  * Enhanced warnings system to track scalar overwrites and duplicate links.

* **Bug Fixes**
  * Added validation to prevent component type mismatches during upsert.
  * Implemented source conflict detection for idempotent source additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->