### PR TITLE
fix: upgrade deterministic-agent-workflow packages to 0.2.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,23 +326,23 @@ importers:
   tools/dev-workflow-v2:
     dependencies:
       '@nt-ai-lab/deterministic-agent-workflow-claude-code':
-        specifier: 0.1.5
-        version: 0.1.5
+        specifier: 0.2.1
+        version: 0.2.1
       '@nt-ai-lab/deterministic-agent-workflow-cli':
-        specifier: 0.1.5
-        version: 0.1.5
+        specifier: 0.2.1
+        version: 0.2.1
       '@nt-ai-lab/deterministic-agent-workflow-dsl':
-        specifier: 0.1.5
-        version: 0.1.5
+        specifier: 0.2.1
+        version: 0.2.1
       '@nt-ai-lab/deterministic-agent-workflow-engine':
-        specifier: 0.1.5
-        version: 0.1.5
+        specifier: 0.2.1
+        version: 0.2.1
       '@nt-ai-lab/deterministic-agent-workflow-event-store':
-        specifier: 0.1.5
-        version: 0.1.5
+        specifier: 0.2.1
+        version: 0.2.1
       '@nt-ai-lab/deterministic-agent-workflow-opencode':
-        specifier: 0.1.5
-        version: 0.1.5
+        specifier: 0.2.1
+        version: 0.2.1
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1766,23 +1766,23 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.1.5':
-    resolution: {integrity: sha512-dZLOzV2C9NjWdTBvwccJkLUYdEiyO18poKs8b8NIJX9OT2jfuhrCxDoqqUnPmdZ1+2vUgoAsEZM+Gf6MS5HXRA==}
+  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.2.1':
+    resolution: {integrity: sha512-J8SSk8RWZJ0OxMAR8KDzpSlyoEU3zCjiUokZXU4mRYPiwjZ7F5q1NaqaAahRetBevbu57DOOByZ1EFLAxyHq2w==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-cli@0.1.5':
-    resolution: {integrity: sha512-3u0PRJdIwlXXPG6c1sNvPgQePwfQdKTDGxXyK7vqwiVf7GpTyzV4CrOhxynXQWBa/5US4alHGdzbzj23oNqDTw==}
+  '@nt-ai-lab/deterministic-agent-workflow-cli@0.2.1':
+    resolution: {integrity: sha512-loNoTUTu5Y/jeSm8YUMQqAn7LAHS7uR2WiuGve0lZfm4TEHfaaYdZaJul24lZDmFVLgvDCo0xCgh37oZiuEocA==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-dsl@0.1.5':
-    resolution: {integrity: sha512-E9xKgPFc0UrSvHj9IU6Jn0gtrNFpIV8s6oGmQZ7cb+95N6CeceeXbwxyHM9D2ZQAdAUt4xeS6JeFlJXth45NZw==}
+  '@nt-ai-lab/deterministic-agent-workflow-dsl@0.2.1':
+    resolution: {integrity: sha512-vGVD8TnSfyS3LN+TpthOEdzJr2Z4VHK8Gqjpfuw0agRQdOQZi5d5MYSzrOQcEgSvzegbPjI3Ksbz5rC84Ftf0Q==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-engine@0.1.5':
-    resolution: {integrity: sha512-+Fy284Gg+e4bRKhWi/wAs1j7Eao7K4h8BpA6uqBDvV+UBWOKhONtSyP4h94Ysm2nUE6BdNb/4fWxyicPy1tg0Q==}
+  '@nt-ai-lab/deterministic-agent-workflow-engine@0.2.1':
+    resolution: {integrity: sha512-gPjmXU6bSeiijr2rwWfiQK1NpBwnLYd5RLDEBY1+g8ONzrJtfJrHflIcawhl6v8AtPjtpqUM8kwVUgwFLZbuaQ==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-event-store@0.1.5':
-    resolution: {integrity: sha512-Re0qA5wGJrw9Nmyjt6GFhl933jB4yrtvTvhNasBmMQ7onIkA5GaoDu8OB4B1ABI0TfFrP9IdwX84IUJyzhEfHA==}
+  '@nt-ai-lab/deterministic-agent-workflow-event-store@0.2.1':
+    resolution: {integrity: sha512-BEgZ9wr1ecHn6gjmgcTyxuW84/JAvn1DuHsTPbBspDT4VnbS1e0/xQ+l1BlOMYr4yXXWTmN/qBNrLxdspOdcVg==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.1.5':
-    resolution: {integrity: sha512-OeOrsTq7E79Hu4CSw8OuLiygoQn3z0nWJkiusZ8OM83QbWxx7VhH1VvJg5UO01x9MMGxNKM41T9Qd9R6WKxEqQ==}
+  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.2.1':
+    resolution: {integrity: sha512-9rDu6NQAfMfvly9CNiMl7aCyeeKsY/3sUcE1UVE5fWDs/jVbg0CXIRJE6Xy/UufVE2q6V3jL0NEPbih2PfFMqQ==}
 
   '@nx/devkit@22.5.2':
     resolution: {integrity: sha512-5JuCMlU6AwXBKCoMWp1hTyTzjfB5vXL5khmoziZPmnaIBg+gX0Hp13YhWfO1C6/HuXS+i4mor7dtFHukPKWemQ==}
@@ -8894,37 +8894,37 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.1.5':
+  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.2.1':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.1.5
-      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.1.5
+      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.2.1
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.2.1
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-cli@0.1.5':
+  '@nt-ai-lab/deterministic-agent-workflow-cli@0.2.1':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-dsl': 0.1.5
-      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.1.5
-      '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.1.5
+      '@nt-ai-lab/deterministic-agent-workflow-dsl': 0.2.1
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.2.1
+      '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.2.1
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-dsl@0.1.5':
+  '@nt-ai-lab/deterministic-agent-workflow-dsl@0.2.1':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.1.5
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.2.1
 
-  '@nt-ai-lab/deterministic-agent-workflow-engine@0.1.5':
+  '@nt-ai-lab/deterministic-agent-workflow-engine@0.2.1':
     dependencies:
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-event-store@0.1.5':
+  '@nt-ai-lab/deterministic-agent-workflow-event-store@0.2.1':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.1.5
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.2.1
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.1.5':
+  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.2.1':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.1.5
-      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.1.5
-      '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.1.5
+      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.2.1
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.2.1
+      '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.2.1
       '@opencode-ai/plugin': 1.4.3
       zod: 3.25.76
     transitivePeerDependencies:

--- a/tools/dev-workflow-v2/package.json
+++ b/tools/dev-workflow-v2/package.json
@@ -8,12 +8,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@nt-ai-lab/deterministic-agent-workflow-claude-code": "0.1.5",
-    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.1.5",
-    "@nt-ai-lab/deterministic-agent-workflow-dsl": "0.1.5",
-    "@nt-ai-lab/deterministic-agent-workflow-engine": "0.1.5",
-    "@nt-ai-lab/deterministic-agent-workflow-event-store": "0.1.5",
-    "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.1.5",
+    "@nt-ai-lab/deterministic-agent-workflow-claude-code": "0.2.1",
+    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.2.1",
+    "@nt-ai-lab/deterministic-agent-workflow-dsl": "0.2.1",
+    "@nt-ai-lab/deterministic-agent-workflow-engine": "0.2.1",
+    "@nt-ai-lab/deterministic-agent-workflow-event-store": "0.2.1",
+    "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.2.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Upgrades all `@nt-ai-lab/deterministic-agent-workflow-*` packages from `0.1.5` to `0.2.1`
- Updates lockfile accordingly

## Test plan
- [ ] CI passes