### PR TITLE
docs: define external contribution workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--
+External contributors: this pull request description is the specification for
+the change. No GitHub issue is required. Replace the guidance below with enough
+detail for the pull request to stand alone.
+-->
+
+## Problem
+
+<!-- What limitation, bug or need does this contribution address? Include reproduction details or evidence where relevant. -->
+
+## Proposed outcome
+
+<!-- Describe the intended, observable behaviour after this pull request is merged. -->
+
+## Changes
+
+<!-- Describe the concrete changes made. Do not only list filenames. -->
+
+## Acceptance criteria
+
+- [ ] <!-- Add an observable condition that reviewers can verify. -->
+
+## Validation
+
+<!-- List the automated and manual checks run, with their results. Explain any checks that could not be run. -->
+
+## Design decisions and constraints
+
+<!-- Record important choices, assumptions, compatibility concerns or trade-offs. Write "None" if there are none. -->
+
+## Out of scope
+
+<!-- State what this pull request deliberately does not address. Write "None" if nothing needs calling out. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,6 @@
 
 Read and follow all instructions in @CLAUDE.md
 
+If you are not explicitly working as part of the maintainer team, read and follow @CONTRIBUTING.md. That public contribution guide replaces the Maintainer Workflow in @CLAUDE.md. Do not create an issue or install the maintainer harness; make the change and raise a pull request whose description is the specification.
+
 For planning, discovery, PRD, architecture, delivery planning, or future-project discussion, also read and follow @project-memory/AGENTS.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,10 @@ After generating a new project:
 
 ## Task Workflow
 
-*CRUCIAL*: Whenever working on any task, follow `docs/workflow/task-workflow.md` from start to finish. Do not make any changes or commit any code without following these steps exactly.
+There are two contribution workflows. Team membership determines the workflow, not the agent provider or harness being used.
+
+- **Maintainer workflow:** when working as part of the maintainer team, follow `docs/workflow/task-workflow.md` from start to finish. Maintainers can create GitHub issues and use `dev-workflow-v2` to run the full planning and implementation lifecycle.
+- **External contribution workflow:** anyone not explicitly working as part of the maintainer team follows `CONTRIBUTING.md`. This is a lightweight pull-request workflow. Do not create a GitHub issue and do not attempt to use or install the maintainer harness. The pull request description is the specification for the change.
 
 ## Testing
 
@@ -157,7 +160,7 @@ The CLI (`riviere-cli`) bundles several packages via esbuild. To ensure users al
 ## General Guidelines
 
 - **Process before fix** - When you encounter a problem, improve the process/tooling first, then apply the fix. This ensures the same issue won't recur and benefits future work. Never just fix the symptom without addressing the root cause.
-- **Use scripts and dev-workflow-v2 for operations** - See `docs/workflow/task-workflow.md` for which commands to use. Direct `git add`/`git commit` is fine; `git push` and `gh pr` are blocked by hooks.
+- **Maintainer workflow operations** - Maintainers use the scripts and `dev-workflow-v2` commands documented in `docs/workflow/task-workflow.md`. Direct `git add`/`git commit` is fine; `git push` and `gh pr` are blocked by maintainer harness hooks. External contributors instead follow `CONTRIBUTING.md` and raise their pull request normally.
 - **Command failures vs code quality issues**:
   - **Command failures** (script doesn't exist, tool errors, missing dependencies) → STOP and consult with user
   - **Code quality issues** (lint errors, unused dependencies, test failures, knip warnings) → fix them directly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,18 @@
 # Contributing to Living Architecture
 
+This is the public workflow for external contributors. Members of the maintainer team use the separate [`maintainer workflow`](docs/workflow/task-workflow.md).
+
 ## How to Contribute
 
 1. Fork the repository
 2. Create a feature branch from `main`
 3. Make your changes
-4. Submit a pull request
+4. Run the relevant tests and `pnpm verify`
+5. Submit a pull request with a detailed description
+
+External contributors do not create a GitHub issue or install the maintainer harness. The pull request description is the specification for the change: it must explain the problem, the proposed outcome, the concrete changes, the acceptance criteria and how the result was validated.
+
+This workflow is deliberately independent of Claude Code, Codex, OpenCode, Kimi, Hermes or any other agent harness.
 
 ## Development Setup
 
@@ -57,15 +64,25 @@ Follow the conventions in [`docs/conventions/`](docs/conventions/):
 pnpm verify
 ```
 
+## Optional Agent Reviews
+
+If your harness supports agents, you can run these against your changes:
+
+- [`architecture-review`](tools/dev-workflow-v2/agents/architecture-review.md)
+- [`code-review`](tools/dev-workflow-v2/agents/code-review.md)
+- [`bug-scanner`](tools/dev-workflow-v2/agents/bug-scanner.md)
+
 ## Pull Request Process
 
 1. Ensure `pnpm run verify` passes locally
-2. Write clear PR description
+2. Complete the pull request template in enough detail for maintainers to assess the change without a separate issue
 3. Address review feedback
 
-## Task Workflow
+## Contribution Workflows
 
-For task management, see [`docs/workflow/task-workflow.md`](docs/workflow/task-workflow.md).
+External contributors use this lightweight public workflow: make the change and raise a detailed pull request.
+
+Members of the maintainer team use the full [`maintainer workflow`](docs/workflow/task-workflow.md), including planning, GitHub issues and the development harness.
 
 ## AI-Assisted Development
 

--- a/docs/workflow/task-workflow.md
+++ b/docs/workflow/task-workflow.md
@@ -1,4 +1,8 @@
-# Task Workflow
+# Maintainer Workflow
+
+This workflow is for members of the maintainer team. It includes planning, GitHub issue creation and the `dev-workflow-v2` development harness.
+
+External contributors use the lightweight public workflow in [`CONTRIBUTING.md`](../../CONTRIBUTING.md) instead.
 
 Canonical workflow guidance lives in `tools/dev-workflow-v2/README.md`.
 


### PR DESCRIPTION
## Problem

The repository currently directs every contributor through the maintainer workflow. That workflow stores specifications in GitHub issues and depends on the `dev-workflow-v2` harness, which external contributors may not have or be able to run from their agent provider.

External contributors need a lightweight, provider-independent route that does not require an issue or the maintainer harness.

## Proposed outcome

The repository has two explicit contribution paths:

- Maintainers continue to use the issue-based `dev-workflow-v2` workflow.
- External contributors make their change and raise a pull request whose detailed description acts as the specification.

## Changes

- Route non-maintainer agents from `AGENTS.md` to the public contribution guide.
- Define the maintainer and external contribution paths in `CLAUDE.md`.
- Update `CONTRIBUTING.md` with the lightweight external workflow and clarify that it is independent of the agent provider.
- Offer architecture, code and bug-scanner agent reviews as optional checks for harnesses that support agents.
- Rename the existing task workflow documentation to the maintainer workflow and link external contributors back to `CONTRIBUTING.md`.
- Add a pull request template that captures the problem, outcome, changes, acceptance criteria, validation, decisions and scope.

## Acceptance criteria

- [x] External contributors are not asked to create a GitHub issue.
- [x] External contributors are not asked to install or run the maintainer harness.
- [x] The pull request description is the specification for an external contribution.
- [x] The existing issue-based maintainer workflow remains available to the team.
- [x] The workflow is based on team membership rather than agent provider.
- [x] The three supported review agents are presented as optional.

## Validation

- Full pre-commit hook, including `pnpm verify`: passed.
- `git diff --check`: passed.

## Design decisions and constraints

`CONTRIBUTING.md` remains the public source of truth for external contributors. Provider-specific files only route agents to that guide; they do not duplicate the workflow.

## Out of scope

- Packaging the maintainer harness for additional providers.
- Requiring external contributors to reproduce the maintainer workflow.
