### PR TITLE
feat(eclair): improve custom graph exploration

### DIFF
--- a/apps/eclair/docs/brand/graph-visualization.md
+++ b/apps/eclair/docs/brand/graph-visualization.md
@@ -40,7 +40,7 @@ Canvas, node, edge, and tooltip specifications for graph views.
   content: '';
   position: absolute;
   inset: 0;
-  background-image: radial-gradient(circle, rgba(13, 148, 136, 0.25) 1.5px, transparent 1.5px);
+  background-image: radial-gradient(circle, rgba(100, 116, 139, 0.22) 1.5px, transparent 1.5px);
   background-size: 24px 24px;
   pointer-events: none;
 }
@@ -57,7 +57,7 @@ Canvas, node, edge, and tooltip specifications for graph views.
   content: '';
   position: absolute;
   inset: 0;
-  background-image: radial-gradient(circle, rgba(0, 212, 255, 0.15) 1.5px, transparent 1.5px);
+  background-image: radial-gradient(circle, rgba(160, 160, 176, 0.18) 1.5px, transparent 1.5px);
   background-size: 24px 24px;
   pointer-events: none;
 }
@@ -149,7 +149,10 @@ Nodes must stand out from canvas through:
 
 See [Global Brand Colors](/docs/brand/colors.md#architectural-component-colors) for the authoritative color values per component type.
 
-In Éclair, these are implemented in `types.ts` as `NODE_COLORS` and used throughout the application.
+In Éclair, built-in and graph-defined custom types are resolved through
+`src/platform/domain/node-type-presentation.ts`. Built-in types use the documented brand colours;
+custom type names use one stable, theme-aware colour mapping shared by graphs, badges, filters and
+legends.
 
 ---
 

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.spec.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.spec.tsx
@@ -98,6 +98,37 @@ describe('DomainMapPage', () => {
     expect(screen.getByText('1 connection')).toBeInTheDocument()
   })
 
+  it('displays every relationship when a domain pair has multiple connections', () => {
+    const graph = createTestGraph()
+    const graphWithMultipleConnections: RiviereGraph = {
+      ...graph,
+      components: [
+        ...graph.components,
+        parseNode({
+          sourceLocation: testSourceLocation,
+          id: 'n3',
+          type: 'Custom',
+          name: 'Worker 1',
+          domain: 'orders',
+          module: 'm1',
+          customTypeName: 'Worker',
+        }),
+      ],
+      links: [
+        ...graph.links,
+        parseEdge({
+          source: 'n3',
+          target: 'n2',
+          type: 'sync',
+        }),
+      ],
+    }
+
+    renderWithRouter(graphWithMultipleConnections)
+
+    expect(screen.getByText('2 connections')).toBeInTheDocument()
+  })
+
   it('renders React Flow container', () => {
     const graph = createTestGraph()
 

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.spec.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.spec.tsx
@@ -7,6 +7,7 @@ import {
 import { MemoryRouter } from 'react-router-dom'
 import { DomainMapPage } from './DomainMapPage'
 import { ExportProvider } from '@/platform/infra/export/ExportContext'
+import { ThemeProvider } from '@/platform/infra/theme/ThemeContext'
 import type { RiviereGraph } from '@living-architecture/riviere-schema'
 import {
   parseNode, parseEdge, parseDomainMetadata 
@@ -22,8 +23,12 @@ function createTestGraph(): RiviereGraph {
     version: '1.0',
     metadata: {
       domains: parseDomainMetadata({
-        'test-domain': {
-          description: 'Test domain',
+        orders: {
+          description: 'Orders domain',
+          systemType: 'domain',
+        },
+        payments: {
+          description: 'Payments domain',
           systemType: 'domain',
         },
       }),
@@ -59,9 +64,11 @@ function createTestGraph(): RiviereGraph {
 function renderWithRouter(graph: RiviereGraph, initialEntry = '/'): ReturnType<typeof render> {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <ExportProvider>
-        <DomainMapPage graph={graph} />
-      </ExportProvider>
+      <ThemeProvider>
+        <ExportProvider>
+          <DomainMapPage graph={graph} />
+        </ExportProvider>
+      </ThemeProvider>
     </MemoryRouter>,
   )
 }

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
@@ -61,7 +61,11 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
     setEdges(initialEdges)
   }, [initialNodes, initialEdges, setNodes, setEdges])
 
-  const connectionText = pluralizeConnection(initialEdges.length)
+  const connectionCount = initialEdges.reduce(
+    (total, edge) => total + edge.data.connectionCount,
+    0,
+  )
+  const connectionText = pluralizeConnection(connectionCount)
 
   const nodeCountMap = useMemo(() => {
     const map = new Map<string, number>()

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
@@ -30,20 +30,17 @@ import type {
 } from '../queries/extract-domain-map'
 import { DomainNode } from '@/platform/infra/ui/DomainNode/DomainNode'
 import { useDomainMapInteractions } from '../hooks/useDomainMapInteractions'
+import { NodeTypeBadge } from '@/platform/infra/ui/NodeTypeBadge/NodeTypeBadge'
+import { useTheme } from '@/platform/infra/theme/ThemeContext'
 
 interface DomainMapPageProps {readonly graph: RiviereGraph}
 
 const nodeTypes = { domain: DomainNode }
 
-function getConnectionTypeLabel(targetNodeType: string): string {
-  if (targetNodeType === 'EventHandler') return 'EVENT'
-  if (targetNodeType === 'API') return 'API'
-  return targetNodeType
-}
-
 export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+  const { theme } = useTheme()
   const {
     registerExportHandlers, clearExportHandlers 
   } = useExport()
@@ -334,18 +331,16 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
             <div className="inspector-section-title">Connections</div>
             <div className="inspector-connection-list">
               {inspector.connections.map((conn) => {
-                const isEvent = conn.targetNodeType === 'EventHandler'
                 return (
                   <div
                     key={`${conn.sourceName}-${conn.targetName}-${conn.type}-${conn.targetNodeType}`}
                     className="inspector-connection-item"
                   >
                     <div className="flex items-center gap-2">
-                      <span
-                        className={isEvent ? 'badge-integration-event' : 'badge-integration-api'}
-                      >
-                        {getConnectionTypeLabel(conn.targetNodeType)}
-                      </span>
+                      <NodeTypeBadge
+                        type={conn.targetNodeType}
+                        theme={theme}
+                      />
                     </div>
                     <div className="mt-2 text-sm text-[var(--text-primary)]">{conn.sourceName}</div>
                     <div className="text-xs text-[var(--text-secondary)]">→ {conn.targetName}</div>

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
@@ -35,6 +35,12 @@ interface DomainMapPageProps {readonly graph: RiviereGraph}
 
 const nodeTypes = { domain: DomainNode }
 
+function getConnectionTypeLabel(targetNodeType: string): string {
+  if (targetNodeType === 'EventHandler') return 'EVENT'
+  if (targetNodeType === 'API') return 'API'
+  return targetNodeType
+}
+
 export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -104,8 +110,7 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
         event.clientY,
         edge.source,
         edge.target,
-        edge.data.apiCount,
-        edge.data.eventCount,
+        edge.data.connectionCount,
       )
     },
     [showEdgeTooltip],
@@ -131,6 +136,7 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
         sourceNodeCount,
         targetNodeCount,
         edge.data.connections,
+        edge.data.connectionCount,
       )
     },
     [selectEdge, nodeCountMap],
@@ -181,7 +187,7 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
     })
   }, [edges, focusedDomain])
 
-  const totalConnections = inspector.apiCount + inspector.eventCount
+  const totalConnections = inspector.connectionCount
 
   useEffect(() => {
     const graphName = graph.metadata.name ?? UNNAMED_GRAPH_EXPORT_NAME
@@ -338,7 +344,7 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
                       <span
                         className={isEvent ? 'badge-integration-event' : 'badge-integration-api'}
                       >
-                        {isEvent ? 'EVENT' : 'API'}
+                        {getConnectionTypeLabel(conn.targetNodeType)}
                       </span>
                     </div>
                     <div className="mt-2 text-sm text-[var(--text-primary)]">{conn.sourceName}</div>

--- a/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.spec.ts
+++ b/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.spec.ts
@@ -35,19 +35,19 @@ describe('useDomainMapInteractions', () => {
       const { result } = renderHook(() => useDomainMapInteractions())
 
       act(() => {
-        result.current.showEdgeTooltip(100, 200, 'orders', 'payments', 3, 2)
+        result.current.showEdgeTooltip(100, 200, 'orders', 'payments', 7)
       })
 
       expect(result.current.tooltip.visible).toBe(true)
       expect(result.current.tooltip.title).toBe('orders → payments')
-      expect(result.current.tooltip.detail).toBe('5 connections · Click for details')
+      expect(result.current.tooltip.detail).toBe('7 connections · Click for details')
     })
 
     it('uses singular connection for count of 1', () => {
       const { result } = renderHook(() => useDomainMapInteractions())
 
       act(() => {
-        result.current.showEdgeTooltip(100, 200, 'orders', 'payments', 1, 0)
+        result.current.showEdgeTooltip(100, 200, 'orders', 'payments', 1)
       })
 
       expect(result.current.tooltip.detail).toBe('1 connection · Click for details')
@@ -106,7 +106,7 @@ describe('useDomainMapInteractions', () => {
       const { result } = renderHook(() => useDomainMapInteractions())
 
       act(() => {
-        result.current.selectEdge('orders', 'payments', 3, 2, 10, 5, [])
+        result.current.selectEdge('orders', 'payments', 3, 2, 10, 5, [], 7)
       })
 
       expect(result.current.inspector).toMatchObject({
@@ -115,6 +115,7 @@ describe('useDomainMapInteractions', () => {
         target: 'payments',
         apiCount: 3,
         eventCount: 2,
+        connectionCount: 7,
         sourceNodeCount: 10,
         targetNodeCount: 5,
       })
@@ -124,12 +125,12 @@ describe('useDomainMapInteractions', () => {
       const { result } = renderHook(() => useDomainMapInteractions())
 
       act(() => {
-        result.current.showEdgeTooltip(100, 200, 'orders', 'payments', 3, 2)
+        result.current.showEdgeTooltip(100, 200, 'orders', 'payments', 7)
       })
       expect(result.current.tooltip.visible).toBe(true)
 
       act(() => {
-        result.current.selectEdge('orders', 'payments', 3, 2, 10, 5, [])
+        result.current.selectEdge('orders', 'payments', 3, 2, 10, 5, [], 7)
       })
       expect(result.current.tooltip.visible).toBe(false)
     })
@@ -138,7 +139,7 @@ describe('useDomainMapInteractions', () => {
       const { result } = renderHook(() => useDomainMapInteractions())
 
       act(() => {
-        result.current.selectEdge('orders', 'payments', 3, 2, 10, 5, [])
+        result.current.selectEdge('orders', 'payments', 3, 2, 10, 5, [], 7)
       })
       expect(result.current.inspector.visible).toBe(true)
 
@@ -166,7 +167,7 @@ describe('useDomainMapInteractions', () => {
       ]
 
       act(() => {
-        result.current.selectEdge('orders', 'payments', 1, 1, 10, 5, connections)
+        result.current.selectEdge('orders', 'payments', 1, 1, 10, 5, connections, 2)
       })
 
       expect(result.current.inspector.connections).toStrictEqual(connections)

--- a/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.ts
+++ b/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.ts
@@ -20,6 +20,7 @@ interface InspectorState {
   target: string
   apiCount: number
   eventCount: number
+  connectionCount: number
   sourceNodeCount: number
   targetNodeCount: number
   connections: ConnectionDetail[]
@@ -38,8 +39,7 @@ interface UseDomainMapInteractionsResult {
     y: number,
     source: string,
     target: string,
-    apiCount: number,
-    eventCount: number,
+    connectionCount: number,
   ) => void
   hideTooltip: () => void
   selectEdge: (
@@ -50,6 +50,7 @@ interface UseDomainMapInteractionsResult {
     sourceNodeCount: number,
     targetNodeCount: number,
     connections: ConnectionDetail[],
+    connectionCount: number,
   ) => void
   closeInspector: () => void
   selectDomain: (domain: string) => void
@@ -78,6 +79,7 @@ export function useDomainMapInteractions(
     target: '',
     apiCount: 0,
     eventCount: 0,
+    connectionCount: 0,
     sourceNodeCount: 0,
     targetNodeCount: 0,
     connections: [],
@@ -109,21 +111,13 @@ export function useDomainMapInteractions(
   )
 
   const showEdgeTooltip = useCallback(
-    (
-      x: number,
-      y: number,
-      source: string,
-      target: string,
-      apiCount: number,
-      eventCount: number,
-    ) => {
-      const total = apiCount + eventCount
+    (x: number, y: number, source: string, target: string, connectionCount: number) => {
       setTooltip({
         visible: true,
         x: x + TOOLTIP_OFFSET_X,
         y: y + TOOLTIP_OFFSET_Y,
         title: `${source} → ${target}`,
-        detail: `${pluralizeConnection(total)} · Click for details`,
+        detail: `${pluralizeConnection(connectionCount)} · Click for details`,
       })
     },
     [],
@@ -145,6 +139,7 @@ export function useDomainMapInteractions(
       sourceNodeCount: number,
       targetNodeCount: number,
       connections: ConnectionDetail[],
+      connectionCount: number,
     ) => {
       setTooltip((prev) => ({
         ...prev,
@@ -156,6 +151,7 @@ export function useDomainMapInteractions(
         target,
         apiCount,
         eventCount,
+        connectionCount,
         sourceNodeCount,
         targetNodeCount,
         connections,

--- a/apps/eclair/src/features/domain-map/queries/edgeAggregation.ts
+++ b/apps/eclair/src/features/domain-map/queries/edgeAggregation.ts
@@ -5,19 +5,6 @@ export interface ConnectionDetail {
   targetNodeType: string
 }
 
-export function formatEdgeLabel(apiCount: number, eventCount: number): string | undefined {
-  if (apiCount > 0 && eventCount > 0) {
-    return `${apiCount} API · ${eventCount} Event`
-  }
-  if (apiCount > 0) {
-    return `${apiCount} API`
-  }
-  if (eventCount > 0) {
-    return `${eventCount} Event`
-  }
-  return undefined
-}
-
 export function getEdgeType(type: string | undefined): 'sync' | 'async' | 'unknown' {
   if (type === 'sync') return 'sync'
   if (type === 'async') return 'async'
@@ -27,6 +14,7 @@ export function getEdgeType(type: string | undefined): 'sync' | 'async' | 'unkno
 export interface EdgeAggregation {
   source: string
   target: string
+  connectionCount: number
   apiCount: number
   eventCount: number
   connections: ConnectionDetail[]
@@ -54,6 +42,7 @@ export function recordEdgeAggregation(
     aggregation.set(key, {
       source: sourceInfo.domain,
       target: targetInfo.domain,
+      connectionCount: 1,
       apiCount: isApi ? 1 : 0,
       eventCount: isEventHandler ? 1 : 0,
       connections: [connection],
@@ -61,6 +50,7 @@ export function recordEdgeAggregation(
     return
   }
 
+  existing.connectionCount += 1
   if (isApi) {
     existing.apiCount += 1
   }

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.external.spec.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.external.spec.ts
@@ -17,8 +17,8 @@ function createMinimalGraph(overrides: Partial<RiviereGraph> = {}): RiviereGraph
     version: '1.0',
     metadata: {
       domains: parseDomainMetadata({
-        'test-domain': {
-          description: 'Test domain',
+        orders: {
+          description: 'Orders domain',
           systemType: 'domain',
         },
       }),
@@ -72,10 +72,12 @@ describe('extractDomainMap external links integration', () => {
     expect(stripeNode?.data).toMatchObject({
       label: 'Stripe',
       isExternal: true,
+      systemType: 'external',
     })
     expect(twilioNode?.data).toMatchObject({
       label: 'Twilio',
       isExternal: true,
+      systemType: 'external',
     })
   })
 

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.reactflow.spec.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.reactflow.spec.ts
@@ -308,7 +308,7 @@ describe('extractDomainMap React Flow compatibility', () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  it('includes label with API count', () => {
+  it('labels a single cross-domain relationship', () => {
     const graph = createMinimalGraph({
       components: [
         parseNode({
@@ -341,10 +341,10 @@ describe('extractDomainMap React Flow compatibility', () => {
 
     const result = extractDomainMap(graph)
 
-    expect(result.domainEdges[0]?.label).toBe('1 API')
+    expect(result.domainEdges[0]?.label).toBe('1 relationship')
   })
 
-  it('includes label with event count', () => {
+  it('counts an event relationship without changing its meaning', () => {
     const graph = createMinimalGraph({
       components: [
         parseNode({
@@ -377,10 +377,10 @@ describe('extractDomainMap React Flow compatibility', () => {
 
     const result = extractDomainMap(graph)
 
-    expect(result.domainEdges[0]?.label).toBe('1 Event')
+    expect(result.domainEdges[0]?.label).toBe('1 relationship')
   })
 
-  it('includes combined label with both API and event counts', () => {
+  it('labels the total across different endpoint types', () => {
     const graph = createMinimalGraph({
       components: [
         parseNode({
@@ -427,7 +427,7 @@ describe('extractDomainMap React Flow compatibility', () => {
 
     const result = extractDomainMap(graph)
 
-    expect(result.domainEdges[0]?.label).toBe('1 API · 1 Event')
+    expect(result.domainEdges[0]?.label).toBe('2 relationships')
   })
 
   it('uses cyan style for API-only edges', () => {

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.reactflow.spec.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.reactflow.spec.ts
@@ -19,8 +19,20 @@ function createMinimalGraph(overrides: Partial<RiviereGraph> = {}): RiviereGraph
     version: '1.0',
     metadata: {
       domains: parseDomainMetadata({
-        'test-domain': {
-          description: 'Test domain',
+        orders: {
+          description: 'Orders domain',
+          systemType: 'domain',
+        },
+        payments: {
+          description: 'Payments domain',
+          systemType: 'domain',
+        },
+        inventory: {
+          description: 'Inventory domain',
+          systemType: 'domain',
+        },
+        shipping: {
+          description: 'Shipping domain',
           systemType: 'domain',
         },
       }),

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.spec.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.spec.ts
@@ -22,9 +22,13 @@ function createMinimalGraph(overrides: Partial<RiviereGraph> = {}): RiviereGraph
     version: '1.0',
     metadata: {
       domains: parseDomainMetadata({
-        'test-domain': {
-          description: 'Test domain',
+        orders: {
+          description: 'Orders domain',
           systemType: 'domain',
+        },
+        payments: {
+          description: 'Payments domain',
+          systemType: 'bff',
         },
       }),
     },
@@ -151,7 +155,31 @@ describe('extractDomainMap', () => {
       const result = extractDomainMap(graph)
 
       expect(result.domainNodes[0]?.data).toStrictEqual(
-        expect.objectContaining({ label: 'orders' }),
+        expect.objectContaining({
+          label: 'orders',
+          systemType: 'domain',
+        }),
+      )
+    })
+
+    it('includes the declared domain type in node data', () => {
+      const graph = createMinimalGraph({
+        components: [
+          parseNode({
+            sourceLocation: testSourceLocation,
+            id: 'n1',
+            type: 'API',
+            name: 'API 1',
+            domain: 'payments',
+            module: 'm1',
+          }),
+        ],
+      })
+
+      const result = extractDomainMap(graph)
+
+      expect(result.domainNodes[0]?.data).toStrictEqual(
+        expect.objectContaining({ systemType: 'bff' }),
       )
     })
   })
@@ -345,6 +373,54 @@ describe('extractDomainMap', () => {
 
       expect(result.domainEdges).toHaveLength(1)
       expect(result.domainEdges[0]?.data?.connections[0]?.type).toBe('unknown')
+    })
+
+    it('uses the effective custom type in connection details', () => {
+      const graph = createMinimalGraph({
+        metadata: {
+          domains: parseDomainMetadata({
+            orders: {
+              description: 'Orders domain',
+              systemType: 'domain',
+            },
+            payments: {
+              description: 'Payments domain',
+              systemType: 'bff',
+            },
+          }),
+          customTypes: { Job: { description: 'A scheduled unit of work' } },
+        },
+        components: [
+          parseNode({
+            sourceLocation: testSourceLocation,
+            id: 'n1',
+            type: 'API',
+            name: 'Trigger',
+            domain: 'orders',
+            module: 'm1',
+          }),
+          parseNode({
+            sourceLocation: testSourceLocation,
+            id: 'n2',
+            type: 'Custom',
+            customTypeName: 'Job',
+            name: 'Process order',
+            domain: 'payments',
+            module: 'm2',
+          }),
+        ],
+        links: [
+          parseEdge({
+            source: 'n1',
+            target: 'n2',
+            type: 'sync',
+          }),
+        ],
+      })
+
+      const result = extractDomainMap(graph)
+
+      expect(result.domainEdges[0]?.data?.connections[0]?.targetNodeType).toBe('Job')
     })
   })
 })

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.spec.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.spec.ts
@@ -394,6 +394,14 @@ describe('external edges', () => {
     const result = extractDomainMap(graph)
 
     const stripeEdge = result.domainEdges.find((e) => e.target === 'external:Stripe')
+    expect(stripeEdge).toMatchObject({
+      label: '2 relationships',
+      data: {
+        connectionCount: 2,
+        apiCount: 0,
+        eventCount: 0,
+      },
+    })
     expect(stripeEdge?.data?.connections).toHaveLength(2)
     expect(stripeEdge?.data?.connections).toContainEqual({
       sourceName: 'PlaceOrder',
@@ -426,6 +434,7 @@ describe('getConnectedDomains', () => {
         source: 'orders',
         target: 'payments',
         data: {
+          connectionCount: 1,
           apiCount: 1,
           eventCount: 0,
           connections: [],
@@ -436,6 +445,7 @@ describe('getConnectedDomains', () => {
         source: 'orders',
         target: 'shipping',
         data: {
+          connectionCount: 1,
           apiCount: 0,
           eventCount: 1,
           connections: [],
@@ -456,6 +466,7 @@ describe('getConnectedDomains', () => {
         source: 'orders',
         target: 'payments',
         data: {
+          connectionCount: 1,
           apiCount: 1,
           eventCount: 0,
           connections: [],
@@ -466,6 +477,7 @@ describe('getConnectedDomains', () => {
         source: 'shipping',
         target: 'payments',
         data: {
+          connectionCount: 1,
           apiCount: 1,
           eventCount: 0,
           connections: [],
@@ -486,6 +498,7 @@ describe('getConnectedDomains', () => {
         source: 'orders',
         target: 'payments',
         data: {
+          connectionCount: 1,
           apiCount: 1,
           eventCount: 0,
           connections: [],
@@ -496,6 +509,7 @@ describe('getConnectedDomains', () => {
         source: 'payments',
         target: 'notifications',
         data: {
+          connectionCount: 1,
           apiCount: 1,
           eventCount: 0,
           connections: [],

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.ts
@@ -11,6 +11,7 @@ import { aggregateDomainEdges } from './edge-aggregation'
 import {
   aggregateExternalEdges, createExternalNodeId 
 } from './external-domain-handling'
+import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
 
 export type ConnectionDetail = DomainMapEdgeTypes.ConnectionDetail
 
@@ -119,7 +120,7 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
     nodeInfo.set(node.id, {
       domain: node.domain,
       name: node.name,
-      type: node.type,
+      type: getEffectiveNodeType(node),
     })
   }
 
@@ -163,6 +164,7 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
       throw new LayoutError(`Domain ${domain} missing from layout computation`)
     }
     const calculatedSize = nodeSizes.get(domain)
+    const domainMetadata = graph.metadata.domains[domain]
     return {
       id: domain,
       type: 'domain',
@@ -170,6 +172,7 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
       data: {
         label: domain,
         nodeCount,
+        systemType: domainMetadata?.systemType ?? 'other',
         calculatedSize,
         isExternal: false,
       },
@@ -190,6 +193,7 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
       data: {
         label: ed.name,
         nodeCount: ed.connectionCount,
+        systemType: 'external',
         calculatedSize,
         isExternal: true,
       },

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.ts
@@ -5,16 +5,14 @@ import type {
 import dagre from 'dagre'
 import { getClosestHandle } from '@/platform/infra/layout/handle-positioning'
 import { RiviereQuery } from '@living-architecture/riviere-query'
-import {
-  formatEdgeLabel, type ConnectionDetail, type EdgeAggregation 
-} from './edgeAggregation'
+import type * as DomainMapEdgeTypes from './edgeAggregation'
 import { LayoutError } from '@/platform/infra/errors/errors'
 import { aggregateDomainEdges } from './edge-aggregation'
 import {
   aggregateExternalEdges, createExternalNodeId 
 } from './external-domain-handling'
 
-export type { ConnectionDetail } from './edgeAggregation'
+export type ConnectionDetail = DomainMapEdgeTypes.ConnectionDetail
 
 const LABEL_BG_PADDING: [number, number] = [4, 6]
 const DOMAIN_NODE_SIZE = 120
@@ -23,6 +21,7 @@ const EXTERNAL_NODE_SIZE = 100
 export type { DomainNodeData } from '@/platform/domain/domain-node-types'
 
 export interface DomainEdgeData {
+  connectionCount: number
   apiCount: number
   eventCount: number
   connections: ConnectionDetail[]
@@ -124,7 +123,7 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
     })
   }
 
-  const edgeAggregation = new Map<string, EdgeAggregation>()
+  const edgeAggregation = new Map<string, DomainMapEdgeTypes.EdgeAggregation>()
   aggregateDomainEdges(graph.links, nodeInfo, edgeAggregation)
 
   const externalEdges = aggregateExternalEdges(graph, nodeInfo)
@@ -219,8 +218,9 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
       target: agg.target,
       sourceHandle: handles.sourceHandle,
       targetHandle: handles.targetHandle,
-      label: formatEdgeLabel(agg.apiCount, agg.eventCount),
+      label: `${agg.connectionCount} ${agg.connectionCount === 1 ? 'relationship' : 'relationships'}`,
       data: {
+        connectionCount: agg.connectionCount,
         apiCount: agg.apiCount,
         eventCount: agg.eventCount,
         connections: agg.connections,
@@ -260,9 +260,10 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
       target: targetId,
       sourceHandle: handles.sourceHandle,
       targetHandle: handles.targetHandle,
-      label: `${e.connectionCount} API`,
+      label: `${e.connectionCount} ${e.connectionCount === 1 ? 'relationship' : 'relationships'}`,
       data: {
-        apiCount: e.connectionCount,
+        connectionCount: e.connectionCount,
+        apiCount: 0,
         eventCount: 0,
         connections: e.connections,
       },

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.spec.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.spec.tsx
@@ -19,18 +19,21 @@ function createConnections(
       direction: 'outgoing',
       apiCount: 2,
       eventCount: 1,
+      relationshipCount: 3,
     },
     {
       targetDomain: 'payment-domain',
       direction: 'outgoing',
       apiCount: 1,
       eventCount: 0,
+      relationshipCount: 1,
     },
     {
       targetDomain: 'shipping-domain',
       direction: 'incoming',
       apiCount: 0,
       eventCount: 2,
+      relationshipCount: 2,
     },
   ]
   if (overrides.length === 0) return defaults
@@ -133,6 +136,30 @@ describe('DomainContextGraph', () => {
 
       const edge = screen.getByTestId('edge-order-domain-shipping-domain')
       expect(edge).toHaveAttribute('data-direction', 'incoming')
+    })
+
+    it('marks both edges as bidirectional when domains connect in both directions', () => {
+      const connections = createConnections([
+        {
+          targetDomain: 'inventory-domain',
+          direction: 'outgoing',
+          apiCount: 1,
+          eventCount: 0,
+        },
+        {
+          targetDomain: 'inventory-domain',
+          direction: 'incoming',
+          apiCount: 0,
+          eventCount: 1,
+        },
+      ])
+
+      renderWithRouter(<DomainContextGraph domainId="order-domain" connections={connections} />)
+
+      const edges = screen.getAllByTestId('edge-order-domain-inventory-domain')
+      expect(edges).toHaveLength(2)
+      expect(edges[0]).toHaveAttribute('data-bidirectional', 'true')
+      expect(edges[1]).toHaveAttribute('data-bidirectional', 'true')
     })
   })
 

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
@@ -242,6 +242,11 @@ export function DomainContextGraph({
             const isOutgoing = conn.direction === 'outgoing'
             const fromPos = isOutgoing ? currentPosition : targetPosition
             const toPos = isOutgoing ? targetPosition : currentPosition
+            const isBidirectional = connections.some(
+              (candidate) =>
+                candidate.targetDomain === conn.targetDomain &&
+                candidate.direction !== conn.direction,
+            )
 
             return (
               <EdgeLine
@@ -253,6 +258,7 @@ export function DomainContextGraph({
                 testId={`edge-${domainId}-${conn.targetDomain}`}
                 direction={conn.direction}
                 relationshipCount={conn.relationshipCount}
+                isBidirectional={isBidirectional}
               />
             )
           })}

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
@@ -52,7 +52,7 @@ function calculatePositions(
 }
 
 function calculateViewBox(positions: DomainPosition[]): string {
-  const padding = 20
+  const padding = 60
   const maxNodeRadius = 40
 
   const xs = positions.map((p) => p.x)
@@ -252,6 +252,7 @@ export function DomainContextGraph({
                 toRadius={toPos.isCurrent ? 40 : 30}
                 testId={`edge-${domainId}-${conn.targetDomain}`}
                 direction={conn.direction}
+                relationshipCount={conn.relationshipCount}
               />
             )
           })}

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
@@ -29,6 +29,8 @@ describe('EdgeLine', () => {
           toRadius={30}
           testId="test-edge"
           direction="outgoing"
+          relationshipCount={2}
+          isBidirectional={false}
         />
       </svg>,
     )
@@ -54,6 +56,8 @@ describe('EdgeLine', () => {
           toRadius={30}
           testId="same-edge"
           direction="outgoing"
+          relationshipCount={1}
+          isBidirectional={false}
         />
       </svg>,
     )
@@ -73,11 +77,49 @@ describe('EdgeLine', () => {
           toRadius={30}
           testId="directed-edge"
           direction="incoming"
+          relationshipCount={1}
+          isBidirectional={false}
         />
       </svg>,
     )
 
     const group = container.querySelector('[data-direction="incoming"]')
     expect(group).toBeInTheDocument()
+  })
+
+  it('separates the paths and labels for opposite relationship directions', () => {
+    const { container } = render(
+      <svg>
+        <EdgeLine
+          from={from}
+          to={to}
+          fromRadius={40}
+          toRadius={30}
+          testId="outgoing-edge"
+          direction="outgoing"
+          relationshipCount={2}
+          isBidirectional
+        />
+        <EdgeLine
+          from={to}
+          to={from}
+          fromRadius={30}
+          toRadius={40}
+          testId="incoming-edge"
+          direction="incoming"
+          relationshipCount={1}
+          isBidirectional
+        />
+      </svg>,
+    )
+
+    const outgoingLine = container.querySelector('[data-testid="outgoing-edge"] line')
+    const incomingLine = container.querySelector('[data-testid="incoming-edge"] line')
+    const outgoingLabel = container.querySelector('[data-testid="outgoing-edge"] text')
+    const incomingLabel = container.querySelector('[data-testid="incoming-edge"] text')
+
+    expect(outgoingLine?.getAttribute('x1')).not.toBe(incomingLine?.getAttribute('x2'))
+    expect(outgoingLabel?.getAttribute('x')).not.toBe(incomingLabel?.getAttribute('x'))
+    expect(outgoingLabel?.getAttribute('y')).not.toBe(incomingLabel?.getAttribute('y'))
   })
 })

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
@@ -8,7 +8,10 @@ interface EdgeLineProps {
   readonly testId: string
   readonly direction: 'incoming' | 'outgoing'
   readonly relationshipCount: number
+  readonly isBidirectional: boolean
 }
+
+const BIDIRECTIONAL_EDGE_SEPARATION = 8
 
 export function EdgeLine({
   from,
@@ -18,6 +21,7 @@ export function EdgeLine({
   testId,
   direction,
   relationshipCount,
+  isBidirectional,
 }: Readonly<EdgeLineProps>): React.ReactElement {
   const dx = to.x - from.x
   const dy = to.y - from.y
@@ -27,14 +31,17 @@ export function EdgeLine({
 
   const startOffset = fromRadius / length
   const endOffset = toRadius / length
+  const edgeSeparation = isBidirectional ? BIDIRECTIONAL_EDGE_SEPARATION : 0
+  const separationX = (-dy / length) * edgeSeparation
+  const separationY = (dx / length) * edgeSeparation
 
-  const startX = from.x + dx * startOffset
-  const startY = from.y + dy * startOffset
-  const endX = to.x - dx * endOffset
-  const endY = to.y - dy * endOffset
+  const startX = from.x + dx * startOffset + separationX
+  const startY = from.y + dy * startOffset + separationY
+  const endX = to.x - dx * endOffset + separationX
+  const endY = to.y - dy * endOffset + separationY
 
   return (
-    <g data-testid={testId} data-direction={direction}>
+    <g data-testid={testId} data-direction={direction} data-bidirectional={isBidirectional}>
       <line
         x1={startX}
         y1={startY}

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
@@ -7,6 +7,7 @@ interface EdgeLineProps {
   readonly toRadius: number
   readonly testId: string
   readonly direction: 'incoming' | 'outgoing'
+  readonly relationshipCount: number
 }
 
 export function EdgeLine({
@@ -16,6 +17,7 @@ export function EdgeLine({
   toRadius,
   testId,
   direction,
+  relationshipCount,
 }: Readonly<EdgeLineProps>): React.ReactElement {
   const dx = to.x - from.x
   const dy = to.y - from.y
@@ -43,6 +45,14 @@ export function EdgeLine({
         strokeOpacity="0.6"
         markerEnd="url(#arrow-marker)"
       />
+      <text
+        x={(startX + endX) / 2}
+        y={(startY + endY) / 2 - 6}
+        textAnchor="middle"
+        className="fill-[var(--text-secondary)] text-[10px] font-semibold"
+      >
+        {relationshipCount} {relationshipCount === 1 ? 'relationship' : 'relationships'}
+      </text>
     </g>
   )
 }

--- a/apps/eclair/src/features/domains/components/DomainDetailModal/DomainDetailModal.tsx
+++ b/apps/eclair/src/features/domains/components/DomainDetailModal/DomainDetailModal.tsx
@@ -77,7 +77,7 @@ export function DomainDetailModal({
                 {domain.nodes.map((node) => (
                   <div key={node.id} className="domain-node-item">
                     <div className="domain-node-info">
-                      <NodeTypeBadge type={node.type} />
+                      <NodeTypeBadge type={node.type} description={node.typeDescription} />
                       <span className="domain-node-name">{node.name}</span>
                     </div>
                     {node.location !== undefined && (

--- a/apps/eclair/src/features/domains/components/DomainDetailView/DomainDetailView.tsx
+++ b/apps/eclair/src/features/domains/components/DomainDetailView/DomainDetailView.tsx
@@ -1,33 +1,25 @@
 import { useMemo } from 'react'
-import type { NodeType } from '@/platform/domain/eclair-types'
 import type { DomainDetails } from '../../queries/extract-domain-details'
 import { NodeTypeBadge } from '@/platform/infra/ui/NodeTypeBadge/NodeTypeBadge'
 import { CodeLinkMenu } from '@/platform/infra/ui/CodeLinkMenu/CodeLinkMenu'
 import { EntityAccordion } from '@/platform/infra/ui/EntityAccordion/EntityAccordion'
 import { EventsSection } from './DomainDetailViewEvents'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
 type DomainDetailsNode = DomainDetails['nodes'][number]
 type DomainDetailsEntity = DomainDetails['entities'][number]
-export type NodeTypeFilter = NodeType | 'all'
-const NODE_TYPES: NodeType[] = [
-  'UI',
-  'API',
-  'UseCase',
-  'DomainOp',
-  'Event',
-  'EventHandler',
-  'Custom',
-]
 interface DomainDetailViewProps {
   readonly domain: DomainDetails
   readonly nodeSearch: string
   readonly setNodeSearch: (search: string) => void
-  readonly nodeTypeFilter: NodeTypeFilter
-  readonly setNodeTypeFilter: (filter: NodeTypeFilter) => void
+  readonly nodeTypeFilter: string
+  readonly setNodeTypeFilter: (filter: string) => void
   readonly entitySearch: string
   readonly setEntitySearch: (search: string) => void
   readonly eventSearch: string
   readonly setEventSearch: (search: string) => void
+  readonly theme?: Theme
 }
 
 export function DomainDetailView({
@@ -40,6 +32,7 @@ export function DomainDetailView({
   setEntitySearch,
   eventSearch,
   setEventSearch,
+  theme = DEFAULT_THEME,
 }: DomainDetailViewProps): React.ReactElement {
   const filteredNodes = useMemo(() => {
     return domain.nodes.filter((node) => {
@@ -81,6 +74,10 @@ export function DomainDetailView({
   const hasEvents = domain.events.published.length > 0 || domain.events.consumed.length > 0
   const operationsCount = domain.entities.reduce((sum, e) => sum + e.operations.length, 0)
   const eventsCount = domain.events.published.length + domain.events.consumed.length
+  const nodeTypes = useMemo(
+    () => [...new Set(domain.nodes.map((node) => node.type))].sort((a, b) => a.localeCompare(b)),
+    [domain.nodes],
+  )
 
   return (
     <>
@@ -96,6 +93,8 @@ export function DomainDetailView({
         setNodeSearch={setNodeSearch}
         nodeTypeFilter={nodeTypeFilter}
         setNodeTypeFilter={setNodeTypeFilter}
+        nodeTypes={nodeTypes}
+        theme={theme}
       />
       <EntitiesSection
         filteredEntities={filteredEntities}
@@ -167,8 +166,10 @@ interface NodesSectionProps {
   readonly domain: DomainDetails
   readonly nodeSearch: string
   readonly setNodeSearch: (search: string) => void
-  readonly nodeTypeFilter: NodeTypeFilter
-  readonly setNodeTypeFilter: (filter: NodeTypeFilter) => void
+  readonly nodeTypeFilter: string
+  readonly setNodeTypeFilter: (filter: string) => void
+  readonly nodeTypes: readonly string[]
+  readonly theme: Theme
 }
 function NodesSection({
   filteredNodes,
@@ -177,6 +178,8 @@ function NodesSection({
   setNodeSearch,
   nodeTypeFilter,
   setNodeTypeFilter,
+  nodeTypes,
+  theme,
 }: NodesSectionProps): React.ReactElement {
   return (
     <section data-testid="detail-panel">
@@ -190,8 +193,9 @@ function NodesSection({
         setNodeSearch={setNodeSearch}
         nodeTypeFilter={nodeTypeFilter}
         setNodeTypeFilter={setNodeTypeFilter}
+        nodeTypes={nodeTypes}
       />
-      <NodesListOrEmpty filteredNodes={filteredNodes} domain={domain} />
+      <NodesListOrEmpty filteredNodes={filteredNodes} domain={domain} theme={theme} />
     </section>
   )
 }
@@ -199,14 +203,16 @@ function NodesSection({
 interface NodeFilterBarProps {
   readonly nodeSearch: string
   readonly setNodeSearch: (search: string) => void
-  readonly nodeTypeFilter: NodeTypeFilter
-  readonly setNodeTypeFilter: (filter: NodeTypeFilter) => void
+  readonly nodeTypeFilter: string
+  readonly setNodeTypeFilter: (filter: string) => void
+  readonly nodeTypes: readonly string[]
 }
 function NodeFilterBar({
   nodeSearch,
   setNodeSearch,
   nodeTypeFilter,
   setNodeTypeFilter,
+  nodeTypes,
 }: NodeFilterBarProps): React.ReactElement {
   return (
     <div data-testid="filters-section" className="filters-section mb-4">
@@ -230,7 +236,7 @@ function NodeFilterBar({
         >
           All
         </button>
-        {NODE_TYPES.map((type) => (
+        {nodeTypes.map((type) => (
           <button
             key={type}
             type="button"
@@ -248,15 +254,16 @@ function NodeFilterBar({
 interface NodesListOrEmptyProps {
   readonly filteredNodes: Array<DomainDetailsNode>
   readonly domain: DomainDetails
+  readonly theme: Theme
 }
 function NodesListOrEmpty({
-  filteredNodes, domain 
+  filteredNodes, domain, theme,
 }: NodesListOrEmptyProps): React.ReactElement {
   if (filteredNodes.length > 0) {
     return (
       <div data-testid="nodes-list" className="max-h-[320px] space-y-2 overflow-y-auto">
         {filteredNodes.map((node) => (
-          <NodeListItem key={node.id} node={node} />
+          <NodeListItem key={node.id} node={node} theme={theme} />
         ))}
       </div>
     )
@@ -269,8 +276,14 @@ function NodesListOrEmpty({
   )
 }
 
-interface NodeListItemProps {readonly node: DomainDetailsNode}
-function NodeListItem({ node }: NodeListItemProps): React.ReactElement {
+interface NodeListItemProps {
+  readonly node: DomainDetailsNode
+  readonly theme: Theme
+}
+function NodeListItem({
+  node,
+  theme,
+}: NodeListItemProps): React.ReactElement {
   const sourceLocation = node.sourceLocation
   const hasSourceLocation = sourceLocation?.lineNumber !== undefined
   const hasNodeLocation = node.location !== undefined
@@ -305,7 +318,7 @@ function NodeListItem({ node }: NodeListItemProps): React.ReactElement {
   return (
     <div className="flex items-center justify-between gap-4 rounded-[var(--radius)] border border-[var(--border-color)] bg-[var(--bg-secondary)] px-3 py-2 shadow-sm">
       <div className="flex min-w-0 items-center gap-3">
-        <NodeTypeBadge type={node.type} />
+        <NodeTypeBadge type={node.type} description={node.typeDescription} theme={theme} />
         <span className="truncate text-sm font-medium text-[var(--text-primary)]">{node.name}</span>
       </div>
       {nodeAction}

--- a/apps/eclair/src/features/domains/components/DomainDetailView/DomainDetailView.tsx
+++ b/apps/eclair/src/features/domains/components/DomainDetailView/DomainDetailView.tsx
@@ -215,7 +215,7 @@ function NodeFilterBar({
   nodeTypes,
 }: NodeFilterBarProps): React.ReactElement {
   return (
-    <div data-testid="filters-section" className="filters-section mb-4">
+    <div data-testid="filters-section" className="filters-section node-filter-bar mb-4">
       <div className="search-container">
         <i className="ph ph-magnifying-glass search-icon" aria-hidden="true" />
         <input

--- a/apps/eclair/src/features/domains/entrypoint/DomainDetailPage.tsx
+++ b/apps/eclair/src/features/domains/entrypoint/DomainDetailPage.tsx
@@ -8,15 +8,21 @@ import {
 } from '../queries/extract-domain-details'
 import { parseDomainKey } from '@/platform/infra/__fixtures__/riviere-test-fixtures'
 import { DomainContextGraph } from '../components/DomainContextGraph/DomainContextGraph'
-import {
-  DomainDetailView, type NodeTypeFilter
-} from '../components/DomainDetailView/DomainDetailView'
+import {DomainDetailView} from '../components/DomainDetailView/DomainDetailView'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
 type ViewMode = 'graph' | 'detail'
 
-interface DomainDetailPageProps {readonly graph: RiviereGraph}
+interface DomainDetailPageProps {
+  readonly graph: RiviereGraph
+  readonly theme?: Theme
+}
 
-export function DomainDetailPage({ graph }: DomainDetailPageProps): React.ReactElement {
+export function DomainDetailPage({
+  graph,
+  theme = DEFAULT_THEME,
+}: DomainDetailPageProps): React.ReactElement {
   const { domainId } = useParams<{ domainId: string }>()
 
   if (domainId === undefined) {
@@ -30,17 +36,23 @@ export function DomainDetailPage({ graph }: DomainDetailPageProps): React.ReactE
     return <DomainNotFound />
   }
 
-  return <DomainDetailContent domain={domain} />
+  return <DomainDetailContent domain={domain} theme={theme} />
 }
 
-interface DomainDetailContentProps {readonly domain: DomainDetails}
+interface DomainDetailContentProps {
+  readonly domain: DomainDetails
+  readonly theme: Theme
+}
 
-function DomainDetailContent({ domain }: DomainDetailContentProps): React.ReactElement {
+function DomainDetailContent({
+  domain,
+  theme,
+}: DomainDetailContentProps): React.ReactElement {
   const [viewMode, setViewMode] = useState<ViewMode>('detail')
   const tabRefs = useRef<Map<ViewMode, HTMLButtonElement | null>>(new Map())
 
   const [nodeSearch, setNodeSearch] = useState('')
-  const [nodeTypeFilter, setNodeTypeFilter] = useState<NodeTypeFilter>('all')
+  const [nodeTypeFilter, setNodeTypeFilter] = useState('all')
   const [entitySearch, setEntitySearch] = useState('')
   const [eventSearch, setEventSearch] = useState('')
 
@@ -88,7 +100,7 @@ function DomainDetailContent({ domain }: DomainDetailContentProps): React.ReactE
       />
 
       {viewMode === 'graph' ? (
-        <div data-testid="graph-panel">
+        <div data-testid="graph-panel" className="h-[min(70vh,720px)] min-h-[500px]">
           <DomainContextGraph domainId={domain.id} connections={domain.aggregatedConnections} />
         </div>
       ) : (
@@ -102,6 +114,7 @@ function DomainDetailContent({ domain }: DomainDetailContentProps): React.ReactE
           setEntitySearch={setEntitySearch}
           eventSearch={eventSearch}
           setEventSearch={setEventSearch}
+          theme={theme}
         />
       )}
     </div>

--- a/apps/eclair/src/features/domains/queries/domain-node-breakdown.spec.ts
+++ b/apps/eclair/src/features/domains/queries/domain-node-breakdown.spec.ts
@@ -31,18 +31,10 @@ function createNode(overrides: Partial<RawNode> = {}): ReturnType<typeof parseNo
 
 describe('domainNodeBreakdown', () => {
   describe('countNodesByType', () => {
-    it('returns zero counts for all types with empty array', () => {
+    it('returns no type buckets for an empty array', () => {
       const result = countNodesByType([])
 
-      const expected: NodeBreakdown = {
-        UI: 0,
-        API: 0,
-        UseCase: 0,
-        DomainOp: 0,
-        Event: 0,
-        EventHandler: 0,
-        Custom: 0,
-      }
+      const expected: NodeBreakdown = {}
       expect(result).toStrictEqual(expected)
     })
 
@@ -92,7 +84,7 @@ describe('domainNodeBreakdown', () => {
         DomainOp: 1,
         Event: 1,
         EventHandler: 1,
-        Custom: 1,
+        TestCustomType: 1,
       })
     })
 
@@ -115,7 +107,7 @@ describe('domainNodeBreakdown', () => {
       const result = countNodesByType(nodes)
 
       expect(result.API).toBe(3)
-      expect(result.UI).toBe(0)
+      expect(result.UI).toBeUndefined()
     })
 
     it('handles mixed node types', () => {
@@ -152,7 +144,6 @@ describe('domainNodeBreakdown', () => {
         API: 2,
         Event: 1,
         EventHandler: 1,
-        UseCase: 0,
       })
     })
   })
@@ -215,7 +206,7 @@ describe('domainNodeBreakdown', () => {
       expect(result[0]?.location).toBe('src/api/orders.ts')
     })
 
-    it('sorts by type priority (UI, API, UseCase, DomainOp, Event, EventHandler, Custom)', () => {
+    it('sorts built-ins by type priority and then declared custom types', () => {
       const nodes = [
         createNode({
           id: 'handler-1',
@@ -262,7 +253,7 @@ describe('domainNodeBreakdown', () => {
         'DomainOp',
         'Event',
         'EventHandler',
-        'Custom',
+        'TestCustomType',
       ])
     })
 

--- a/apps/eclair/src/features/domains/queries/domain-node-breakdown.ts
+++ b/apps/eclair/src/features/domains/queries/domain-node-breakdown.ts
@@ -1,48 +1,32 @@
-import type { SourceLocation } from '@living-architecture/riviere-schema'
-import {
-  entryPointSchema, type Node, type NodeType 
-} from '@/platform/domain/eclair-types'
+import type * as RiviereSchema from '@living-architecture/riviere-schema'
+import * as EclairDomain from '@/platform/domain/eclair-types'
+import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
 
 export interface DomainNode {
   id: string
-  type: NodeType
+  type: string
+  typeDescription?: string
   name: string
   location: string | undefined
-  sourceLocation: SourceLocation | undefined
+  sourceLocation: RiviereSchema.SourceLocation | undefined
 }
 
-export interface NodeBreakdown {
-  UI: number
-  API: number
-  UseCase: number
-  DomainOp: number
-  Event: number
-  EventHandler: number
-  Custom: number
-}
+export type NodeBreakdown = Record<string, number>
 
-const NODE_TYPE_PRIORITY: Record<NodeType, number> = {
+const NODE_TYPE_PRIORITY: Readonly<Record<string, number>> = {
   UI: 1,
   API: 2,
   UseCase: 3,
   DomainOp: 4,
   Event: 5,
   EventHandler: 6,
-  Custom: 7,
 }
 
-export function countNodesByType(nodes: Node[]): NodeBreakdown {
-  const breakdown: NodeBreakdown = {
-    UI: 0,
-    API: 0,
-    UseCase: 0,
-    DomainOp: 0,
-    Event: 0,
-    EventHandler: 0,
-    Custom: 0,
-  }
+export function countNodesByType(nodes: EclairDomain.Node[]): NodeBreakdown {
+  const breakdown: NodeBreakdown = {}
   for (const node of nodes) {
-    breakdown[node.type]++
+    const type = getEffectiveNodeType(node)
+    breakdown[type] = (breakdown[type] ?? 0) + 1
   }
   return breakdown
 }
@@ -54,25 +38,43 @@ function formatLocation(filePath: string, lineNumber: number | undefined): strin
   return filePath
 }
 
-export function formatDomainNodes(nodes: Node[]): DomainNode[] {
+export function formatDomainNodes(
+  nodes: EclairDomain.Node[],
+  customTypes: Record<string, RiviereSchema.CustomTypeDefinition> | undefined = undefined,
+): DomainNode[] {
   return nodes
-    .map((node) => ({
-      id: node.id,
-      type: node.type,
-      name: node.name,
-      location: formatLocation(node.sourceLocation.filePath, node.sourceLocation.lineNumber),
-      sourceLocation: node.sourceLocation,
-    }))
-    .sort((a, b) => NODE_TYPE_PRIORITY[a.type] - NODE_TYPE_PRIORITY[b.type])
+    .map((node) => {
+      const typeDescription =
+        node.type === 'Custom' ? customTypes?.[node.customTypeName]?.description : undefined
+      return {
+        id: node.id,
+        type: getEffectiveNodeType(node),
+        ...(typeDescription === undefined ? {} : { typeDescription }),
+        name: node.name,
+        location: formatLocation(node.sourceLocation.filePath, node.sourceLocation.lineNumber),
+        sourceLocation: node.sourceLocation,
+      }
+    })
+    .sort((a, b) => {
+      const priorityDifference =
+        (NODE_TYPE_PRIORITY[a.type] ?? Number.MAX_SAFE_INTEGER) -
+        (NODE_TYPE_PRIORITY[b.type] ?? Number.MAX_SAFE_INTEGER)
+      if (priorityDifference !== 0) return priorityDifference
+      const typeOrder = a.type.localeCompare(b.type)
+      if (typeOrder !== 0) return typeOrder
+      return a.name.localeCompare(b.name)
+    })
 }
 
-export function extractEntryPoints(nodes: Node[]): ReturnType<typeof entryPointSchema.parse>[] {
-  const entryPoints: ReturnType<typeof entryPointSchema.parse>[] = []
+export function extractEntryPoints(
+  nodes: EclairDomain.Node[],
+): ReturnType<typeof EclairDomain.entryPointSchema.parse>[] {
+  const entryPoints: ReturnType<typeof EclairDomain.entryPointSchema.parse>[] = []
   for (const node of nodes) {
     if (node.type === 'UI') {
-      entryPoints.push(entryPointSchema.parse(node.route))
+      entryPoints.push(EclairDomain.entryPointSchema.parse(node.route))
     } else if (node.type === 'API' && node.path !== undefined) {
-      entryPoints.push(entryPointSchema.parse(node.path))
+      entryPoints.push(EclairDomain.entryPointSchema.parse(node.path))
     }
   }
   return entryPoints

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.advanced.spec.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.advanced.spec.ts
@@ -420,6 +420,7 @@ describe('extractDomainDetails - advanced tests', () => {
         direction: 'outgoing',
         apiCount: 1,
         eventCount: 1,
+        relationshipCount: 2,
       })
     })
 
@@ -467,6 +468,7 @@ describe('extractDomainDetails - advanced tests', () => {
         direction: 'incoming',
         apiCount: 1,
         eventCount: 0,
+        relationshipCount: 1,
       })
     })
 

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.spec.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.spec.ts
@@ -155,7 +155,7 @@ describe('extractDomainDetails', () => {
       })
     })
 
-    it('sorts nodes by type priority (UI, API, UseCase, DomainOp, Event, EventHandler, Custom)', () => {
+    it('sorts built-in nodes by type priority', () => {
       const graph = createMinimalGraph({
         metadata: {
           domains: parseDomainMetadata({
@@ -487,10 +487,6 @@ describe('extractDomainDetails', () => {
         UI: 1,
         API: 2,
         UseCase: 1,
-        DomainOp: 0,
-        Event: 0,
-        EventHandler: 0,
-        Custom: 0,
       })
     })
   })

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.ts
@@ -25,6 +25,7 @@ export interface AggregatedConnection {
   direction: 'incoming' | 'outgoing'
   apiCount: number
   eventCount: number
+  relationshipCount: number
 }
 
 interface KnownSourceEventInfo {
@@ -116,7 +117,7 @@ export function extractDomainDetails(
   const domainNodes = graph.components.filter((n) => n.domain === domainId)
 
   const breakdown = countNodesByType(domainNodes)
-  const nodes = formatDomainNodes(domainNodes)
+  const nodes = formatDomainNodes(domainNodes, graph.metadata.customTypes)
   const entities = query.entities(domainId)
 
   const queryPublished = query.publishedEvents(domainId)
@@ -166,7 +167,7 @@ export function extractDomainDetails(
   }
 
   const crossDomainEdges = buildCrossDomainEdges(graph, domainId)
-  const aggregatedConnections = query.domainConnections(domainId)
+  const aggregatedConnections = buildAggregatedConnections(graph, domainId)
   const entryPoints = extractEntryPoints(domainNodes)
 
   const repository = domainNodes.find((node) => node.sourceLocation?.repository)?.sourceLocation
@@ -185,4 +186,41 @@ export function extractDomainDetails(
     entryPoints,
     repository,
   }
+}
+
+function buildAggregatedConnections(graph: RiviereGraph, domainId: string): AggregatedConnection[] {
+  const componentById = new Map(graph.components.map((component) => [component.id, component]))
+  const connections = new Map<string, AggregatedConnection>()
+
+  for (const link of graph.links) {
+    const source = componentById.get(link.source)
+    const target = componentById.get(link.target)
+    if (source === undefined || target === undefined || source.domain === target.domain) continue
+
+    const isOutgoing = source.domain === domainId
+    const isIncoming = target.domain === domainId
+    if (!isOutgoing && !isIncoming) continue
+
+    const direction = isOutgoing ? 'outgoing' : 'incoming'
+    const targetDomain = isOutgoing ? target.domain : source.domain
+    const key = `${direction}:${targetDomain}`
+    const existing = connections.get(key) ?? {
+      targetDomain,
+      direction,
+      apiCount: 0,
+      eventCount: 0,
+      relationshipCount: 0,
+    }
+
+    existing.relationshipCount += 1
+    if (target.type === 'API') existing.apiCount += 1
+    if (target.type === 'EventHandler') existing.eventCount += 1
+    connections.set(key, existing)
+  }
+
+  return [...connections.values()].sort((left, right) => {
+    const domainOrder = compareByCodePoint(left.targetDomain, right.targetDomain)
+    if (domainOrder !== 0) return domainOrder
+    return compareByCodePoint(left.direction, right.direction)
+  })
 }

--- a/apps/eclair/src/features/flows/components/FlowCard/FlowCard.spec.tsx
+++ b/apps/eclair/src/features/flows/components/FlowCard/FlowCard.spec.tsx
@@ -186,7 +186,7 @@ describe('FlowCard', () => {
   })
 
   describe('header', () => {
-    it('renders header with flow-item-header class', () => {
+    it('renders the expandable header as a dedicated toggle', () => {
       render(
         <FlowCard
           flow={createTestFlow()}
@@ -196,7 +196,9 @@ describe('FlowCard', () => {
         />,
       )
 
-      expect(screen.getByTestId('flow-card-header')).toHaveClass('flow-item-header')
+      const toggle = screen.getByTestId('flow-card-header')
+      expect(toggle).toHaveClass('flow-item-toggle')
+      expect(toggle.querySelector('button')).not.toBeInTheDocument()
     })
 
     it('renders left section with flow-item-left class', () => {
@@ -314,6 +316,8 @@ describe('FlowCard', () => {
 
       const graphBtn = screen.getByTitle('View on Full Graph')
       expect(graphBtn).toHaveClass('graph-link-btn')
+      expect(graphBtn).toHaveAccessibleName('View on Full Graph')
+      expect(screen.queryByText('View on Graph')).not.toBeInTheDocument()
     })
 
     it('navigates to full graph with node param when View on Graph clicked', async () => {

--- a/apps/eclair/src/features/flows/components/FlowCard/FlowCard.tsx
+++ b/apps/eclair/src/features/flows/components/FlowCard/FlowCard.tsx
@@ -33,23 +33,31 @@ export function FlowCard({
 
   return (
     <div data-testid="flow-card" className="flow-item">
-      <button
-        type="button"
-        data-testid="flow-card-header"
-        onClick={onToggle}
-        className="flow-item-header"
-      >
-        <div data-testid="flow-item-left" className="flow-item-left">
-          <NodeTypeBadge
-            type={entryPoint.type}
-            description={getNodeTypeDescription(graph, entryPoint.type)}
-            theme={theme}
+      <div className="flow-item-header">
+        <button
+          type="button"
+          data-testid="flow-card-header"
+          onClick={onToggle}
+          className="flow-item-toggle"
+          aria-expanded={expanded}
+        >
+          <div data-testid="flow-item-left" className="flow-item-left">
+            <NodeTypeBadge
+              type={entryPoint.type}
+              description={getNodeTypeDescription(graph, entryPoint.type)}
+              theme={theme}
+            />
+            <span className="flow-item-title" title={entryPoint.name}>
+              {entryPoint.name}
+            </span>
+            <span className="flow-item-domain">{entryPoint.domain}</span>
+          </div>
+          <i
+            data-testid="flow-card-chevron"
+            className={`ph ph-caret-down flow-item-chevron ${expanded ? 'rotate-180' : ''}`}
+            aria-hidden="true"
           />
-          <span className="flow-item-title" title={entryPoint.name}>
-            {entryPoint.name}
-          </span>
-          <span className="flow-item-domain">{entryPoint.domain}</span>
-        </div>
+        </button>
         <div data-testid="flow-item-actions" className="flow-item-actions">
           {entryPoint.sourceLocation?.lineNumber !== undefined && (
             <CodeLinkMenu
@@ -62,18 +70,13 @@ export function FlowCard({
             type="button"
             className="graph-link-btn"
             title="View on Full Graph"
+            aria-label="View on Full Graph"
             onClick={handleViewOnGraph}
           >
             <i className="ph ph-graph" aria-hidden="true" />
-            View on Graph
           </button>
-          <i
-            data-testid="flow-card-chevron"
-            className={`ph ph-caret-down text-[var(--text-tertiary)] transition-transform ${expanded ? 'rotate-180' : ''}`}
-            aria-hidden="true"
-          />
         </div>
-      </button>
+      </div>
       {expanded && <FlowTrace steps={flow.steps} graph={graph} theme={theme} />}
     </div>
   )

--- a/apps/eclair/src/features/flows/components/FlowCard/FlowCard.tsx
+++ b/apps/eclair/src/features/flows/components/FlowCard/FlowCard.tsx
@@ -4,12 +4,16 @@ import type { Flow } from '../../queries/extract-flows'
 import { CodeLinkMenu } from '@/platform/infra/ui/CodeLinkMenu/CodeLinkMenu'
 import { FlowTrace } from '../FlowTrace/FlowTrace'
 import { NodeTypeBadge } from '@/platform/infra/ui/NodeTypeBadge/NodeTypeBadge'
+import { getNodeTypeDescription } from '@/platform/domain/node-type-presentation'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
 interface FlowCardProps {
   readonly flow: Flow
   readonly graph: RiviereGraph
   readonly expanded: boolean
   readonly onToggle: () => void
+  readonly theme?: Theme
 }
 
 export function FlowCard({
@@ -17,6 +21,7 @@ export function FlowCard({
   graph,
   expanded,
   onToggle,
+  theme = DEFAULT_THEME,
 }: Readonly<FlowCardProps>): React.ReactElement {
   const navigate = useNavigate()
   const { entryPoint } = flow
@@ -35,7 +40,11 @@ export function FlowCard({
         className="flow-item-header"
       >
         <div data-testid="flow-item-left" className="flow-item-left">
-          <NodeTypeBadge type={entryPoint.type} />
+          <NodeTypeBadge
+            type={entryPoint.type}
+            description={getNodeTypeDescription(graph, entryPoint.type)}
+            theme={theme}
+          />
           <span className="flow-item-title" title={entryPoint.name}>
             {entryPoint.name}
           </span>
@@ -65,7 +74,7 @@ export function FlowCard({
           />
         </div>
       </button>
-      {expanded && <FlowTrace steps={flow.steps} graph={graph} />}
+      {expanded && <FlowTrace steps={flow.steps} graph={graph} theme={theme} />}
     </div>
   )
 }

--- a/apps/eclair/src/features/flows/components/FlowTrace/FlowGraphView.tsx
+++ b/apps/eclair/src/features/flows/components/FlowTrace/FlowGraphView.tsx
@@ -1,16 +1,18 @@
 import {
   useMemo, useState, useCallback, useRef 
 } from 'react'
-import { useTheme } from '@/platform/infra/theme/ThemeContext'
 import { ForceGraph } from '@/platform/infra/graph/ForceGraph/ForceGraph'
 import { GraphTooltip } from '@/platform/infra/graph/GraphTooltip/GraphTooltip'
 import type { TooltipData } from '@/platform/infra/graph/graph-types'
 import type { FlowStep } from '../../queries/extract-flows'
 import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
 interface FlowGraphViewProps {
   readonly steps: readonly FlowStep[]
   readonly graph: RiviereGraph
+  readonly theme?: Theme
 }
 
 function extractSubgraph(steps: FlowStep[], graph: RiviereGraph): RiviereGraph {
@@ -29,9 +31,8 @@ function extractSubgraph(steps: FlowStep[], graph: RiviereGraph): RiviereGraph {
 }
 
 export function FlowGraphView({
-  steps, graph 
+  steps, graph, theme = DEFAULT_THEME,
 }: Readonly<FlowGraphViewProps>): React.ReactElement {
-  const { theme } = useTheme()
   const subgraph = useMemo(() => extractSubgraph(steps, graph), [steps, graph])
   const [tooltipData, setTooltipData] = useState<TooltipData | null>(null)
   const tooltipHideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)

--- a/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.spec.tsx
+++ b/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.spec.tsx
@@ -191,6 +191,14 @@ describe('FlowTrace', () => {
   })
 
   describe('step circles', () => {
+    it('labels the module, domain, and type metadata', () => {
+      render(<FlowTrace steps={createTestSteps()} graph={createTestGraph()} />)
+
+      expect(screen.getAllByText('Module')).toHaveLength(4)
+      expect(screen.getAllByText('Domain')).toHaveLength(4)
+      expect(screen.getAllByText('Type')).toHaveLength(4)
+    })
+
     it('renders step circles with flow-step-circle class', () => {
       render(<FlowTrace steps={createTestSteps()} graph={createTestGraph()} />)
 
@@ -254,9 +262,11 @@ describe('FlowTrace', () => {
     })
 
     it('renders step metadata with flow-step-meta class', () => {
-      render(<FlowTrace steps={createTestSteps()} graph={createTestGraph()} />)
+      const { container } = render(
+        <FlowTrace steps={createTestSteps()} graph={createTestGraph()} />,
+      )
 
-      expect(screen.getByText('ui · checkout · UI')).toHaveClass('flow-step-meta')
+      expect(container.querySelectorAll('.flow-step-meta')).toHaveLength(4)
     })
 
     it('displays title attribute with full node name for tooltip', () => {

--- a/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
+++ b/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
@@ -1,32 +1,36 @@
 import { useState } from 'react'
 import type { FlowStep } from '../../queries/extract-flows'
 import type { RiviereGraph } from '@living-architecture/riviere-schema'
-import type { NodeType } from '@/platform/domain/eclair-types'
 import { FlowGraphView } from './FlowGraphView'
+import { getNodeTypeColor } from '@/platform/domain/node-type-presentation'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
 type ViewMode = 'waterfall' | 'graph'
 
 interface FlowTraceProps {
   readonly steps: readonly FlowStep[]
   readonly graph: RiviereGraph
+  readonly theme?: Theme
 }
 
-function getCircleTypeClass(nodeType: NodeType): string {
-  const typeClassMap: Record<NodeType, string> = {
-    UI: 'flow-step-circle-ui',
-    API: 'flow-step-circle-api',
-    UseCase: 'flow-step-circle-usecase',
-    DomainOp: 'flow-step-circle-domainop',
-    Event: 'flow-step-circle-event',
-    EventHandler: 'flow-step-circle-eventhandler',
-    Custom: 'flow-step-circle-custom',
-    External: 'flow-step-circle-external',
-  }
-  return typeClassMap[nodeType]
+const CIRCLE_CLASSES: Readonly<Record<string, string>> = {
+  UI: 'flow-step-circle-ui',
+  API: 'flow-step-circle-api',
+  UseCase: 'flow-step-circle-usecase',
+  DomainOp: 'flow-step-circle-domainop',
+  Event: 'flow-step-circle-event',
+  EventHandler: 'flow-step-circle-eventhandler',
+  Custom: 'flow-step-circle-custom',
+  External: 'flow-step-circle-external',
+}
+
+function getCircleTypeClass(type: string): string {
+  return CIRCLE_CLASSES[type] ?? 'flow-step-circle-custom'
 }
 
 export function FlowTrace({
-  steps, graph 
+  steps, graph, theme = DEFAULT_THEME,
 }: Readonly<FlowTraceProps>): React.ReactElement {
   const [viewMode, setViewMode] = useState<ViewMode>('waterfall')
 
@@ -65,7 +69,10 @@ export function FlowTrace({
           {steps.map((step, index) => (
             <div key={step.node.id}>
               <div className="flow-step">
-                <div className={`flow-step-circle ${getCircleTypeClass(step.node.type)}`}>
+                <div
+                  className={`flow-step-circle ${getCircleTypeClass(step.node.type)}`}
+                  style={{ backgroundColor: getNodeTypeColor(step.node.type, theme) }}
+                >
                   {index + 1}
                 </div>
                 <div className="flow-step-content">
@@ -106,7 +113,7 @@ export function FlowTrace({
 
       {viewMode === 'graph' && (
         <div data-testid="flow-graph-view" className="flow-graph-view">
-          <FlowGraphView steps={steps} graph={graph} />
+          <FlowGraphView steps={steps} graph={graph} theme={theme} />
         </div>
       )}
     </div>

--- a/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
+++ b/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
@@ -79,9 +79,20 @@ export function FlowTrace({
                   <div className="flow-step-name" title={step.node.name}>
                     {step.node.name}
                   </div>
-                  <div className="flow-step-meta">
-                    {step.node.module} · {step.node.domain} · {step.node.type}
-                  </div>
+                  <dl className="flow-step-meta">
+                    <div className="flow-step-meta-item">
+                      <dt>Module</dt>
+                      <dd>{step.node.module}</dd>
+                    </div>
+                    <div className="flow-step-meta-item">
+                      <dt>Domain</dt>
+                      <dd>{step.node.domain}</dd>
+                    </div>
+                    <div className="flow-step-meta-item">
+                      <dt>Type</dt>
+                      <dd>{step.node.type}</dd>
+                    </div>
+                  </dl>
                   {step.node.subscribedEvents !== undefined &&
                     step.node.subscribedEvents.length > 0 && (
                     <div className="flow-step-subscribed-events">

--- a/apps/eclair/src/features/flows/entrypoint/FlowsPage.spec.tsx
+++ b/apps/eclair/src/features/flows/entrypoint/FlowsPage.spec.tsx
@@ -195,6 +195,41 @@ describe('FlowsPage', () => {
       expect(screen.getByText('Daily Report')).toBeInTheDocument()
     })
 
+    it('filters a declared custom type named all independently from the All filter', async () => {
+      const user = userEvent.setup()
+      const graph = createTestGraph()
+      const graphWithAllType: RiviereGraph = {
+        ...graph,
+        components: graph.components.map((component) =>
+          component.id === 'job-1'
+            ? parseNode({
+              sourceLocation: testSourceLocation,
+              id: 'job-1',
+              type: 'Custom',
+              name: 'Daily Report',
+              domain: 'reporting',
+              module: 'jobs',
+              customTypeName: 'all',
+            })
+            : component,
+        ),
+      }
+
+      renderWithRouter(graphWithAllType)
+
+      expect(screen.getByTestId('stat-all')).toHaveTextContent('1')
+      await user.click(
+        screen.getByRole('button', {
+          name: 'all',
+          exact: true,
+        }),
+      )
+
+      expect(screen.queryByText('Order Form')).not.toBeInTheDocument()
+      expect(screen.queryByText('GET /health')).not.toBeInTheDocument()
+      expect(screen.getByText('Daily Report')).toBeInTheDocument()
+    })
+
     it('shows all flows when All filter selected', async () => {
       const user = userEvent.setup()
 

--- a/apps/eclair/src/features/flows/entrypoint/FlowsPage.spec.tsx
+++ b/apps/eclair/src/features/flows/entrypoint/FlowsPage.spec.tsx
@@ -118,29 +118,29 @@ describe('FlowsPage', () => {
       expect(totalValue).toHaveTextContent('3')
     })
 
-    it('renders UI Entries stat with icon and count', () => {
+    it('renders UI entry-point stat with icon and count', () => {
       renderWithRouter(createTestGraph())
 
-      expect(screen.getByText('UI Entries')).toHaveClass('stats-bar-label')
-      const uiValue = screen.getByTestId('stat-ui-entries')
+      expect(screen.getByText('UI entries')).toHaveClass('stats-bar-label')
+      const uiValue = screen.getByTestId('stat-UI')
       expect(uiValue).toHaveClass('stats-bar-value')
       expect(uiValue).toHaveTextContent('1')
     })
 
-    it('renders API Entries stat with icon and count', () => {
+    it('renders API entry-point stat with icon and count', () => {
       renderWithRouter(createTestGraph())
 
-      expect(screen.getByText('API Entries')).toHaveClass('stats-bar-label')
-      const apiValue = screen.getByTestId('stat-api-entries')
+      expect(screen.getByText('API entries')).toHaveClass('stats-bar-label')
+      const apiValue = screen.getByTestId('stat-API')
       expect(apiValue).toHaveClass('stats-bar-value')
       expect(apiValue).toHaveTextContent('1')
     })
 
-    it('renders Scheduled Jobs stat with icon and count', () => {
+    it('renders the declared custom entry-point type with icon and count', () => {
       renderWithRouter(createTestGraph())
 
-      expect(screen.getByText('Scheduled Jobs')).toHaveClass('stats-bar-label')
-      const jobsValue = screen.getByTestId('stat-scheduled-jobs')
+      expect(screen.getByText('ScheduledJob entries')).toHaveClass('stats-bar-label')
+      const jobsValue = screen.getByTestId('stat-ScheduledJob')
       expect(jobsValue).toHaveClass('stats-bar-value')
       expect(jobsValue).toHaveTextContent('1')
     })
@@ -183,12 +183,12 @@ describe('FlowsPage', () => {
       expect(screen.queryByText('Daily Report')).not.toBeInTheDocument()
     })
 
-    it('filters by Jobs type', async () => {
+    it('filters by the declared custom type', async () => {
       const user = userEvent.setup()
 
       renderWithRouter(createTestGraph())
 
-      await user.click(screen.getByRole('button', { name: 'Jobs' }))
+      await user.click(screen.getByRole('button', { name: 'ScheduledJob' }))
 
       expect(screen.queryByText('Order Form')).not.toBeInTheDocument()
       expect(screen.queryByText('GET /health')).not.toBeInTheDocument()

--- a/apps/eclair/src/features/flows/entrypoint/FlowsPage.tsx
+++ b/apps/eclair/src/features/flows/entrypoint/FlowsPage.tsx
@@ -3,9 +3,18 @@ import type { RiviereGraph } from '@living-architecture/riviere-schema'
 import { compareByCodePoint } from '../queries/compare-by-code-point'
 import { extractFlows } from '../queries/extract-flows'
 import { FlowCard } from '../components/FlowCard/FlowCard'
-import { useFlowsState } from '../hooks/useFlowsState'
+import {
+  type FlowTypeFilter,
+  useFlowsState,
+} from '../hooks/useFlowsState'
 import type { Theme } from '@/types/theme'
 import { DEFAULT_THEME } from '@/types/theme'
+
+function isActiveFilter(activeFilter: FlowTypeFilter, candidateFilter: FlowTypeFilter): boolean {
+  if (activeFilter.kind === 'all') return candidateFilter.kind === 'all'
+
+  return candidateFilter.kind === 'type' && activeFilter.value === candidateFilter.value
+}
 
 interface FlowsPageProps {
   readonly graph: RiviereGraph
@@ -40,7 +49,7 @@ export function FlowsPage({
 
       if (!matchesSearch) return false
 
-      if (activeFilter !== 'all' && flow.entryPoint.type !== activeFilter) return false
+      if (activeFilter.kind === 'type' && flow.entryPoint.type !== activeFilter.value) return false
 
       if (activeDomains.size > 0 && !activeDomains.has(flow.entryPoint.domain)) return false
 
@@ -59,14 +68,20 @@ export function FlowsPage({
   const filters: Array<{
     key: string
     label: string
+    filter: FlowTypeFilter
   }> = [
     {
-      key: 'all',
+      key: 'filter:all',
       label: 'All',
+      filter: { kind: 'all' },
     },
     ...typeCounts.map(([type]) => ({
-      key: type,
+      key: `type:${type}`,
       label: type,
+      filter: {
+        kind: 'type' as const,
+        value: type,
+      },
     })),
   ]
 
@@ -118,8 +133,8 @@ export function FlowsPage({
             <button
               key={filter.key}
               type="button"
-              className={`filter-tag ${activeFilter === filter.key ? 'active' : ''}`}
-              onClick={() => setActiveFilter(filter.key)}
+              className={`filter-tag ${isActiveFilter(activeFilter, filter.filter) ? 'active' : ''}`}
+              onClick={() => setActiveFilter(filter.filter)}
             >
               {filter.label}
             </button>

--- a/apps/eclair/src/features/flows/entrypoint/FlowsPage.tsx
+++ b/apps/eclair/src/features/flows/entrypoint/FlowsPage.tsx
@@ -3,13 +3,19 @@ import type { RiviereGraph } from '@living-architecture/riviere-schema'
 import { compareByCodePoint } from '../queries/compare-by-code-point'
 import { extractFlows } from '../queries/extract-flows'
 import { FlowCard } from '../components/FlowCard/FlowCard'
-import {
-  useFlowsState, type FlowFilter 
-} from '../hooks/useFlowsState'
+import { useFlowsState } from '../hooks/useFlowsState'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
-interface FlowsPageProps {readonly graph: RiviereGraph}
+interface FlowsPageProps {
+  readonly graph: RiviereGraph
+  readonly theme?: Theme
+}
 
-export function FlowsPage({ graph }: Readonly<FlowsPageProps>): React.ReactElement {
+export function FlowsPage({
+  graph,
+  theme = DEFAULT_THEME,
+}: Readonly<FlowsPageProps>): React.ReactElement {
   const {
     searchQuery,
     setSearchQuery,
@@ -34,9 +40,7 @@ export function FlowsPage({ graph }: Readonly<FlowsPageProps>): React.ReactEleme
 
       if (!matchesSearch) return false
 
-      if (activeFilter === 'ui' && flow.entryPoint.type !== 'UI') return false
-      if (activeFilter === 'api' && flow.entryPoint.type !== 'API') return false
-      if (activeFilter === 'jobs' && flow.entryPoint.type !== 'Custom') return false
+      if (activeFilter !== 'all' && flow.entryPoint.type !== activeFilter) return false
 
       if (activeDomains.size > 0 && !activeDomains.has(flow.entryPoint.domain)) return false
 
@@ -44,30 +48,26 @@ export function FlowsPage({ graph }: Readonly<FlowsPageProps>): React.ReactEleme
     })
   }, [flows, searchQuery, activeFilter, activeDomains])
 
-  const uiCount = flows.filter((f) => f.entryPoint.type === 'UI').length
-  const apiCount = flows.filter((f) => f.entryPoint.type === 'API').length
-  const jobsCount = flows.filter((f) => f.entryPoint.type === 'Custom').length
+  const typeCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const flow of flows) {
+      counts.set(flow.entryPoint.type, (counts.get(flow.entryPoint.type) ?? 0) + 1)
+    }
+    return [...counts.entries()].sort(([left], [right]) => left.localeCompare(right))
+  }, [flows])
 
   const filters: Array<{
-    key: FlowFilter
+    key: string
     label: string
   }> = [
     {
       key: 'all',
       label: 'All',
     },
-    {
-      key: 'ui',
-      label: 'UI',
-    },
-    {
-      key: 'api',
-      label: 'API',
-    },
-    {
-      key: 'jobs',
-      label: 'Jobs',
-    },
+    ...typeCounts.map(([type]) => ({
+      key: type,
+      label: type,
+    })),
   ]
 
   return (
@@ -87,33 +87,17 @@ export function FlowsPage({ graph }: Readonly<FlowsPageProps>): React.ReactEleme
             </div>
           </div>
         </div>
-        <div className="stats-bar-item">
-          <i className="ph ph-browser stats-bar-icon" aria-hidden="true" />
-          <div className="stats-bar-content">
-            <div className="stats-bar-label">UI Entries</div>
-            <div data-testid="stat-ui-entries" className="stats-bar-value">
-              {uiCount}
+        {typeCounts.map(([type, count]) => (
+          <div key={type} className="stats-bar-item">
+            <i className="ph ph-cube stats-bar-icon" aria-hidden="true" />
+            <div className="stats-bar-content">
+              <div className="stats-bar-label">{type} entries</div>
+              <div data-testid={`stat-${type}`} className="stats-bar-value">
+                {count}
+              </div>
             </div>
           </div>
-        </div>
-        <div className="stats-bar-item">
-          <i className="ph ph-plug stats-bar-icon" aria-hidden="true" />
-          <div className="stats-bar-content">
-            <div className="stats-bar-label">API Entries</div>
-            <div data-testid="stat-api-entries" className="stats-bar-value">
-              {apiCount}
-            </div>
-          </div>
-        </div>
-        <div className="stats-bar-item">
-          <i className="ph ph-clock stats-bar-icon" aria-hidden="true" />
-          <div className="stats-bar-content">
-            <div className="stats-bar-label">Scheduled Jobs</div>
-            <div data-testid="stat-scheduled-jobs" className="stats-bar-value">
-              {jobsCount}
-            </div>
-          </div>
-        </div>
+        ))}
       </div>
 
       <div className="filters-section">
@@ -169,6 +153,7 @@ export function FlowsPage({ graph }: Readonly<FlowsPageProps>): React.ReactEleme
             graph={graph}
             expanded={expandedFlowIds.has(flow.entryPoint.id)}
             onToggle={() => toggleFlow(flow.entryPoint.id)}
+            theme={theme}
           />
         ))}
       </section>

--- a/apps/eclair/src/features/flows/hooks/useFlowsState.spec.ts
+++ b/apps/eclair/src/features/flows/hooks/useFlowsState.spec.ts
@@ -29,17 +29,23 @@ describe('useFlowsState', () => {
     it('initializes with all filter', () => {
       const { result } = renderHook(() => useFlowsState())
 
-      expect(result.current.activeFilter).toBe('all')
+      expect(result.current.activeFilter).toStrictEqual({ kind: 'all' })
     })
 
     it('updates active filter', () => {
       const { result } = renderHook(() => useFlowsState())
 
       act(() => {
-        result.current.setActiveFilter('api')
+        result.current.setActiveFilter({
+          kind: 'type',
+          value: 'api',
+        })
       })
 
-      expect(result.current.activeFilter).toBe('api')
+      expect(result.current.activeFilter).toStrictEqual({
+        kind: 'type',
+        value: 'api',
+      })
     })
   })
 

--- a/apps/eclair/src/features/flows/hooks/useFlowsState.ts
+++ b/apps/eclair/src/features/flows/hooks/useFlowsState.ts
@@ -2,11 +2,18 @@ import {
   useState, useCallback 
 } from 'react'
 
+export type FlowTypeFilter =
+  | { readonly kind: 'all' }
+  | {
+    readonly kind: 'type'
+    readonly value: string
+  }
+
 interface FlowsState {
   searchQuery: string
   setSearchQuery: (query: string) => void
-  activeFilter: string
-  setActiveFilter: (filter: string) => void
+  activeFilter: FlowTypeFilter
+  setActiveFilter: (filter: FlowTypeFilter) => void
   expandedFlowIds: Set<string>
   toggleFlow: (flowId: string) => void
   activeDomains: Set<string>
@@ -15,7 +22,7 @@ interface FlowsState {
 
 export function useFlowsState(): FlowsState {
   const [searchQuery, setSearchQuery] = useState('')
-  const [activeFilter, setActiveFilter] = useState('all')
+  const [activeFilter, setActiveFilter] = useState<FlowTypeFilter>({ kind: 'all' })
   const [expandedFlowIds, setExpandedFlowIds] = useState<Set<string>>(new Set())
   const [activeDomains, setActiveDomains] = useState<Set<string>>(new Set())
 

--- a/apps/eclair/src/features/flows/hooks/useFlowsState.ts
+++ b/apps/eclair/src/features/flows/hooks/useFlowsState.ts
@@ -2,13 +2,11 @@ import {
   useState, useCallback 
 } from 'react'
 
-export type FlowFilter = 'all' | 'ui' | 'api' | 'jobs'
-
 interface FlowsState {
   searchQuery: string
   setSearchQuery: (query: string) => void
-  activeFilter: FlowFilter
-  setActiveFilter: (filter: FlowFilter) => void
+  activeFilter: string
+  setActiveFilter: (filter: string) => void
   expandedFlowIds: Set<string>
   toggleFlow: (flowId: string) => void
   activeDomains: Set<string>
@@ -17,7 +15,7 @@ interface FlowsState {
 
 export function useFlowsState(): FlowsState {
   const [searchQuery, setSearchQuery] = useState('')
-  const [activeFilter, setActiveFilter] = useState<FlowFilter>('all')
+  const [activeFilter, setActiveFilter] = useState('all')
   const [expandedFlowIds, setExpandedFlowIds] = useState<Set<string>>(new Set())
   const [activeDomains, setActiveDomains] = useState<Set<string>>(new Set())
 

--- a/apps/eclair/src/features/flows/queries/extract-flows.spec.ts
+++ b/apps/eclair/src/features/flows/queries/extract-flows.spec.ts
@@ -194,7 +194,7 @@ describe('extractFlows', () => {
     expect(flows).toHaveLength(2)
   })
 
-  it('includes Custom nodes as entry points', () => {
+  it('includes declared custom types as entry points', () => {
     const graph: RiviereGraph = {
       version: '1.0',
       metadata: {
@@ -222,7 +222,7 @@ describe('extractFlows', () => {
     const flows = extractFlows(graph)
 
     expect(flows).toHaveLength(1)
-    expect(flows[0]?.entryPoint.type).toBe('Custom')
+    expect(flows[0]?.entryPoint.type).toBe('ScheduledJob')
   })
 
   it('preserves httpMethod and path for API entry points', () => {

--- a/apps/eclair/src/features/flows/queries/extract-flows.ts
+++ b/apps/eclair/src/features/flows/queries/extract-flows.ts
@@ -9,11 +9,11 @@ import type {
   RiviereGraph,
   SourceLocation,
 } from '@living-architecture/riviere-schema'
-import type { NodeType } from '@/platform/domain/eclair-types'
+import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
 
 export interface EntryPoint {
   id: string
-  type: NodeType
+  type: string
   name: string
   domain: string
   module?: string
@@ -24,7 +24,7 @@ export interface EntryPoint {
 
 export interface FlowStepNode {
   id: string
-  type: NodeType
+  type: string
   name: string
   module: string
   domain: string
@@ -46,7 +46,7 @@ export interface Flow {
 function componentToFlowStepNode(component: Component): FlowStepNode {
   const node: FlowStepNode = {
     id: component.id,
-    type: component.type,
+    type: getEffectiveNodeType(component),
     name: component.name,
     module: component.module,
     domain: component.domain,
@@ -76,7 +76,7 @@ function adaptFlow(queryFlow: QueryFlow): Flow {
 
   const entryPoint: EntryPoint = {
     id: component.id,
-    type: component.type,
+    type: getEffectiveNodeType(component),
     name: component.name,
     domain: component.domain,
     module: component.module,

--- a/apps/eclair/src/features/full-graph/components/DomainFilters/DomainFilters.tsx
+++ b/apps/eclair/src/features/full-graph/components/DomainFilters/DomainFilters.tsx
@@ -100,7 +100,12 @@ export function DomainFilters({
                     className="h-4 w-4 rounded border-[var(--border-color)] accent-[var(--primary)]"
                     data-testid={`domain-checkbox-${domain.name}`}
                   />
-                  <span className="flex-1 text-sm text-[var(--text-primary)]">{domain.name}</span>
+                  <span
+                    className="min-w-0 flex-1 break-words text-sm leading-tight text-[var(--text-primary)]"
+                    title={domain.name}
+                  >
+                    {domain.name}
+                  </span>
                   <span className="text-xs text-[var(--text-tertiary)]">{domain.nodeCount}</span>
                 </label>
               )

--- a/apps/eclair/src/features/full-graph/components/NodeTypeFilters/NodeTypeFilters.tsx
+++ b/apps/eclair/src/features/full-graph/components/NodeTypeFilters/NodeTypeFilters.tsx
@@ -110,7 +110,12 @@ export function NodeTypeFilters({
                     style={{ backgroundColor: getNodeTypeColor(nodeType.type, theme) }}
                     aria-hidden="true"
                   />
-                  <span className="flex-1 text-sm text-[var(--text-primary)]">{nodeType.type}</span>
+                  <span
+                    className="min-w-0 flex-1 break-words text-sm leading-tight text-[var(--text-primary)]"
+                    title={nodeType.type}
+                  >
+                    {nodeType.type}
+                  </span>
                   <span className="text-xs text-[var(--text-tertiary)]">{nodeType.nodeCount}</span>
                 </label>
               )

--- a/apps/eclair/src/features/full-graph/components/NodeTypeFilters/NodeTypeFilters.tsx
+++ b/apps/eclair/src/features/full-graph/components/NodeTypeFilters/NodeTypeFilters.tsx
@@ -1,19 +1,22 @@
 import {
   useState, useCallback 
 } from 'react'
-import type { NodeType } from '@/platform/domain/eclair-types'
+import { getNodeTypeColor } from '@/platform/domain/node-type-presentation'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
 interface NodeTypeInfo {
-  readonly type: NodeType
+  readonly type: string
   readonly nodeCount: number
 }
 
 interface NodeTypeFiltersProps {
   readonly nodeTypes: readonly NodeTypeInfo[]
-  readonly visibleTypes: Set<NodeType>
-  readonly onToggleType: (type: NodeType) => void
+  readonly visibleTypes: Set<string>
+  readonly onToggleType: (type: string) => void
   readonly onShowAll: () => void
   readonly onHideAll: () => void
+  readonly theme?: Theme
 }
 
 export function NodeTypeFilters({
@@ -22,6 +25,7 @@ export function NodeTypeFilters({
   onToggleType,
   onShowAll,
   onHideAll,
+  theme = DEFAULT_THEME,
 }: Readonly<NodeTypeFiltersProps>): React.ReactElement {
   const [isOpen, setIsOpen] = useState(true)
 
@@ -100,6 +104,11 @@ export function NodeTypeFilters({
                     onChange={() => onToggleType(nodeType.type)}
                     className="h-4 w-4 rounded border-[var(--border-color)] accent-[var(--primary)]"
                     data-testid={`node-type-checkbox-${nodeType.type}`}
+                  />
+                  <span
+                    className="h-3 w-3 shrink-0 rounded-full"
+                    style={{ backgroundColor: getNodeTypeColor(nodeType.type, theme) }}
+                    aria-hidden="true"
                   />
                   <span className="flex-1 text-sm text-[var(--text-primary)]">{nodeType.type}</span>
                   <span className="text-xs text-[var(--text-tertiary)]">{nodeType.nodeCount}</span>

--- a/apps/eclair/src/features/full-graph/domain/graph-focusing/filterByNodeType.ts
+++ b/apps/eclair/src/features/full-graph/domain/graph-focusing/filterByNodeType.ts
@@ -1,6 +1,9 @@
-import type {
-  Node, Edge, NodeType, NodeId 
-} from '@/platform/domain/eclair-types'
+import type * as EclairTypes from '@/platform/domain/eclair-types'
+import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
+
+type Node = EclairTypes.Node
+type Edge = EclairTypes.Edge
+type NodeId = EclairTypes.NodeId
 
 export interface FilteredGraph {
   nodes: Node[]
@@ -102,9 +105,6 @@ function processEdgeForRewiring(
     if (originalEdge.type !== undefined) {
       rewiredEdge.type = originalEdge.type
     }
-    if (originalEdge.type !== undefined) {
-      rewiredEdge.type = originalEdge.type
-    }
     rewiredEdges.push(rewiredEdge)
     addedEdgePairs.add(edgeKey)
   }
@@ -113,9 +113,9 @@ function processEdgeForRewiring(
 export function filterByNodeType(
   nodes: Node[],
   edges: Edge[],
-  visibleTypes: Set<NodeType>,
+  visibleTypes: Set<string>,
 ): FilteredGraph {
-  const visibleNodes = nodes.filter((n) => visibleTypes.has(n.type))
+  const visibleNodes = nodes.filter((n) => visibleTypes.has(getEffectiveNodeType(n)))
   const visibleNodeIds = new Set(visibleNodes.map((n) => n.id))
 
   const outgoingEdges = buildOutgoingEdgesMap(edges)

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
@@ -21,13 +21,15 @@ const testSourceLocation = {
 }
 
 const {
-  capturedOnNodeHover, capturedOnBackgroundClick 
+  capturedOnNodeHover, capturedOnBackgroundClick, capturedGraph,
 } = vi.hoisted(() => {
   const hoverRef: { current: ((data: TooltipData | null) => void) | undefined } = {current: undefined,}
   const backgroundClickRef: { current: (() => void) | undefined } = { current: undefined }
+  const graphRef: { current: RiviereGraph | undefined } = { current: undefined }
   return {
     capturedOnNodeHover: hoverRef,
     capturedOnBackgroundClick: backgroundClickRef,
+    capturedGraph: graphRef,
   }
 })
 
@@ -96,10 +98,12 @@ vi.mock('@/platform/infra/theme/ThemeContext', () => ({
 
 vi.mock('@/platform/infra/graph/ForceGraph/ForceGraph', () => ({
   ForceGraph: (props: {
+    graph: RiviereGraph
     onNodeHover?: (data: TooltipData | null) => void
     onBackgroundClick?: () => void
     highlightedNodeId?: string | null
   }) => {
+    capturedGraph.current = props.graph
     if (props.onNodeHover !== undefined) {
       capturedOnNodeHover.current = props.onNodeHover
     }
@@ -445,6 +449,24 @@ describe('FullGraphPage', () => {
       await user.click(externalCheckbox)
 
       expect(externalCheckbox).not.toBeChecked()
+    })
+
+    it('removes and restores external links when External visibility changes', async () => {
+      const user = userEvent.setup()
+      renderWithExternals()
+
+      await user.click(screen.getByTestId('filter-toggle'))
+      const externalCheckbox = screen.getByTestId('node-type-checkbox-External')
+
+      expect(capturedGraph.current?.externalLinks).toStrictEqual(mockGraphWithExternals.externalLinks)
+
+      await user.click(externalCheckbox)
+
+      expect(capturedGraph.current?.externalLinks).toStrictEqual([])
+
+      await user.click(externalCheckbox)
+
+      expect(capturedGraph.current?.externalLinks).toStrictEqual(mockGraphWithExternals.externalLinks)
     })
   })
 

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
@@ -245,7 +245,7 @@ describe('FullGraphPage', () => {
       const ordersCheckbox = screen.getByTestId('domain-checkbox-orders')
       await user.click(ordersCheckbox)
 
-      expect(screen.getByText('2 nodes focused')).toBeInTheDocument()
+      expect(screen.getByText('2 nodes')).toBeInTheDocument()
     })
 
     it('hides stats panel when domain is focused', async () => {
@@ -273,7 +273,7 @@ describe('FullGraphPage', () => {
 
       expect(screen.getByTestId('focused-domain-banner')).toBeInTheDocument()
 
-      const clearButton = screen.getByText('Clear focus')
+      const clearButton = screen.getByRole('button', { name: 'Clear focus' })
       await user.click(clearButton)
 
       expect(screen.queryByTestId('focused-domain-banner')).not.toBeInTheDocument()

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
@@ -4,8 +4,9 @@ import {
 import { useSearchParams } from 'react-router-dom'
 import type { RiviereGraph } from '@living-architecture/riviere-schema'
 import type {
-  NodeType, Node, Edge 
+  Node, Edge,
 } from '../queries/eclair-types'
+import { extractNodeTypes } from '../queries/extract-node-types'
 import { useTheme } from '@/platform/infra/theme/ThemeContext'
 import { useExport } from '@/platform/infra/export/ExportContext'
 import {
@@ -19,7 +20,7 @@ import { GraphTooltip } from '@/platform/infra/graph/GraphTooltip/GraphTooltip'
 import { DomainFilters } from '../components/DomainFilters/DomainFilters'
 import { NodeTypeFilters } from '../components/NodeTypeFilters/NodeTypeFilters'
 import {
-  filterByNodeType, getThemeFocusColors
+  filterByNodeType, getThemeFocusColors,
 } from '../queries/graph-focusing'
 import type { TooltipData } from '@/platform/infra/graph/graph-types'
 
@@ -52,11 +53,6 @@ interface DomainInfo {
   nodeCount: number
 }
 
-interface NodeTypeInfo {
-  type: NodeType
-  nodeCount: number
-}
-
 function extractDomains(graph: RiviereGraph): DomainInfo[] {
   const domainCounts = new Map<string, number>()
 
@@ -73,27 +69,6 @@ function extractDomains(graph: RiviereGraph): DomainInfo[] {
     .sort((a, b) => compareByCodePoint(a.name, b.name))
 }
 
-function extractNodeTypes(graph: RiviereGraph): NodeTypeInfo[] {
-  const typeCounts = new Map<NodeType, number>()
-
-  for (const node of graph.components) {
-    const count = typeCounts.get(node.type) ?? 0
-    typeCounts.set(node.type, count + 1)
-  }
-
-  if (graph.externalLinks !== undefined && graph.externalLinks.length > 0) {
-    const uniqueExternals = new Set(graph.externalLinks.map((l) => l.target.name))
-    typeCounts.set('External', uniqueExternals.size)
-  }
-
-  return Array.from(typeCounts.entries())
-    .map(([type, nodeCount]) => ({
-      type,
-      nodeCount,
-    }))
-    .sort((a, b) => compareByCodePoint(a.type, b.type))
-}
-
 export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.ReactElement {
   const { theme } = useTheme()
   const {
@@ -105,13 +80,9 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
   const exportContainerRef = useRef<HTMLDivElement>(null)
   const [highlightedNodeId, setHighlightedNodeId] = useState<string | null>(null)
   const [filterPanelOpen, setFilterPanelOpen] = useState(false)
-  const [visibleTypes, setVisibleTypes] = useState<Set<NodeType>>(() => {
-    const types = new Set(graph.components.map((n) => n.type))
-    if (graph.externalLinks !== undefined && graph.externalLinks.length > 0) {
-      types.add('External')
-    }
-    return types
-  })
+  const [visibleTypes, setVisibleTypes] = useState<Set<string>>(
+    () => new Set(extractNodeTypes(graph).map((nodeType) => nodeType.type)),
+  )
   const HIDE_ALL_DOMAINS = '__HIDE_ALL__'
   const [focusedDomain, setFocusedDomain] = useState<string | null>(null)
 
@@ -215,7 +186,7 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
 
   const focusColors = getThemeFocusColors(theme)
 
-  const handleToggleType = useCallback((type: NodeType) => {
+  const handleToggleType = useCallback((type: string) => {
     setVisibleTypes((prev) => {
       const next = new Set(prev)
       if (next.has(type)) {
@@ -290,13 +261,6 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
         onNodeHover={handleNodeHover}
         onBackgroundClick={handleBackgroundClick}
       />
-
-      {focusedDomain !== null && focusedDomain !== HIDE_ALL_DOMAINS && (
-        <div
-          className="pointer-events-none absolute inset-0 transition-opacity duration-600"
-          style={{ backgroundColor: focusColors.overlayBackground }}
-        />
-      )}
 
       <GraphTooltip
         data={tooltipData}
@@ -389,6 +353,7 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
             onToggleType={handleToggleType}
             onShowAll={handleShowAllTypes}
             onHideAll={handleHideAllTypes}
+            theme={theme}
           />
         </div>
       )}

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
@@ -270,40 +270,31 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
 
       {focusedDomain !== null && focusedDomain !== HIDE_ALL_DOMAINS && (
         <div
-          className="floating-panel absolute left-2 right-2 top-4 animate-fade-in border-l-8 px-8 py-6 md:left-4 md:right-auto md:max-w-md"
-          style={{
-            borderLeftColor: focusColors.borderColor,
-            boxShadow: `0 0 60px ${focusColors.shadowColor}, 0 8px 24px rgba(0, 0, 0, ${theme === 'voltage' ? 0.3 : 0.12})`,
-            background: theme === 'voltage' ? 'rgba(26, 26, 36, 0.95)' : undefined,
-          }}
+          className="floating-panel focused-domain-indicator animate-fade-in"
+          style={{ borderColor: focusColors.borderColor }}
           data-testid="focused-domain-banner"
         >
-          <div className="flex items-center gap-4">
-            <div
-              className="h-4 w-4 animate-pulse rounded-full"
-              style={{
-                backgroundColor: focusColors.glowColor,
-                boxShadow: `0 0 20px ${focusColors.shadowColor}`,
-              }}
-            />
-            <div className="text-2xl font-extrabold tracking-tight text-[var(--text-primary)] md:text-4xl">
-              {focusedDomain}
+          <div
+            className="h-3 w-3 shrink-0 rounded-full"
+            style={{
+              backgroundColor: focusColors.glowColor,
+              boxShadow: `0 0 10px ${focusColors.shadowColor}`,
+            }}
+          />
+          <div className="min-w-0 flex-1">
+            <div className="focused-domain-indicator-name">{focusedDomain}</div>
+            <div className="focused-domain-indicator-count">
+              {filteredGraph.nodes.filter((node) => node.domain === focusedDomain).length} nodes
             </div>
-          </div>
-          <div className="mt-3 flex items-center gap-2 text-sm font-semibold text-[var(--text-secondary)] md:text-base">
-            <i className="ph ph-circles-three text-base md:text-lg" />
-            <span>
-              {filteredGraph.nodes.filter((n) => n.domain === focusedDomain).length} nodes focused
-            </span>
           </div>
           <button
             type="button"
             onClick={handleShowAllDomains}
-            className="mt-4 flex items-center gap-2 text-sm font-medium transition-colors"
-            style={{ color: focusColors.borderColor }}
+            className="focused-domain-indicator-clear"
+            title="Clear focus"
+            aria-label="Clear focus"
           >
-            <i className="ph ph-x-circle text-base" />
-            <span>Clear focus</span>
+            <i className="ph ph-x" aria-hidden="true" />
           </button>
         </div>
       )}
@@ -337,7 +328,7 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
 
       {filterPanelOpen && (
         <div
-          className="floating-panel absolute right-2 top-20 w-full max-w-xs space-y-3 md:right-4 md:w-56"
+          className="floating-panel full-graph-filter-panel space-y-3"
           data-testid="filter-panel"
         >
           <DomainFilters

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
@@ -7,6 +7,7 @@ import type {
   Node, Edge,
 } from '../queries/eclair-types'
 import { extractNodeTypes } from '../queries/extract-node-types'
+import { compareByCodePoint } from '../queries/compare-by-code-point'
 import { useTheme } from '@/platform/infra/theme/ThemeContext'
 import { useExport } from '@/platform/infra/export/ExportContext'
 import {
@@ -23,12 +24,6 @@ import {
   filterByNodeType, getThemeFocusColors,
 } from '../queries/graph-focusing'
 import type { TooltipData } from '@/platform/infra/graph/graph-types'
-
-function compareByCodePoint(a: string, b: string): number {
-  if (a < b) return -1
-  if (a > b) return 1
-  return 0
-}
 
 function findOrphanNodeIds(nodes: Node[], edges: Edge[]): Set<string> {
   const connectedNodeIds = new Set<string>()
@@ -114,6 +109,7 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
     return {
       nodes: nonOrphanNodes,
       edges: nonOrphanEdges,
+      externalLinks: visibleTypes.has('External') ? graph.externalLinks : [],
     }
   }, [graph, visibleTypes])
 
@@ -252,6 +248,7 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
           ...graph,
           components: filteredGraph.nodes,
           links: filteredGraph.edges,
+          externalLinks: filteredGraph.externalLinks,
         }}
         theme={theme}
         highlightedNodeIds={highlightedNodeIds}

--- a/apps/eclair/src/features/full-graph/queries/compare-by-code-point.ts
+++ b/apps/eclair/src/features/full-graph/queries/compare-by-code-point.ts
@@ -1,0 +1,1 @@
+export { compareByCodePoint } from '@/platform/domain/compare-by-code-point'

--- a/apps/eclair/src/features/full-graph/queries/eclair-types.ts
+++ b/apps/eclair/src/features/full-graph/queries/eclair-types.ts
@@ -1,3 +1,4 @@
-export type {
-  NodeType, Node, Edge 
-} from '@/platform/domain/eclair-types'
+import type * as EclairTypes from '@/platform/domain/eclair-types'
+
+export type Node = EclairTypes.Node
+export type Edge = EclairTypes.Edge

--- a/apps/eclair/src/features/full-graph/queries/extract-node-types.ts
+++ b/apps/eclair/src/features/full-graph/queries/extract-node-types.ts
@@ -1,0 +1,29 @@
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
+import { compareByCodePoint } from '@/platform/domain/compare-by-code-point'
+
+export interface NodeTypeInfo {
+  type: string
+  nodeCount: number
+}
+
+export function extractNodeTypes(graph: RiviereGraph): NodeTypeInfo[] {
+  const typeCounts = new Map<string, number>()
+
+  for (const node of graph.components) {
+    const type = getEffectiveNodeType(node)
+    typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1)
+  }
+
+  if (graph.externalLinks !== undefined && graph.externalLinks.length > 0) {
+    const uniqueExternals = new Set(graph.externalLinks.map((link) => link.target.name))
+    typeCounts.set('External', uniqueExternals.size)
+  }
+
+  return [...typeCounts.entries()]
+    .map(([type, nodeCount]) => ({
+      type,
+      nodeCount,
+    }))
+    .sort((left, right) => compareByCodePoint(left.type, right.type))
+}

--- a/apps/eclair/src/features/modules/entrypoint/ModulesPage.spec.tsx
+++ b/apps/eclair/src/features/modules/entrypoint/ModulesPage.spec.tsx
@@ -1,6 +1,7 @@
 import {
   render, screen,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {
   describe, expect, it,
 } from 'vitest'
@@ -45,5 +46,25 @@ describe('ModulesPage', () => {
     expect(screen.getByRole('heading', { name: 'Scheduler' })).toBeInTheDocument()
     expect(screen.getByText('Load warehouse')).toBeInTheDocument()
     expect(screen.getByText('Job')).toHaveAttribute('title', 'A scheduled unit of work')
+  })
+
+  it('lets domains and modules be collapsed independently', async () => {
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider>
+        <ModulesPage graph={graph} />
+      </ThemeProvider>,
+    )
+
+    const domainGroup = screen.getByTestId('domain-group-operations')
+    const moduleGroup = screen.getByTestId('module-group-Scheduler')
+    expect(domainGroup).toHaveAttribute('open')
+    expect(moduleGroup).toHaveAttribute('open')
+
+    await user.click(screen.getByRole('heading', { name: 'Scheduler' }))
+    expect(moduleGroup).not.toHaveAttribute('open')
+
+    await user.click(screen.getByRole('heading', { name: 'operations' }))
+    expect(domainGroup).not.toHaveAttribute('open')
   })
 })

--- a/apps/eclair/src/features/modules/entrypoint/ModulesPage.spec.tsx
+++ b/apps/eclair/src/features/modules/entrypoint/ModulesPage.spec.tsx
@@ -1,0 +1,49 @@
+import {
+  render, screen,
+} from '@testing-library/react'
+import {
+  describe, expect, it,
+} from 'vitest'
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import { ThemeProvider } from '@/platform/infra/theme/ThemeContext'
+import { ModulesPage } from './ModulesPage'
+
+const graph: RiviereGraph = {
+  version: '1.0',
+  metadata: {
+    domains: {
+      operations: {
+        description: 'Operations',
+        systemType: 'other',
+      },
+    },
+    customTypes: {Job: { description: 'A scheduled unit of work' },},
+  },
+  components: [
+    {
+      id: 'job-1',
+      type: 'Custom',
+      customTypeName: 'Job',
+      name: 'Load warehouse',
+      domain: 'operations',
+      module: 'Scheduler',
+      sourceLocation: { filePath: 'jobs.csv' },
+    },
+  ],
+  links: [],
+}
+
+describe('ModulesPage', () => {
+  it('shows modules grouped under their domains with actual node types', () => {
+    render(
+      <ThemeProvider>
+        <ModulesPage graph={graph} />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'operations' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Scheduler' })).toBeInTheDocument()
+    expect(screen.getByText('Load warehouse')).toBeInTheDocument()
+    expect(screen.getByText('Job')).toHaveAttribute('title', 'A scheduled unit of work')
+  })
+})

--- a/apps/eclair/src/features/modules/entrypoint/ModulesPage.tsx
+++ b/apps/eclair/src/features/modules/entrypoint/ModulesPage.tsx
@@ -42,26 +42,37 @@ export function ModulesPage({
       </div>
 
       {domains.map((domain) => (
-        <section key={domain.domain} aria-labelledby={`domain-${domain.domain}`} className="space-y-3">
-          <h2
-            id={`domain-${domain.domain}`}
-            className="font-[var(--font-heading)] text-xl font-bold text-[var(--text-primary)]"
-          >
-            {domain.domain}
-          </h2>
-          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+        <details
+          key={domain.domain}
+          open
+          data-testid={`domain-group-${domain.domain}`}
+          className="module-domain-group"
+        >
+          <summary className="module-tree-summary module-domain-summary">
+            <i className="ph ph-caret-right module-tree-caret" aria-hidden="true" />
+            <h2 className="font-[var(--font-heading)] text-xl font-bold text-[var(--text-primary)]">
+              {domain.domain}
+            </h2>
+            <span className="ml-auto text-xs text-[var(--text-tertiary)]">
+              {domain.modules.length} {domain.modules.length === 1 ? 'module' : 'modules'}
+            </span>
+          </summary>
+          <div className="grid grid-cols-1 gap-4 pl-6 xl:grid-cols-2">
             {domain.modules.map((module) => (
-              <article
+              <details
                 key={module.name}
-                className="rounded-[var(--radius)] border border-[var(--border-color)] bg-[var(--bg-secondary)] p-4"
+                open
+                data-testid={`module-group-${module.name}`}
+                className="module-card"
               >
-                <div className="mb-3 flex items-center justify-between gap-3">
+                <summary className="module-tree-summary module-card-summary">
+                  <i className="ph ph-caret-right module-tree-caret" aria-hidden="true" />
                   <h3 className="font-semibold text-[var(--text-primary)]">{module.name}</h3>
-                  <span className="text-xs text-[var(--text-tertiary)]">
+                  <span className="ml-auto text-xs text-[var(--text-tertiary)]">
                     {module.nodes.length} {module.nodes.length === 1 ? 'node' : 'nodes'}
                   </span>
-                </div>
-                <div className="space-y-2">
+                </summary>
+                <div className="space-y-2 px-4 pb-4">
                   {module.nodes.map((node) => (
                     <div
                       key={node.id}
@@ -78,10 +89,10 @@ export function ModulesPage({
                     </div>
                   ))}
                 </div>
-              </article>
+              </details>
             ))}
           </div>
-        </section>
+        </details>
       ))}
     </div>
   )

--- a/apps/eclair/src/features/modules/entrypoint/ModulesPage.tsx
+++ b/apps/eclair/src/features/modules/entrypoint/ModulesPage.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react'
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import { NodeTypeBadge } from '@/platform/infra/ui/NodeTypeBadge/NodeTypeBadge'
+import { extractModules } from '../queries/extract-modules'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
+
+interface ModulesPageProps {
+  readonly graph: RiviereGraph
+  readonly theme?: Theme
+}
+
+export function ModulesPage({
+  graph,
+  theme = DEFAULT_THEME,
+}: Readonly<ModulesPageProps>): React.ReactElement {
+  const domains = useMemo(() => extractModules(graph), [graph])
+  const moduleCount = domains.reduce((total, domain) => total + domain.modules.length, 0)
+
+  return (
+    <div data-testid="modules-page" className="space-y-6">
+      <header className="page-header">
+        <h1 className="page-title">Modules</h1>
+        <p className="page-subtitle">Nodes grouped by their graph-defined domain and module</p>
+      </header>
+
+      <div className="stats-bar">
+        <div className="stats-bar-item">
+          <i className="ph ph-stack stats-bar-icon" aria-hidden="true" />
+          <div className="stats-bar-content">
+            <div className="stats-bar-label">Modules</div>
+            <div className="stats-bar-value">{moduleCount}</div>
+          </div>
+        </div>
+        <div className="stats-bar-item">
+          <i className="ph ph-circles-three stats-bar-icon" aria-hidden="true" />
+          <div className="stats-bar-content">
+            <div className="stats-bar-label">Domains</div>
+            <div className="stats-bar-value">{domains.length}</div>
+          </div>
+        </div>
+      </div>
+
+      {domains.map((domain) => (
+        <section key={domain.domain} aria-labelledby={`domain-${domain.domain}`} className="space-y-3">
+          <h2
+            id={`domain-${domain.domain}`}
+            className="font-[var(--font-heading)] text-xl font-bold text-[var(--text-primary)]"
+          >
+            {domain.domain}
+          </h2>
+          <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+            {domain.modules.map((module) => (
+              <article
+                key={module.name}
+                className="rounded-[var(--radius)] border border-[var(--border-color)] bg-[var(--bg-secondary)] p-4"
+              >
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <h3 className="font-semibold text-[var(--text-primary)]">{module.name}</h3>
+                  <span className="text-xs text-[var(--text-tertiary)]">
+                    {module.nodes.length} {module.nodes.length === 1 ? 'node' : 'nodes'}
+                  </span>
+                </div>
+                <div className="space-y-2">
+                  {module.nodes.map((node) => (
+                    <div
+                      key={node.id}
+                      className="flex items-center gap-3 rounded bg-[var(--bg-tertiary)] px-3 py-2"
+                    >
+                      <NodeTypeBadge
+                        type={node.type}
+                        description={node.typeDescription}
+                        theme={theme}
+                      />
+                      <span className="min-w-0 truncate text-sm text-[var(--text-primary)]">
+                        {node.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/apps/eclair/src/features/modules/queries/extract-modules.spec.ts
+++ b/apps/eclair/src/features/modules/queries/extract-modules.spec.ts
@@ -1,0 +1,119 @@
+import {
+  // Keep expanded for ESLint.
+  describe,
+  expect,
+  it,
+} from 'vitest'
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import { extractModules } from './extract-modules'
+
+const graph: RiviereGraph = {
+  version: '1.0',
+  metadata: {
+    domains: {
+      warehouse: {
+        description: 'Warehouse',
+        systemType: 'other',
+      },
+      operations: {
+        description: 'Operations',
+        systemType: 'domain',
+      },
+    },
+    customTypes: { Table: { description: 'Stored data' } },
+  },
+  components: [
+    {
+      id: 'table-2',
+      type: 'Custom',
+      customTypeName: 'Table',
+      name: 'Orders',
+      domain: 'warehouse',
+      module: 'WarehouseStore',
+      sourceLocation: { filePath: 'orders.sql' },
+    },
+    {
+      id: 'table-1',
+      type: 'Custom',
+      customTypeName: 'Table',
+      name: 'Configuration',
+      domain: 'operations',
+      module: 'ConfigurationStore',
+      sourceLocation: { filePath: 'config.sql' },
+    },
+    {
+      id: 'api-1',
+      type: 'API',
+      name: 'Order API',
+      domain: 'operations',
+      module: 'OrderProcessing',
+      path: '/orders',
+      sourceLocation: { filePath: 'api.ts' },
+    },
+    {
+      id: 'use-case-1',
+      type: 'UseCase',
+      name: 'Load Order',
+      domain: 'operations',
+      module: 'OrderProcessing',
+      sourceLocation: { filePath: 'load-order.ts' },
+    },
+  ],
+  links: [],
+}
+
+describe('extractModules', () => {
+  it('groups nodes by domain and module using their effective types', () => {
+    expect(extractModules(graph)).toStrictEqual([
+      {
+        domain: 'operations',
+        modules: [
+          {
+            name: 'ConfigurationStore',
+            nodes: [
+              {
+                id: 'table-1',
+                name: 'Configuration',
+                type: 'Table',
+                typeDescription: 'Stored data',
+              },
+            ],
+          },
+          {
+            name: 'OrderProcessing',
+            nodes: [
+              {
+                id: 'use-case-1',
+                name: 'Load Order',
+                type: 'UseCase',
+                typeDescription: undefined,
+              },
+              {
+                id: 'api-1',
+                name: 'Order API',
+                type: 'API',
+                typeDescription: undefined,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        domain: 'warehouse',
+        modules: [
+          {
+            name: 'WarehouseStore',
+            nodes: [
+              {
+                id: 'table-2',
+                name: 'Orders',
+                type: 'Table',
+                typeDescription: 'Stored data',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/apps/eclair/src/features/modules/queries/extract-modules.spec.ts
+++ b/apps/eclair/src/features/modules/queries/extract-modules.spec.ts
@@ -116,4 +116,39 @@ describe('extractModules', () => {
       },
     ])
   })
+
+  it('orders module names by Unicode code point', () => {
+    const firstModule = '\uFFFF'
+    const secondModule = '\u{10000}'
+    const graphWithUnicodeModules: RiviereGraph = {
+      ...graph,
+      components: [
+        {
+          id: 'unicode-2',
+          type: 'Custom',
+          name: 'Second',
+          domain: 'unicode',
+          module: secondModule,
+          customTypeName: 'Worker',
+          sourceLocation: { filePath: 'second.sql' },
+        },
+        {
+          id: 'unicode-1',
+          type: 'Custom',
+          name: 'First',
+          domain: 'unicode',
+          module: firstModule,
+          customTypeName: 'Worker',
+          sourceLocation: { filePath: 'first.sql' },
+        },
+      ],
+    }
+
+    const unicodeDomain = extractModules(graphWithUnicodeModules)[0]
+
+    expect(unicodeDomain?.modules.map((module) => module.name)).toStrictEqual([
+      firstModule,
+      secondModule,
+    ])
+  })
 })

--- a/apps/eclair/src/features/modules/queries/extract-modules.ts
+++ b/apps/eclair/src/features/modules/queries/extract-modules.ts
@@ -1,0 +1,58 @@
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import {
+  getEffectiveNodeType,
+  getNodeTypeDescription,
+} from '@/platform/domain/node-type-presentation'
+
+export interface ModuleNode {
+  id: string
+  name: string
+  type: string
+  typeDescription: string | undefined
+}
+
+interface ModuleInfo {
+  name: string
+  nodes: ModuleNode[]
+}
+
+export interface DomainModules {
+  domain: string
+  modules: ModuleInfo[]
+}
+
+export function extractModules(graph: RiviereGraph): DomainModules[] {
+  const domains = new Map<string, Map<string, ModuleNode[]>>()
+
+  for (const component of graph.components) {
+    const modules = domains.get(component.domain) ?? new Map<string, ModuleNode[]>()
+    const nodes = modules.get(component.module) ?? []
+    const type = getEffectiveNodeType(component)
+    nodes.push({
+      id: component.id,
+      name: component.name,
+      type,
+      typeDescription: getNodeTypeDescription(graph, type),
+    })
+    modules.set(component.module, nodes)
+    domains.set(component.domain, modules)
+  }
+
+  return [...domains.entries()]
+    .sort(([left], [right]) => compareByCodePoint(left, right))
+    .map(([domain, modules]) => ({
+      domain,
+      modules: [...modules.entries()]
+        .sort(([left], [right]) => compareByCodePoint(left, right))
+        .map(([name, nodes]) => ({
+          name,
+          nodes: nodes.toSorted((left, right) => compareByCodePoint(left.name, right.name)),
+        })),
+    }))
+}
+
+function compareByCodePoint(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}

--- a/apps/eclair/src/features/modules/queries/extract-modules.ts
+++ b/apps/eclair/src/features/modules/queries/extract-modules.ts
@@ -3,6 +3,7 @@ import {
   getEffectiveNodeType,
   getNodeTypeDescription,
 } from '@/platform/domain/node-type-presentation'
+import { compareByCodePoint } from '@/platform/domain/compare-by-code-point'
 
 export interface ModuleNode {
   id: string
@@ -49,10 +50,4 @@ export function extractModules(graph: RiviereGraph): DomainModules[] {
           nodes: nodes.toSorted((left, right) => compareByCodePoint(left.name, right.name)),
         })),
     }))
-}
-
-function compareByCodePoint(left: string, right: string): number {
-  if (left < right) return -1
-  if (left > right) return 1
-  return 0
 }

--- a/apps/eclair/src/features/overview/components/NodeBreakdownSection.tsx
+++ b/apps/eclair/src/features/overview/components/NodeBreakdownSection.tsx
@@ -1,0 +1,45 @@
+import { getNodeTypeColor } from '@/platform/domain/node-type-presentation'
+import type { Theme } from '@/types/theme'
+
+interface NodeBreakdownSectionProps {
+  readonly breakdown: Readonly<Record<string, number>>
+  readonly theme: Theme
+}
+
+export function NodeBreakdownSection({
+  breakdown,
+  theme,
+}: Readonly<NodeBreakdownSectionProps>): React.ReactElement {
+  const items = Object.entries(breakdown)
+    .map(([label, value]) => ({
+      label,
+      value,
+    }))
+    .filter((item) => item.value > 0)
+    .sort((left, right) => left.label.localeCompare(right.label))
+
+  return (
+    <div className="mb-3 border-b border-[var(--border-color)] pb-3">
+      <h4 className="mb-2 text-[11px] font-bold uppercase tracking-wide text-[var(--text-tertiary)]">
+        Node Breakdown
+      </h4>
+      <div className="grid grid-cols-2 gap-1.5">
+        {items.map((item) => (
+          <div
+            key={item.label}
+            className="flex items-center justify-between rounded bg-[var(--bg-tertiary)] px-2 py-1 text-xs"
+          >
+            <span className="flex min-w-0 items-center gap-1.5 font-medium text-[var(--text-secondary)]">
+              <span
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: getNodeTypeColor(item.label, theme) }}
+              />
+              <span className="truncate">{item.label}</span>
+            </span>
+            <span className="font-bold text-[var(--text-primary)]">{item.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/eclair/src/features/overview/entrypoint/OverviewPage.spec.tsx
+++ b/apps/eclair/src/features/overview/entrypoint/OverviewPage.spec.tsx
@@ -297,8 +297,31 @@ describe('OverviewPage', () => {
 
     expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Domain' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'UI' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'BFF' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'UI' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'BFF' })).not.toBeInTheDocument()
+  })
+
+  it('renders multiple system types as sorted filter tags', () => {
+    const graph = createTestGraph({
+      metadata: {
+        name: 'Test Architecture',
+        domains: parseDomainMetadata({
+          'order-domain': {
+            description: 'Order management',
+            systemType: 'domain',
+          },
+          'payment-domain': {
+            description: 'Payment processing',
+            systemType: 'other',
+          },
+        }),
+      },
+    })
+
+    renderWithRouter(<OverviewPage graph={graph} />)
+
+    expect(screen.getByRole('button', { name: 'Domain' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Other' })).toBeInTheDocument()
   })
 
   it('renders stats with icons', () => {
@@ -437,6 +460,21 @@ describe('OverviewPage', () => {
 
       expect(domainButton).toHaveClass('active')
       expect(allButton).not.toHaveClass('active')
+    })
+
+    it('returns to all domains when the All filter is clicked', async () => {
+      const user = userEvent.setup()
+      const graph = createTestGraph()
+
+      renderWithRouter(<OverviewPage graph={graph} />)
+
+      await user.click(screen.getByRole('button', { name: 'Domain' }))
+      const allButton = screen.getByRole('button', { name: 'All' })
+      await user.click(allButton)
+
+      expect(allButton).toHaveClass('active')
+      expect(screen.getByText('order-domain')).toBeInTheDocument()
+      expect(screen.getByText('payment-domain')).toBeInTheDocument()
     })
   })
 

--- a/apps/eclair/src/features/overview/entrypoint/OverviewPage.spec.tsx
+++ b/apps/eclair/src/features/overview/entrypoint/OverviewPage.spec.tsx
@@ -301,6 +301,14 @@ describe('OverviewPage', () => {
     expect(screen.queryByRole('button', { name: 'BFF' })).not.toBeInTheDocument()
   })
 
+  it('labels system-type filters as domain types', () => {
+    const graph = createTestGraph()
+
+    renderWithRouter(<OverviewPage graph={graph} />)
+
+    expect(screen.getByText('Domain type:')).toBeInTheDocument()
+  })
+
   it('renders multiple system types as sorted filter tags', () => {
     const graph = createTestGraph({
       metadata: {

--- a/apps/eclair/src/features/overview/entrypoint/OverviewPage.tsx
+++ b/apps/eclair/src/features/overview/entrypoint/OverviewPage.tsx
@@ -6,7 +6,7 @@ import type {
   RiviereGraph, SystemType 
 } from '@living-architecture/riviere-schema'
 import {
-  domainNameSchema, type DomainName
+  domainNameSchema, type DomainName,
 } from '../queries/eclair-domain'
 import { useRiviereQuery } from '@/platform/infra/riviere-query/useRiviereQuery'
 import { useCodeLinkSettings } from '@/platform/infra/settings/use-code-link-settings'
@@ -14,33 +14,45 @@ import { StatsItem } from '../components/StatsItem'
 import {
   EntitiesSection, EntryPointsSection 
 } from '../components/DomainCardSections'
+import { NodeBreakdownSection } from '../components/NodeBreakdownSection'
+import {
+  getNodeTypeBreakdown, type NodeTypeBreakdown,
+} from '../queries/node-type-breakdown'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
 type ViewMode = 'grid' | 'list'
 type FilterType = 'all' | SystemType
 
-interface NodeBreakdown {
-  UI: number
-  API: number
-  UseCase: number
-  DomainOp: number
-  Event: number
-  EventHandler: number
-  Custom: number
+function formatSystemTypeLabel(systemType: string): string {
+  return systemType
+    .split('-')
+    .map((part) => {
+      if (part === 'ui' || part === 'bff') return part.toUpperCase()
+      return `${part.charAt(0).toUpperCase()}${part.slice(1)}`
+    })
+    .join(' ')
 }
 
 interface DomainInfo {
   id: DomainName
   description: string
   systemType: SystemType
-  nodeBreakdown: NodeBreakdown
+  nodeBreakdown: NodeTypeBreakdown
   entities: string[]
   entryPoints: string[]
   repository: string | undefined
 }
 
-interface OverviewPageProps {graph: RiviereGraph}
+interface OverviewPageProps {
+  graph: RiviereGraph
+  theme?: Theme
+}
 
-export function OverviewPage({ graph }: Readonly<OverviewPageProps>): React.ReactElement {
+export function OverviewPage({
+  graph,
+  theme = DEFAULT_THEME,
+}: Readonly<OverviewPageProps>): React.ReactElement {
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
   const [searchQuery, setSearchQuery] = useState('')
   const [activeFilter, setActiveFilter] = useState<FilterType>('all')
@@ -88,7 +100,7 @@ export function OverviewPage({ graph }: Readonly<OverviewPageProps>): React.Reac
         id: domainId,
         description: domain.description,
         systemType: domain.systemType,
-        nodeBreakdown: domain.componentCounts,
+        nodeBreakdown: getNodeTypeBreakdown(domainComponents),
         entities,
         entryPoints,
         repository,
@@ -106,6 +118,14 @@ export function OverviewPage({ graph }: Readonly<OverviewPageProps>): React.Reac
       allDomains: domainInfos,
     }
   }, [query])
+
+  const domainTypes = useMemo(
+    () =>
+      [...new Set(allDomains.map((domain) => domain.systemType))].sort((a, b) =>
+        a.localeCompare(b),
+      ),
+    [allDomains],
+  )
 
   const filteredDomains = allDomains.filter((domain) => {
     const matchesSearch =
@@ -152,24 +172,15 @@ export function OverviewPage({ graph }: Readonly<OverviewPageProps>): React.Reac
           >
             All
           </button>
-          <button
-            className={`filter-tag ${activeFilter === 'domain' ? 'active' : ''}`}
-            onClick={() => setActiveFilter('domain')}
-          >
-            Domain
-          </button>
-          <button
-            className={`filter-tag ${activeFilter === 'ui' ? 'active' : ''}`}
-            onClick={() => setActiveFilter('ui')}
-          >
-            UI
-          </button>
-          <button
-            className={`filter-tag ${activeFilter === 'bff' ? 'active' : ''}`}
-            onClick={() => setActiveFilter('bff')}
-          >
-            BFF
-          </button>
+          {domainTypes.map((domainType) => (
+            <button
+              key={domainType}
+              className={`filter-tag ${activeFilter === domainType ? 'active' : ''}`}
+              onClick={() => setActiveFilter(domainType)}
+            >
+              {formatSystemTypeLabel(domainType)}
+            </button>
+          ))}
         </div>
       </div>
 
@@ -208,6 +219,7 @@ export function OverviewPage({ graph }: Readonly<OverviewPageProps>): React.Reac
               domain={domain}
               viewMode={viewMode}
               graphName={graph.metadata.name}
+              theme={theme}
             />
           ))}
         </div>
@@ -220,15 +232,16 @@ interface DomainCardProps {
   readonly domain: DomainInfo
   readonly viewMode: ViewMode
   readonly graphName: string | undefined
+  readonly theme: Theme
 }
 
 function DomainCard({
   domain,
   viewMode,
   graphName,
+  theme,
 }: Readonly<DomainCardProps>): React.ReactElement {
-  const repoName: string | undefined =
-    domain.repository ?? graphName
+  const repoName: string | undefined = domain.repository ?? graphName
   const { settings } = useCodeLinkSettings()
   const githubUrl =
     repoName === undefined || settings.githubOrg === null
@@ -303,7 +316,7 @@ function DomainCard({
         </p>
       </header>
 
-      <NodeBreakdownSection breakdown={domain.nodeBreakdown} />
+      <NodeBreakdownSection breakdown={domain.nodeBreakdown} theme={theme} />
 
       {domain.entities.length > 0 && <EntitiesSection entities={domain.entities} />}
 
@@ -344,55 +357,5 @@ function DomainCard({
         </div>
       </footer>
     </article>
-  )
-}
-
-interface NodeBreakdownSectionProps {readonly breakdown: DomainInfo['nodeBreakdown']}
-
-function NodeBreakdownSection({breakdown,}: Readonly<NodeBreakdownSectionProps>): React.ReactElement {
-  const items = [
-    {
-      label: 'UI',
-      value: breakdown.UI,
-    },
-    {
-      label: 'API',
-      value: breakdown.API,
-    },
-    {
-      label: 'UseCase',
-      value: breakdown.UseCase,
-    },
-    {
-      label: 'DomainOp',
-      value: breakdown.DomainOp,
-    },
-    {
-      label: 'Event',
-      value: breakdown.Event,
-    },
-    {
-      label: 'Handler',
-      value: breakdown.EventHandler,
-    },
-  ].filter((item) => item.value > 0)
-
-  return (
-    <div className="mb-3 border-b border-[var(--border-color)] pb-3">
-      <h4 className="mb-2 text-[11px] font-bold uppercase tracking-wide text-[var(--text-tertiary)]">
-        Node Breakdown
-      </h4>
-      <div className="grid grid-cols-2 gap-1.5">
-        {items.map((item) => (
-          <div
-            key={item.label}
-            className="flex items-center justify-between rounded bg-[var(--bg-tertiary)] px-2 py-1 text-xs"
-          >
-            <span className="font-medium text-[var(--text-secondary)]">{item.label}</span>
-            <span className="font-bold text-[var(--text-primary)]">{item.value}</span>
-          </div>
-        ))}
-      </div>
-    </div>
   )
 }

--- a/apps/eclair/src/features/overview/entrypoint/OverviewPage.tsx
+++ b/apps/eclair/src/features/overview/entrypoint/OverviewPage.tsx
@@ -164,7 +164,7 @@ export function OverviewPage({
           />
         </div>
         <div className="filter-divider" />
-        <span className="filter-label">Type:</span>
+        <span className="filter-label">Domain type:</span>
         <div className="filter-group">
           <button
             className={`filter-tag ${activeFilter === 'all' ? 'active' : ''}`}

--- a/apps/eclair/src/features/overview/queries/node-type-breakdown.spec.ts
+++ b/apps/eclair/src/features/overview/queries/node-type-breakdown.spec.ts
@@ -1,0 +1,34 @@
+import {
+  describe, expect, it 
+} from 'vitest'
+import { parseNode } from '@/platform/infra/__fixtures__/riviere-test-fixtures'
+import { getNodeTypeBreakdown } from './node-type-breakdown'
+
+const sourceLocation = {
+  repository: 'test-repository',
+  filePath: 'test.sql',
+}
+
+describe('getNodeTypeBreakdown', () => {
+  it('counts custom type names that match object prototype properties', () => {
+    const components = ['constructor', 'toString', '__proto__'].map((customTypeName, index) =>
+      parseNode({
+        id: `custom-${index}`,
+        type: 'Custom',
+        name: customTypeName,
+        domain: 'test-domain',
+        module: 'test-module',
+        customTypeName,
+        sourceLocation,
+      }),
+    )
+
+    expect(getNodeTypeBreakdown(components)).toStrictEqual(
+      Object.fromEntries([
+        ['constructor', 1],
+        ['toString', 1],
+        ['__proto__', 1],
+      ]),
+    )
+  })
+})

--- a/apps/eclair/src/features/overview/queries/node-type-breakdown.ts
+++ b/apps/eclair/src/features/overview/queries/node-type-breakdown.ts
@@ -4,9 +4,10 @@ import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
 export type NodeTypeBreakdown = Record<string, number>
 
 export function getNodeTypeBreakdown(components: readonly Component[]): NodeTypeBreakdown {
-  return components.reduce<NodeTypeBreakdown>((counts, component) => {
+  const counts = new Map<string, number>()
+  for (const component of components) {
     const type = getEffectiveNodeType(component)
-    counts[type] = (counts[type] ?? 0) + 1
-    return counts
-  }, {})
+    counts.set(type, (counts.get(type) ?? 0) + 1)
+  }
+  return Object.fromEntries(counts)
 }

--- a/apps/eclair/src/features/overview/queries/node-type-breakdown.ts
+++ b/apps/eclair/src/features/overview/queries/node-type-breakdown.ts
@@ -1,0 +1,12 @@
+import type { Component } from '@living-architecture/riviere-schema'
+import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
+
+export type NodeTypeBreakdown = Record<string, number>
+
+export function getNodeTypeBreakdown(components: readonly Component[]): NodeTypeBreakdown {
+  return components.reduce<NodeTypeBreakdown>((counts, component) => {
+    const type = getEffectiveNodeType(component)
+    counts[type] = (counts[type] ?? 0) + 1
+    return counts
+  }, {})
+}

--- a/apps/eclair/src/index.css
+++ b/apps/eclair/src/index.css
@@ -437,7 +437,7 @@
     content: '';
     position: absolute;
     inset: 0;
-    background-image: radial-gradient(circle, rgba(13, 148, 136, 0.25) 1.5px, transparent 1.5px);
+    background-image: radial-gradient(circle, rgba(100, 116, 139, 0.22) 1.5px, transparent 1.5px);
     background-size: 24px 24px;
     pointer-events: none;
   }
@@ -447,7 +447,7 @@
   }
 
   .theme-voltage .canvas-background::before {
-    background-image: radial-gradient(circle, rgba(0, 212, 255, 0.15) 1.5px, transparent 1.5px);
+    background-image: radial-gradient(circle, rgba(160, 160, 176, 0.18) 1.5px, transparent 1.5px);
   }
 
   .theme-circuit .canvas-background {

--- a/apps/eclair/src/index.css
+++ b/apps/eclair/src/index.css
@@ -270,7 +270,8 @@
   .filters-section {
     display: flex;
     align-items: center;
-    gap: 16px;
+    flex-wrap: wrap;
+    gap: 12px 16px;
   }
 
   @media (max-width: 768px) {
@@ -281,9 +282,15 @@
   }
 
   .search-container {
-    flex: 1;
+    flex: 1 1 320px;
+    min-width: min(100%, 280px);
     max-width: 400px;
     position: relative;
+  }
+
+  .node-filter-bar .search-container {
+    flex-basis: 100%;
+    max-width: 100%;
   }
 
   @media (max-width: 768px) {
@@ -344,7 +351,11 @@
 
   .filter-group {
     display: flex;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
     gap: 8px;
+    min-width: 0;
+    max-width: 100%;
   }
 
   @media (max-width: 768px) {
@@ -437,8 +448,8 @@
     content: '';
     position: absolute;
     inset: 0;
-    background-image: radial-gradient(circle, rgba(100, 116, 139, 0.22) 1.5px, transparent 1.5px);
-    background-size: 24px 24px;
+    background-image: radial-gradient(circle, rgba(100, 116, 139, 0.16) 0.75px, transparent 0.8px);
+    background-size: 20px 20px;
     pointer-events: none;
   }
 
@@ -447,7 +458,7 @@
   }
 
   .theme-voltage .canvas-background::before {
-    background-image: radial-gradient(circle, rgba(160, 160, 176, 0.18) 1.5px, transparent 1.5px);
+    background-image: radial-gradient(circle, rgba(160, 160, 176, 0.14) 0.75px, transparent 0.8px);
   }
 
   .theme-circuit .canvas-background {
@@ -455,7 +466,7 @@
   }
 
   .theme-circuit .canvas-background::before {
-    background-image: radial-gradient(circle, rgba(36, 41, 47, 0.12) 1.5px, transparent 1.5px);
+    background-image: radial-gradient(circle, rgba(36, 41, 47, 0.1) 0.75px, transparent 0.8px);
   }
 
   .graph-node {
@@ -682,6 +693,15 @@
     align-items: center;
     justify-content: space-between;
     gap: 16px;
+  }
+
+  .flow-item-toggle {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    gap: 12px;
+    min-width: 0;
+    text-align: left;
     cursor: pointer;
   }
 
@@ -694,6 +714,8 @@
   }
 
   .flow-item-title {
+    flex: 1;
+    min-width: 0;
     font-size: 14px;
     font-weight: 600;
     color: var(--text-primary);
@@ -715,7 +737,17 @@
     align-items: center;
     gap: 8px;
     flex-shrink: 0;
-    margin-left: 16px;
+  }
+
+  .flow-item-actions .code-link,
+  .flow-item-actions .graph-link-btn {
+    width: 32px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .flow-item-actions .code-link-text {
+    display: none;
   }
 
   .flow-item-chevron {
@@ -902,8 +934,141 @@
   }
 
   .flow-step-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 14px;
+    margin-top: 2px;
     font-size: 11px;
     color: var(--text-tertiary);
+  }
+
+  .flow-step-meta-item {
+    display: flex;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .flow-step-meta-item dt {
+    font-weight: 700;
+    color: var(--text-secondary);
+  }
+
+  .flow-step-meta-item dd {
+    overflow-wrap: anywhere;
+  }
+
+  .module-domain-group {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .module-tree-summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .module-tree-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .module-tree-caret {
+    color: var(--text-tertiary);
+    transition: transform 0.2s ease;
+  }
+
+  details[open] > .module-tree-summary > .module-tree-caret {
+    transform: rotate(90deg);
+  }
+
+  .module-domain-summary {
+    min-height: 36px;
+  }
+
+  .module-card {
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    background: var(--bg-secondary);
+  }
+
+  .module-card-summary {
+    padding: 16px;
+  }
+
+  .full-graph-filter-panel {
+    position: absolute;
+    top: 72px;
+    right: 16px;
+    width: min(320px, calc(100% - 32px));
+    max-height: calc(100% - 88px);
+    overflow-y: auto;
+  }
+
+  .focused-domain-indicator {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    max-width: min(360px, calc(100% - 88px));
+    padding: 10px 12px;
+  }
+
+  .focused-domain-indicator-name {
+    overflow: hidden;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.2;
+    color: var(--text-primary);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .focused-domain-indicator-count {
+    font-size: 11px;
+    color: var(--text-secondary);
+  }
+
+  .focused-domain-indicator-clear {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    margin-left: 4px;
+    border-radius: calc(var(--radius) / 2);
+    color: var(--text-secondary);
+  }
+
+  .focused-domain-indicator-clear:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+  }
+
+  .domain-node-other {
+    border-color: var(--text-tertiary) !important;
+  }
+
+  .domain-node-bff {
+    border-color: var(--purple) !important;
+  }
+
+  .domain-node-ui {
+    border-color: var(--node-ui) !important;
+  }
+
+  .domain-node-system-type {
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1.2;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
   }
 
   .flow-step-subscribed-events {

--- a/apps/eclair/src/platform/domain/domain-node-types.ts
+++ b/apps/eclair/src/platform/domain/domain-node-types.ts
@@ -1,6 +1,11 @@
+import type { SystemType } from '@living-architecture/riviere-schema'
+
+export type DomainMapSystemType = SystemType | 'external'
+
 export interface DomainNodeData {
   label: string
   nodeCount: number
+  systemType: DomainMapSystemType
   calculatedSize?: number
   dimmed?: boolean
   isExternal?: boolean

--- a/apps/eclair/src/platform/domain/node-type-presentation.spec.ts
+++ b/apps/eclair/src/platform/domain/node-type-presentation.spec.ts
@@ -1,0 +1,107 @@
+import {
+  // Keep expanded for ESLint.
+  describe,
+  expect,
+  it,
+} from 'vitest'
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import {
+  getEffectiveNodeType,
+  getNodeTypeColor,
+  getNodeTypeDescription,
+  getNodeTypesInGraph,
+} from './node-type-presentation'
+import { TestAssertionError } from '@/test-assertions'
+
+const graph: RiviereGraph = {
+  version: '1.0',
+  metadata: {
+    domains: {
+      orders: {
+        description: 'Orders',
+        systemType: 'other',
+      },
+    },
+    customTypes: {
+      Job: { description: 'A scheduled unit of work' },
+      Table: { description: 'Stored data' },
+    },
+  },
+  components: [
+    {
+      id: 'job-1',
+      type: 'Custom',
+      customTypeName: 'Job',
+      name: 'Import orders',
+      domain: 'orders',
+      module: 'agent',
+      sourceLocation: { filePath: 'jobs.csv' },
+    },
+    {
+      id: 'table-1',
+      type: 'Custom',
+      customTypeName: 'Table',
+      name: 'Orders',
+      domain: 'orders',
+      module: 'database',
+      sourceLocation: { filePath: 'orders.sql' },
+    },
+    {
+      id: 'api-1',
+      type: 'API',
+      name: 'Orders API',
+      domain: 'orders',
+      module: 'api',
+      path: '/orders',
+      sourceLocation: { filePath: 'api.ts' },
+    },
+  ],
+  links: [],
+}
+
+function componentById(id: string): RiviereGraph['components'][number] {
+  const component = graph.components.find((candidate) => candidate.id === id)
+  if (component === undefined) throw new TestAssertionError(`Missing test component: ${id}`)
+  return component
+}
+
+describe('node type presentation', () => {
+  it('uses a declared custom type as the effective type', () => {
+    expect(getEffectiveNodeType(componentById('job-1'))).toBe('Job')
+    expect(getEffectiveNodeType(componentById('api-1'))).toBe('API')
+  })
+
+  it('returns the sorted effective types present in the graph', () => {
+    expect(getNodeTypesInGraph(graph)).toStrictEqual(['API', 'Job', 'Table'])
+    expect(getNodeTypesInGraph(graph, true)).toStrictEqual(['API', 'Job', 'Table'])
+  })
+
+  it('includes External only when requested and present', () => {
+    const graphWithExternal: RiviereGraph = {
+      ...graph,
+      externalLinks: [
+        {
+          source: 'api-1',
+          target: { name: 'Payments' },
+        },
+      ],
+    }
+    expect(getNodeTypesInGraph(graphWithExternal, true)).toStrictEqual([
+      'API',
+      'External',
+      'Job',
+      'Table',
+    ])
+  })
+
+  it('returns graph-defined custom type descriptions', () => {
+    expect(getNodeTypeDescription(graph, 'Job')).toBe('A scheduled unit of work')
+    expect(getNodeTypeDescription(graph, 'API')).toBeUndefined()
+  })
+
+  it('maps built-in and custom types deterministically in every theme', () => {
+    expect(getNodeTypeColor('API', 'stream')).toBe('#0D9488')
+    expect(getNodeTypeColor('Job', 'stream')).toBe(getNodeTypeColor('Job', 'stream'))
+    expect(getNodeTypeColor('Job', 'voltage')).not.toBe(getNodeTypeColor('Job', 'stream'))
+  })
+})

--- a/apps/eclair/src/platform/domain/node-type-presentation.ts
+++ b/apps/eclair/src/platform/domain/node-type-presentation.ts
@@ -1,0 +1,142 @@
+import type {
+  Component,
+  RiviereGraph,
+  CustomTypeDefinition,
+} from '@living-architecture/riviere-schema'
+import type { Theme } from '@/types/theme'
+import { compareByCodePoint } from './compare-by-code-point'
+
+const BUILT_IN_NODE_COLORS: Record<Theme, Record<string, string>> = {
+  stream: {
+    UI: '#F43F5E',
+    API: '#0D9488',
+    UseCase: '#A78BFA',
+    DomainOp: '#06B6D4',
+    Event: '#F59E0B',
+    EventHandler: '#EAB308',
+    Custom: '#78716C',
+    External: '#94A3B8',
+  },
+  voltage: {
+    UI: '#FB7185',
+    API: '#00D4FF',
+    UseCase: '#C4B5FD',
+    DomainOp: '#22D3EE',
+    Event: '#F97316',
+    EventHandler: '#FACC15',
+    Custom: '#A8A29E',
+    External: '#94A3B8',
+  },
+  circuit: {
+    UI: '#E11D48',
+    API: '#0969DA',
+    UseCase: '#A78BFA',
+    DomainOp: '#0550AE',
+    Event: '#BF8700',
+    EventHandler: '#9A6700',
+    Custom: '#57534E',
+    External: '#9CA3AF',
+  },
+}
+
+type NonEmptyPalette = readonly [string, ...string[]]
+
+const CUSTOM_NODE_PALETTES: Record<Theme, NonEmptyPalette> = {
+  stream: [
+    '#7C3AED',
+    '#0369A1',
+    '#B45309',
+    '#0F766E',
+    '#BE123C',
+    '#4338CA',
+    '#047857',
+    '#A21CAF',
+    '#C2410C',
+    '#4D7C0F',
+    '#6D28D9',
+    '#0E7490',
+    '#9F1239',
+    '#1D4ED8',
+    '#15803D',
+    '#A16207',
+  ],
+  voltage: [
+    '#C4B5FD',
+    '#38BDF8',
+    '#FDBA74',
+    '#2DD4BF',
+    '#FDA4AF',
+    '#A5B4FC',
+    '#6EE7B7',
+    '#F0ABFC',
+    '#FB923C',
+    '#BEF264',
+    '#A78BFA',
+    '#67E8F9',
+    '#FB7185',
+    '#60A5FA',
+    '#4ADE80',
+    '#FACC15',
+  ],
+  circuit: [
+    '#8250DF',
+    '#0969DA',
+    '#9A6700',
+    '#1A7F37',
+    '#CF222E',
+    '#3E4C9E',
+    '#116329',
+    '#8250DF',
+    '#BC4C00',
+    '#4D7C0F',
+    '#6F42C1',
+    '#0550AE',
+    '#A40E26',
+    '#218BFF',
+    '#2DA44E',
+    '#953800',
+  ],
+}
+
+export function getEffectiveNodeType(component: Component): string {
+  return component.type === 'Custom' ? component.customTypeName : component.type
+}
+
+export function getNodeTypesInGraph(graph: RiviereGraph, includeExternal = false): string[] {
+  const types = new Set(graph.components.map(getEffectiveNodeType))
+  if (includeExternal && (graph.externalLinks?.length ?? 0) > 0) {
+    types.add('External')
+  }
+  return [...types].sort(compareByCodePoint)
+}
+
+function getNodeTypeDefinition(
+  graph: RiviereGraph,
+  type: string,
+): CustomTypeDefinition | undefined {
+  return graph.metadata.customTypes?.[type]
+}
+
+export function getNodeTypeDescription(graph: RiviereGraph, type: string): string | undefined {
+  return getNodeTypeDefinition(graph, type)?.description
+}
+
+export function getNodeTypeColor(type: string, theme: Theme): string {
+  const builtInColor = BUILT_IN_NODE_COLORS[theme][type]
+  if (builtInColor !== undefined) return builtInColor
+
+  const palette = CUSTOM_NODE_PALETTES[theme]
+  const targetIndex = stableHash(type) % palette.length
+  return palette.reduce((selected, candidate, index) =>
+    index === targetIndex ? candidate : selected,
+  )
+}
+
+function stableHash(value: string): number {
+  return (
+    [...value].reduce(
+      (hash, character) => Math.imul(hash ^ character.charCodeAt(0), 16777619),
+      2166136261,
+    ) >>> 0
+  )
+}

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/FocusModeStyling.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/FocusModeStyling.ts
@@ -4,62 +4,6 @@ import type {
   SimulationNode, SimulationLink 
 } from '../graph-types'
 
-export interface FocusModeCircleParams {
-  node: d3.Selection<SVGGElement, SimulationNode, SVGGElement, unknown>
-  focusedDomain: string
-  focusColors: { glowColor: string }
-  transitionDuration: number
-  nodeRadiusScale: {
-    focusedRadius: number
-    unfocusedRadius: number
-  }
-  opacityValues: {
-    focusedNode: number
-    unfocusedNode: number
-  }
-  strokeWidths: {
-    focusedNodeWidth: number
-    unfocusedNodeWidth: number
-  }
-  getNodeRadius: (type: NodeType) => number
-  unfocusedStrokeColor: string
-}
-
-export function applyFocusModeCircleStyles({
-  node,
-  focusedDomain,
-  focusColors,
-  transitionDuration,
-  nodeRadiusScale,
-  opacityValues,
-  strokeWidths,
-  getNodeRadius,
-  unfocusedStrokeColor,
-}: FocusModeCircleParams): void {
-  node
-    .selectAll<SVGCircleElement, SimulationNode>('circle')
-    .transition()
-    .duration(transitionDuration)
-    .attr('r', (d) => {
-      const baseRadius = getNodeRadius(d.type)
-      return d.domain === focusedDomain
-        ? baseRadius * nodeRadiusScale.focusedRadius
-        : baseRadius * nodeRadiusScale.unfocusedRadius
-    })
-    .attr('opacity', (d) =>
-      d.domain === focusedDomain ? opacityValues.focusedNode : opacityValues.unfocusedNode,
-    )
-    .attr('stroke-width', (d) =>
-      d.domain === focusedDomain ? strokeWidths.focusedNodeWidth : strokeWidths.unfocusedNodeWidth,
-    )
-    .attr('stroke', (d) =>
-      d.domain === focusedDomain ? focusColors.glowColor : unfocusedStrokeColor,
-    )
-    .attr('filter', (d) =>
-      d.domain === focusedDomain ? 'url(#focused-glow)' : 'url(#blur-background)',
-    )
-}
-
 export interface ResetModeCircleParams {
   node: d3.Selection<SVGGElement, SimulationNode, SVGGElement, unknown>
   transitionDuration: number
@@ -82,55 +26,8 @@ export function applyResetModeCircleStyles({
     .attr('filter', 'none')
 }
 
-export interface FocusModeLinkParams {
-  link: d3.Selection<SVGPathElement, SimulationLink, SVGGElement, unknown>
-  nodes: SimulationNode[]
-  focusedDomain: string
-  transitionDuration: number
-  focusedOpacity: number
-  unfocusedOpacity: number
-  focusedStrokeWidth: number
-  unfocusedStrokeWidth: number
-}
-
 export function getLinkNodeId(nodeOrId: SimulationNode | string): string {
   return typeof nodeOrId === 'string' ? nodeOrId : nodeOrId.id
-}
-
-export function applyFocusModeLinkStyles({
-  link,
-  nodes,
-  focusedDomain,
-  transitionDuration,
-  focusedOpacity,
-  unfocusedOpacity,
-  focusedStrokeWidth,
-  unfocusedStrokeWidth,
-}: FocusModeLinkParams): void {
-  link
-    .transition()
-    .duration(transitionDuration)
-    .attr('opacity', (d) => {
-      const sourceNode = nodes.find((n) => n.id === getLinkNodeId(d.source))
-      const targetNode = nodes.find((n) => n.id === getLinkNodeId(d.target))
-      const isInFocusedDomain =
-        sourceNode?.domain === focusedDomain || targetNode?.domain === focusedDomain
-      return isInFocusedDomain ? focusedOpacity : unfocusedOpacity
-    })
-    .attr('stroke-width', (d) => {
-      const sourceNode = nodes.find((n) => n.id === getLinkNodeId(d.source))
-      const targetNode = nodes.find((n) => n.id === getLinkNodeId(d.target))
-      const bothInDomain =
-        sourceNode?.domain === focusedDomain && targetNode?.domain === focusedDomain
-      return bothInDomain ? focusedStrokeWidth : unfocusedStrokeWidth
-    })
-    .attr('filter', (d) => {
-      const sourceNode = nodes.find((n) => n.id === getLinkNodeId(d.source))
-      const targetNode = nodes.find((n) => n.id === getLinkNodeId(d.target))
-      const isInFocusedDomain =
-        sourceNode?.domain === focusedDomain || targetNode?.domain === focusedDomain
-      return isInFocusedDomain ? 'none' : 'url(#blur-background)'
-    })
 }
 
 export interface ResetModeLinkParams {
@@ -147,40 +44,6 @@ export function applyResetModeLinkStyles({
     .attr('opacity', 0.6)
     .attr('stroke-width', 2)
     .attr('filter', 'none')
-}
-
-export interface FocusModeTextParams {
-  node: d3.Selection<SVGGElement, SimulationNode, SVGGElement, unknown>
-  focusedDomain: string
-  transitionDuration: number
-  selector: string
-  focusedOpacity: number
-  focusedFontSize: string
-  focusedFontWeight: number
-  unfocusedFontSize: string
-  unfocusedFontWeight: number
-}
-
-export function applyFocusModeTextStyles({
-  node,
-  focusedDomain,
-  transitionDuration,
-  selector,
-  focusedOpacity,
-  focusedFontSize,
-  focusedFontWeight,
-  unfocusedFontSize,
-  unfocusedFontWeight,
-}: FocusModeTextParams): void {
-  node
-    .selectAll<SVGTextElement, SimulationNode>(selector)
-    .transition()
-    .duration(transitionDuration)
-    .attr('opacity', (d) => (d.domain === focusedDomain ? focusedOpacity : 0))
-    .attr('font-size', (d) => (d.domain === focusedDomain ? focusedFontSize : unfocusedFontSize))
-    .attr('font-weight', (d) =>
-      d.domain === focusedDomain ? focusedFontWeight : unfocusedFontWeight,
-    )
 }
 
 export interface ResetModeTextParams {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.focus-lifecycle.spec.tsx
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.focus-lifecycle.spec.tsx
@@ -1,0 +1,116 @@
+import {
+  afterEach, describe, expect, it, vi,
+} from 'vitest'
+import {
+  act, render, waitFor,
+} from '@testing-library/react'
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import { ForceGraph } from './ForceGraph'
+import {
+  parseDomainMetadata, parseNode,
+} from '@/platform/infra/__fixtures__/riviere-test-fixtures'
+
+const {
+  applyFocusModeMock, applyResetModeMock,
+} = vi.hoisted(() => ({
+  applyFocusModeMock: vi.fn(),
+  applyResetModeMock: vi.fn(),
+}))
+
+vi.mock('./applyFocusModeBehavior', () => ({
+  applyFocusMode: applyFocusModeMock,
+  applyResetMode: applyResetModeMock,
+}))
+
+const graph: RiviereGraph = {
+  version: '1.0',
+  metadata: {
+    domains: parseDomainMetadata({
+      orders: {
+        description: 'Orders',
+        systemType: 'domain',
+      },
+    }),
+  },
+  components: [
+    parseNode({
+      id: 'orders-api',
+      type: 'API',
+      name: 'Orders API',
+      domain: 'orders',
+      module: 'api',
+      sourceLocation: {
+        repository: 'test-repository',
+        filePath: 'orders.ts',
+      },
+    }),
+  ],
+  links: [],
+}
+
+type ResizeCallback = (
+  entries: ReadonlyArray<{
+    readonly contentRect: {
+      readonly width: number
+      readonly height: number
+    }
+  }>,
+) => void
+type ResizeGraph = (width: number, height: number) => void
+
+describe('ForceGraph focus lifecycle', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reapplies focus mode after the SVG is rebuilt on resize', async () => {
+    const resizeController: { resize: ResizeGraph | undefined } = { resize: undefined }
+    class SizedResizeObserver {
+      constructor(callback: ResizeCallback) {
+        resizeController.resize = (width, height) =>
+          callback([
+            {
+              contentRect: {
+                width,
+                height,
+              },
+            },
+          ])
+      }
+
+      observe(target: Element): void {
+        const svg = target.querySelector('svg')
+        if (!(svg instanceof SVGSVGElement)) {
+          throw new TypeError('Expected ForceGraph SVG before observing its container')
+        }
+        Object.defineProperties(svg, {
+          width: { value: { baseVal: { value: 800 } } },
+          height: { value: { baseVal: { value: 600 } } },
+        })
+        resizeController.resize?.(800, 600)
+      }
+
+      disconnect(): void {
+        return
+      }
+    }
+    vi.stubGlobal('ResizeObserver', SizedResizeObserver)
+
+    render(<ForceGraph graph={graph} theme="stream" focusedDomain="orders" />)
+
+    await waitFor(() =>
+      expect(applyFocusModeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ domain: 'orders' }),
+      ),
+    )
+    applyFocusModeMock.mockClear()
+
+    act(() => resizeController.resize?.(1024, 768))
+
+    await waitFor(() =>
+      expect(applyFocusModeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ domain: 'orders' }),
+      ),
+    )
+  })
+})

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
@@ -51,6 +51,35 @@ interface ForceGraphProps {
   readonly onBackgroundClick?: () => void
 }
 
+interface ApplyDomainFocusParams {
+  readonly node: d3.Selection<SVGGElement, SimulationNode, SVGGElement, unknown>
+  readonly link: d3.Selection<SVGPathElement, SimulationLink, SVGGElement, unknown>
+  readonly focusedDomain: string | null | undefined
+  readonly theme: Theme
+}
+
+function applyDomainFocus({
+  node,
+  link,
+  focusedDomain,
+  theme,
+}: ApplyDomainFocusParams): void {
+  if (focusedDomain !== null && focusedDomain !== undefined) {
+    applyFocusMode({
+      node,
+      link,
+      domain: focusedDomain,
+      theme,
+    })
+    return
+  }
+
+  applyResetMode({
+    node,
+    link,
+  })
+}
+
 export function ForceGraph({
   graph,
   theme,
@@ -85,7 +114,9 @@ export function ForceGraph({
   const nodesRef = useRef<SimulationNode[]>([])
   const wasHighlightedRef = useRef(false)
   const onNodeHoverRef = useRef(onNodeHover)
+  const focusedDomainRef = useRef(focusedDomain)
   onNodeHoverRef.current = onNodeHover
+  focusedDomainRef.current = focusedDomain
 
   const filteredNodes = visibleNodeIds
     ? graph.components.filter((n) => visibleNodeIds.has(n.id))
@@ -330,6 +361,12 @@ export function ForceGraph({
     nodesRef.current = nodes
 
     applyVisualization(node, link, zoom, svg, nodes, undefined, isGraphDataChange)
+    applyDomainFocus({
+      node,
+      link,
+      focusedDomain: focusedDomainRef.current,
+      theme,
+    })
     svg.on('click', handleBackgroundClick)
   }, [
     filteredNodes,
@@ -347,21 +384,13 @@ export function ForceGraph({
     const link = linkSelectionRef.current
     if (node === null || link === null) return
 
-    if (focusedDomain) {
-      applyFocusMode({
-        node,
-        link,
-        domain: focusedDomain,
-        theme,
-      })
-      return
-    }
-
-    applyResetMode({
+    applyDomainFocus({
       node,
       link,
+      focusedDomain,
+      theme,
     })
-  }, [focusedDomain, theme, filteredNodes])
+  }, [focusedDomain, theme])
 
   useEffect(() => {
     const node = nodeSelectionRef.current

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
@@ -165,23 +165,9 @@ export function ForceGraph({
       zoom: d3.ZoomBehavior<SVGSVGElement, unknown>,
       svg: d3.Selection<SVGSVGElement, unknown, d3.BaseType, unknown>,
       nodes: SimulationNode[],
-      domain: string | null | undefined,
       highlightIds: Set<string> | undefined,
       shouldFitViewport: boolean,
     ) => {
-      if (domain) {
-        applyFocusMode({
-          svg,
-          node,
-          link,
-          zoom,
-          nodes,
-          domain,
-          theme,
-          dimensions,
-        })
-        return
-      }
       if (highlightIds) {
         return
       }
@@ -193,7 +179,7 @@ export function ForceGraph({
         fitViewportFn(svg, zoom, nodes)
       }
     },
-    [fitViewportFn, dimensions, theme],
+    [fitViewportFn, dimensions],
   )
 
   const setupNodeEvents = useCallback(
@@ -229,7 +215,7 @@ export function ForceGraph({
     const svg = d3.select(svgRef.current)
     svg.selectAll('*').remove()
 
-    const regularNodes = createSimulationNodes(filteredNodes)
+    const regularNodes = createSimulationNodes(filteredNodes, graph.metadata.customTypes)
     const regularLinks = createSimulationLinks(filteredEdges)
     const externalNodes = createExternalNodes(graph.externalLinks)
     const externalSimLinks = createExternalLinks(graph.externalLinks)
@@ -343,7 +329,7 @@ export function ForceGraph({
     zoomRef.current = zoom
     nodesRef.current = nodes
 
-    applyVisualization(node, link, zoom, svg, nodes, focusedDomain, undefined, isGraphDataChange)
+    applyVisualization(node, link, zoom, svg, nodes, undefined, isGraphDataChange)
     svg.on('click', handleBackgroundClick)
   }, [
     filteredNodes,
@@ -351,11 +337,31 @@ export function ForceGraph({
     allEdgesForTracing,
     theme,
     dimensions,
-    focusedDomain,
     applyVisualization,
     setupNodeEvents,
     handleBackgroundClick,
   ])
+
+  useEffect(() => {
+    const node = nodeSelectionRef.current
+    const link = linkSelectionRef.current
+    if (node === null || link === null) return
+
+    if (focusedDomain) {
+      applyFocusMode({
+        node,
+        link,
+        domain: focusedDomain,
+        theme,
+      })
+      return
+    }
+
+    applyResetMode({
+      node,
+      link,
+    })
+  }, [focusedDomain, theme, filteredNodes])
 
   useEffect(() => {
     const node = nodeSelectionRef.current

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.ts
@@ -1,10 +1,7 @@
 export {
   getLinkNodeId,
-  applyFocusModeCircleStyles,
   applyResetModeCircleStyles,
-  applyFocusModeLinkStyles,
   applyResetModeLinkStyles,
-  applyFocusModeTextStyles,
   applyResetModeTextStyles,
   setupLinks,
   setupNodes,

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/VisualizationDataAdapters.spec.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/VisualizationDataAdapters.spec.ts
@@ -55,6 +55,28 @@ describe('VisualizationDataAdapters', () => {
       })
       expect(result[0]?.originalNode).toBeDefined()
     })
+
+    it('adds the declared custom type and its description to simulation nodes', () => {
+      const nodes: Node[] = [
+        parseNode({
+          sourceLocation: testSourceLocation,
+          id: 'job-1',
+          type: 'Custom',
+          customTypeName: 'Job',
+          name: 'Load warehouse',
+          domain: 'operations',
+          module: 'Scheduler',
+        }),
+      ]
+
+      const result = createSimulationNodes(nodes, {Job: { description: 'A scheduled unit of work' },})
+
+      expect(result[0]).toMatchObject({
+        type: 'Custom',
+        effectiveType: 'Job',
+        typeDescription: 'A scheduled unit of work',
+      })
+    })
   })
 
   describe('createSimulationLinks', () => {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/VisualizationDataAdapters.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/VisualizationDataAdapters.ts
@@ -1,18 +1,16 @@
-import type { ExternalLink } from '@living-architecture/riviere-schema'
+import type * as RiviereSchema from '@living-architecture/riviere-schema'
 import type {
   Node, NodeType, Edge 
 } from '@/platform/domain/eclair-types'
-import type {
-  SimulationNode, SimulationLink 
-} from '../graph-types'
+import * as GraphTypes from '../graph-types'
 import type { Theme } from '@/types/theme'
 import {
-  EDGE_COLORS,
-  SEMANTIC_EDGE_COLORS,
-  NODE_COLORS,
-  NODE_RADII,
-  getDomainColor,
-} from '../graph-types'
+  getEffectiveNodeType,
+  getNodeTypeColor as getPresentationNodeTypeColor,
+} from '@/platform/domain/node-type-presentation'
+
+type SimulationNode = GraphTypes.SimulationNode
+type SimulationLink = GraphTypes.SimulationLink
 
 interface ExternalNode {
   id: string
@@ -26,10 +24,16 @@ interface ExternalNode {
   url?: string
 }
 
-export function createSimulationNodes(nodes: Node[]): SimulationNode[] {
+export function createSimulationNodes(
+  nodes: Node[],
+  customTypes: Record<string, RiviereSchema.CustomTypeDefinition> | undefined = undefined,
+): SimulationNode[] {
   return nodes.map((node) => ({
     id: node.id,
     type: node.type,
+    effectiveType: getEffectiveNodeType(node),
+    typeDescription:
+      node.type === 'Custom' ? customTypes?.[node.customTypeName]?.description : undefined,
     name: node.name,
     domain: node.domain,
     originalNode: node,
@@ -49,7 +53,7 @@ function createExternalNodeId(name: string): string {
   return `external:${name}`
 }
 
-function createExternalNodeFromLink(link: ExternalLink): ExternalNode {
+function createExternalNodeFromLink(link: RiviereSchema.ExternalLink): ExternalNode {
   return {
     id: createExternalNodeId(link.target.name),
     type: 'External',
@@ -63,7 +67,9 @@ function createExternalNodeFromLink(link: ExternalLink): ExternalNode {
   }
 }
 
-export function createExternalNodes(externalLinks: ExternalLink[] | undefined): SimulationNode[] {
+export function createExternalNodes(
+  externalLinks: RiviereSchema.ExternalLink[] | undefined,
+): SimulationNode[] {
   if (externalLinks === undefined) {
     return []
   }
@@ -82,6 +88,8 @@ export function createExternalNodes(externalLinks: ExternalLink[] | undefined): 
     externalNodes.push({
       id: externalNode.id,
       type: 'External',
+      effectiveType: 'External',
+      typeDescription: undefined,
       name: externalNode.name,
       domain: 'external',
       originalNode: externalNode,
@@ -91,7 +99,9 @@ export function createExternalNodes(externalLinks: ExternalLink[] | undefined): 
   return externalNodes
 }
 
-export function createExternalLinks(externalLinks: ExternalLink[] | undefined): SimulationLink[] {
+export function createExternalLinks(
+  externalLinks: RiviereSchema.ExternalLink[] | undefined,
+): SimulationLink[] {
   if (externalLinks === undefined) {
     return []
   }
@@ -113,16 +123,16 @@ export function createExternalLinks(externalLinks: ExternalLink[] | undefined): 
   })
 }
 
-export function getNodeColor(type: NodeType, theme: Theme): string {
-  return NODE_COLORS[theme][type]
+export function getNodeColor(type: string, theme: Theme): string {
+  return getPresentationNodeTypeColor(type, theme)
 }
 
 export function getNodeRadius(type: NodeType): number {
-  return NODE_RADII[type]
+  return GraphTypes.NODE_RADII[type]
 }
 
 export function getEdgeColor(type: string | undefined, theme: Theme): string {
-  const colors = EDGE_COLORS[theme]
+  const colors = GraphTypes.EDGE_COLORS[theme]
   if (type === 'async') {
     return colors.async
   }
@@ -146,7 +156,7 @@ export function getSemanticEdgeColor(
   theme: Theme,
 ): string {
   const semanticType = getSemanticEdgeType(sourceType, targetType)
-  return SEMANTIC_EDGE_COLORS[theme][semanticType]
+  return GraphTypes.SEMANTIC_EDGE_COLORS[theme][semanticType]
 }
 
 export function truncateName(name: string, maxLength: number): string {
@@ -161,7 +171,7 @@ interface LayoutEdge {
 
 export function createLayoutEdges(
   internalEdges: Edge[],
-  externalLinks: ExternalLink[] | undefined,
+  externalLinks: RiviereSchema.ExternalLink[] | undefined,
 ): LayoutEdge[] {
   const layoutEdges: LayoutEdge[] = internalEdges.map((e) => ({
     source: e.source,
@@ -180,4 +190,4 @@ export function createLayoutEdges(
   return layoutEdges
 }
 
-export { getDomainColor }
+export const getDomainColor = GraphTypes.getDomainColor

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/applyFocusModeBehavior.spec.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/applyFocusModeBehavior.spec.ts
@@ -1,5 +1,8 @@
 import {
-  describe, it, expect, vi 
+  // Keep expanded for ESLint.
+  describe,
+  expect,
+  it,
 } from 'vitest'
 import * as d3 from 'd3'
 import {
@@ -21,6 +24,8 @@ function createTestNode(id: string, type: SimulationNode['type'], domain: string
   return {
     id,
     type,
+    effectiveType: type,
+    typeDescription: undefined,
     name: `node-${id}`,
     domain,
     x: 100,
@@ -56,7 +61,6 @@ interface TestContext {
   svg: d3.Selection<SVGSVGElement, unknown, null, undefined>
   nodeGroup: d3.Selection<SVGGElement, unknown, null, undefined>
   linkGroup: d3.Selection<SVGGElement, unknown, null, undefined>
-  zoom: d3.ZoomBehavior<SVGSVGElement, unknown>
 }
 
 function createTestContext(): TestContext {
@@ -69,21 +73,11 @@ function createTestContext(): TestContext {
   const nodeGroup = svg.append('g').attr('class', 'nodes')
   const linkGroup = svg.append('g').attr('class', 'links')
 
-  const zoom = d3.zoom<SVGSVGElement, unknown>()
-
-  const originalTransition = svg.transition.bind(svg)
-  vi.spyOn(svg, 'transition').mockImplementation(() => {
-    const t = originalTransition()
-    vi.spyOn(t, 'call').mockReturnValue(t)
-    return t
-  })
-
   return {
     svgElement,
     svg,
     nodeGroup,
     linkGroup,
-    zoom,
   }
 }
 
@@ -118,17 +112,10 @@ describe('applyFocusModeBehavior', () => {
 
       expect(() =>
         applyFocusMode({
-          svg: ctx.svg,
           node: nodeSelection,
           link: linkSelection,
-          zoom: ctx.zoom,
-          nodes,
           domain: 'orders',
           theme: 'stream',
-          dimensions: {
-            width: 800,
-            height: 600,
-          },
         }),
       ).not.toThrow()
 
@@ -149,17 +136,10 @@ describe('applyFocusModeBehavior', () => {
 
       expect(() =>
         applyFocusMode({
-          svg: ctx.svg,
           node: nodeSelection,
           link: linkSelection,
-          zoom: ctx.zoom,
-          nodes,
           domain: 'nonexistent',
           theme: 'stream',
-          dimensions: {
-            width: 800,
-            height: 600,
-          },
         }),
       ).not.toThrow()
 
@@ -183,17 +163,10 @@ describe('applyFocusModeBehavior', () => {
 
       expect(() =>
         applyFocusMode({
-          svg: ctx.svg,
           node: nodeSelection,
           link: linkSelection,
-          zoom: ctx.zoom,
-          nodes,
           domain: 'orders',
           theme: 'voltage',
-          dimensions: {
-            width: 800,
-            height: 600,
-          },
         }),
       ).not.toThrow()
 
@@ -217,17 +190,10 @@ describe('applyFocusModeBehavior', () => {
 
       expect(() =>
         applyFocusMode({
-          svg: ctx.svg,
           node: nodeSelection,
           link: linkSelection,
-          zoom: ctx.zoom,
-          nodes,
           domain: 'orders',
           theme: 'circuit',
-          dimensions: {
-            width: 800,
-            height: 600,
-          },
         }),
       ).not.toThrow()
 
@@ -254,17 +220,10 @@ describe('applyFocusModeBehavior', () => {
 
       expect(() =>
         applyFocusMode({
-          svg: ctx.svg,
           node: nodeSelection,
           link: linkSelection,
-          zoom: ctx.zoom,
-          nodes,
           domain: 'nonexistent',
           theme: 'stream',
-          dimensions: {
-            width: 800,
-            height: 600,
-          },
         }),
       ).not.toThrow()
 
@@ -348,17 +307,10 @@ describe('applyFocusModeBehavior', () => {
         .join('path')
 
       applyFocusMode({
-        svg: ctx.svg,
         node: nodeSelection,
         link: linkSelection,
-        zoom: ctx.zoom,
-        nodes,
         domain: 'orders',
         theme: 'stream',
-        dimensions: {
-          width: 800,
-          height: 600,
-        },
       })
 
       expect(() =>

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/applyFocusModeBehavior.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/applyFocusModeBehavior.ts
@@ -5,108 +5,40 @@ import type {
 import type { Theme } from '@/types/theme'
 import { getThemeFocusColors } from '@/platform/domain/theme-focus-colors'
 import {
-  FOCUS_MODE_TRANSITIONS,
-  FOCUS_MODE_NODE_SCALES,
-  FOCUS_MODE_OPACITY,
-  FOCUS_MODE_STROKES,
-  FOCUS_MODE_TEXT,
-  UNFOCUSED_NODE_STROKE_COLOR,
-} from '@/platform/domain/focus-mode-constants'
-import {
-  applyFocusModeCircleStyles,
   applyResetModeCircleStyles,
-  applyFocusModeLinkStyles,
   applyResetModeLinkStyles,
-  applyFocusModeTextStyles,
   applyResetModeTextStyles,
-  calculateFocusModeZoom,
 } from './GraphRenderingSetup'
 import { getNodeRadius } from './VisualizationDataAdapters'
+import { FOCUS_MODE_TRANSITIONS } from '@/platform/domain/focus-mode-constants'
 
 export interface ApplyFocusModeParams {
-  svg: d3.Selection<SVGSVGElement, unknown, d3.BaseType, unknown>
   node: d3.Selection<SVGGElement, SimulationNode, SVGGElement, unknown>
   link: d3.Selection<SVGPathElement, SimulationLink, SVGGElement, unknown>
-  zoom: d3.ZoomBehavior<SVGSVGElement, unknown>
-  nodes: SimulationNode[]
   domain: string
   theme: Theme
-  dimensions: {
-    width: number
-    height: number
-  }
 }
 
 export function applyFocusMode(params: ApplyFocusModeParams): void {
-  const {
-    svg, node, link, zoom, nodes, domain, theme, dimensions 
-  } = params
+  const node = params.node
+  const link = params.link
+  const domain = params.domain
+  const theme = params.theme
   const focusColors = getThemeFocusColors(theme)
 
-  applyFocusModeCircleStyles({
+  applyResetMode({
     node,
-    focusedDomain: domain,
-    focusColors,
-    transitionDuration: FOCUS_MODE_TRANSITIONS.elementAnimation,
-    nodeRadiusScale: FOCUS_MODE_NODE_SCALES,
-    opacityValues: FOCUS_MODE_OPACITY,
-    strokeWidths: FOCUS_MODE_STROKES,
-    getNodeRadius,
-    unfocusedStrokeColor: UNFOCUSED_NODE_STROKE_COLOR,
-  })
-
-  applyFocusModeTextStyles({
-    node,
-    focusedDomain: domain,
-    transitionDuration: FOCUS_MODE_TRANSITIONS.elementAnimation,
-    selector: '.node-label',
-    focusedOpacity: 1,
-    focusedFontSize: FOCUS_MODE_TEXT.focusedLabelSize,
-    focusedFontWeight: FOCUS_MODE_TEXT.focusedLabelWeight,
-    unfocusedFontSize: FOCUS_MODE_TEXT.unfocusedLabelSize,
-    unfocusedFontWeight: FOCUS_MODE_TEXT.unfocusedLabelWeight,
-  })
-
-  applyFocusModeTextStyles({
-    node,
-    focusedDomain: domain,
-    transitionDuration: FOCUS_MODE_TRANSITIONS.elementAnimation,
-    selector: '.node-domain-label',
-    focusedOpacity: 1,
-    focusedFontSize: FOCUS_MODE_TEXT.focusedDomainSize,
-    focusedFontWeight: FOCUS_MODE_TEXT.focusedDomainWeight,
-    unfocusedFontSize: FOCUS_MODE_TEXT.unfocusedDomainSize,
-    unfocusedFontWeight: FOCUS_MODE_TEXT.unfocusedDomainWeight,
-  })
-
-  applyFocusModeLinkStyles({
     link,
-    nodes,
-    focusedDomain: domain,
-    transitionDuration: FOCUS_MODE_TRANSITIONS.elementAnimation,
-    focusedOpacity: FOCUS_MODE_OPACITY.focusedEdge,
-    unfocusedOpacity: FOCUS_MODE_OPACITY.unfocusedEdge,
-    focusedStrokeWidth: FOCUS_MODE_STROKES.focusedEdgeWidth,
-    unfocusedStrokeWidth: FOCUS_MODE_STROKES.unfocusedEdgeWidth,
   })
-
-  const focusZoom = calculateFocusModeZoom({
-    nodes,
-    focusedDomain: domain,
-    dimensions,
-  })
-
-  if (focusZoom) {
-    svg
-      .transition()
-      .duration(FOCUS_MODE_TRANSITIONS.zoomAnimation)
-      .call(
-        zoom.transform,
-        d3.zoomIdentity
-          .translate(focusZoom.translateX, focusZoom.translateY)
-          .scale(focusZoom.scale),
-      )
-  }
+  node
+    .selectAll<SVGCircleElement, SimulationNode>('circle')
+    .transition()
+    .duration(FOCUS_MODE_TRANSITIONS.elementAnimation)
+    .attr('stroke', (datum) =>
+      datum.domain === domain ? focusColors.glowColor : 'rgba(255, 255, 255, 0.3)',
+    )
+    .attr('stroke-width', (datum) => (datum.domain === domain ? 5 : 2))
+    .attr('filter', (datum) => (datum.domain === domain ? 'url(#focused-glow)' : 'none'))
 }
 
 export interface ApplyResetModeParams {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/applyFocusModeBehavior.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/applyFocusModeBehavior.ts
@@ -11,6 +11,7 @@ import {
 } from './GraphRenderingSetup'
 import { getNodeRadius } from './VisualizationDataAdapters'
 import { FOCUS_MODE_TRANSITIONS } from '@/platform/domain/focus-mode-constants'
+import { getLinkNodeId } from './FocusModeStyling'
 
 export interface ApplyFocusModeParams {
   node: d3.Selection<SVGGElement, SimulationNode, SVGGElement, unknown>
@@ -25,6 +26,12 @@ export function applyFocusMode(params: ApplyFocusModeParams): void {
   const domain = params.domain
   const theme = params.theme
   const focusColors = getThemeFocusColors(theme)
+  const focusedNodeIds = new Set(
+    node
+      .data()
+      .filter((datum) => datum.domain === domain)
+      .map((datum) => datum.id),
+  )
 
   applyResetMode({
     node,
@@ -35,10 +42,33 @@ export function applyFocusMode(params: ApplyFocusModeParams): void {
     .transition()
     .duration(FOCUS_MODE_TRANSITIONS.elementAnimation)
     .attr('stroke', (datum) =>
-      datum.domain === domain ? focusColors.glowColor : 'rgba(255, 255, 255, 0.3)',
+      datum.domain === domain ? focusColors.glowColor : 'rgba(128, 128, 128, 0.12)',
     )
-    .attr('stroke-width', (datum) => (datum.domain === domain ? 5 : 2))
+    .attr('stroke-width', (datum) => (datum.domain === domain ? 8 : 1))
+    .attr('opacity', (datum) => (datum.domain === domain ? 1 : 0.22))
     .attr('filter', (datum) => (datum.domain === domain ? 'url(#focused-glow)' : 'none'))
+
+  node
+    .selectAll<SVGTextElement, SimulationNode>('.node-label, .node-domain-label')
+    .transition()
+    .duration(FOCUS_MODE_TRANSITIONS.elementAnimation)
+    .attr('opacity', (datum) => (datum.domain === domain ? 1 : 0.16))
+
+  link
+    .transition()
+    .duration(FOCUS_MODE_TRANSITIONS.elementAnimation)
+    .attr('opacity', (datum) => {
+      const connectsFocusedNode =
+        focusedNodeIds.has(getLinkNodeId(datum.source)) ||
+        focusedNodeIds.has(getLinkNodeId(datum.target))
+      return connectsFocusedNode ? 0.75 : 0.08
+    })
+    .attr('stroke-width', (datum) => {
+      const connectsFocusedNode =
+        focusedNodeIds.has(getLinkNodeId(datum.source)) ||
+        focusedNodeIds.has(getLinkNodeId(datum.target))
+      return connectsFocusedNode ? 2.5 : 1
+    })
 }
 
 export interface ApplyResetModeParams {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
@@ -11,11 +11,8 @@ import {
 
 export {
   getLinkNodeId,
-  applyFocusModeCircleStyles,
   applyResetModeCircleStyles,
-  applyFocusModeLinkStyles,
   applyResetModeLinkStyles,
-  applyFocusModeTextStyles,
   applyResetModeTextStyles,
 } from './FocusModeStyling'
 
@@ -88,7 +85,7 @@ export interface SetupNodesParams {
   nodeGroup: d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>
   nodes: SimulationNode[]
   theme: Theme
-  getNodeColor: (type: NodeType, theme: Theme) => string
+  getNodeColor: (type: string, theme: Theme) => string
   getNodeRadius: (type: NodeType) => number
   getDomainColor: (domain: string, uniqueDomains: string[]) => string
   uniqueDomains: string[]
@@ -116,7 +113,7 @@ export function setupNodes({
     .append('circle')
     .attr('class', 'node-circle')
     .attr('r', (d) => getNodeRadius(d.type))
-    .attr('fill', (d) => getNodeColor(d.type, theme))
+    .attr('fill', (d) => getNodeColor(d.effectiveType ?? d.type, theme))
     .attr('stroke', 'rgba(255, 255, 255, 0.3)')
     .attr('stroke-width', 2)
 

--- a/apps/eclair/src/platform/infra/graph/GraphTooltip/GraphTooltip.tsx
+++ b/apps/eclair/src/platform/infra/graph/GraphTooltip/GraphTooltip.tsx
@@ -75,8 +75,11 @@ export function GraphTooltip({
     >
       <div className="mb-2 text-sm font-bold text-[var(--text-primary)]">{node.name}</div>
       <div className="mb-1 text-xs text-[var(--text-secondary)]">
-        <span className="font-semibold">Type:</span> {node.type}
+        <span className="font-semibold">Type:</span> {node.effectiveType ?? node.type}
       </div>
+      {node.typeDescription !== undefined && (
+        <div className="mb-2 text-xs text-[var(--text-secondary)]">{node.typeDescription}</div>
+      )}
       <div className="mb-2 text-xs text-[var(--text-secondary)]">
         <span className="font-semibold">Domain:</span> {node.domain}
       </div>

--- a/apps/eclair/src/platform/infra/graph/graph-types.ts
+++ b/apps/eclair/src/platform/infra/graph/graph-types.ts
@@ -1,6 +1,7 @@
 import type {
   Node, Edge, NodeType 
 } from '@/platform/domain/eclair-types'
+import { getNodeTypeColor } from '@/platform/domain/node-type-presentation'
 import { compareByCodePoint } from '@/platform/domain/compare-by-code-point'
 import type {
   SimulationNodeDatum, SimulationLinkDatum 
@@ -9,6 +10,8 @@ import type {
 export interface SimulationNode extends SimulationNodeDatum {
   id: string
   type: NodeType
+  effectiveType?: string | undefined
+  typeDescription?: string | undefined
   name: string
   domain: string
   originalNode: Node
@@ -38,44 +41,44 @@ interface NodeColors {
 /*
  * NODE TYPE COLORS - MUST STAY IN SYNC WITH CSS VARIABLES
  * =========================================================
- * Source of truth: /apps/eclair/src/index.css (CSS variables)
+ * Source of truth: /apps/eclair/src/platform/domain/node-type-presentation.ts
  * Documentation: /apps/eclair/docs/brand/graph-visualization.md
  *
  * When updating colors:
- * 1. Update index.css :root and theme classes
- * 2. Update this NODE_COLORS object to match
- * 3. Update brand docs table
+ * 1. Update node-type-presentation.ts
+ * 2. Update matching CSS variables where they are still used
+ * 3. Update the brand docs table
  */
 export const NODE_COLORS: NodeColors = {
   stream: {
-    UI: '#F43F5E',
-    API: '#0D9488',
-    UseCase: '#A78BFA',
-    DomainOp: '#06B6D4',
-    Event: '#F59E0B',
-    EventHandler: '#EAB308',
-    Custom: '#78716C',
-    External: '#94A3B8',
+    UI: getNodeTypeColor('UI', 'stream'),
+    API: getNodeTypeColor('API', 'stream'),
+    UseCase: getNodeTypeColor('UseCase', 'stream'),
+    DomainOp: getNodeTypeColor('DomainOp', 'stream'),
+    Event: getNodeTypeColor('Event', 'stream'),
+    EventHandler: getNodeTypeColor('EventHandler', 'stream'),
+    Custom: getNodeTypeColor('Custom', 'stream'),
+    External: getNodeTypeColor('External', 'stream'),
   },
   voltage: {
-    UI: '#FB7185',
-    API: '#00D4FF',
-    UseCase: '#C4B5FD',
-    DomainOp: '#22D3EE',
-    Event: '#F97316',
-    EventHandler: '#FACC15',
-    Custom: '#A8A29E',
-    External: '#94A3B8',
+    UI: getNodeTypeColor('UI', 'voltage'),
+    API: getNodeTypeColor('API', 'voltage'),
+    UseCase: getNodeTypeColor('UseCase', 'voltage'),
+    DomainOp: getNodeTypeColor('DomainOp', 'voltage'),
+    Event: getNodeTypeColor('Event', 'voltage'),
+    EventHandler: getNodeTypeColor('EventHandler', 'voltage'),
+    Custom: getNodeTypeColor('Custom', 'voltage'),
+    External: getNodeTypeColor('External', 'voltage'),
   },
   circuit: {
-    UI: '#E11D48',
-    API: '#0969DA',
-    UseCase: '#A78BFA',
-    DomainOp: '#0550AE',
-    Event: '#BF8700',
-    EventHandler: '#9A6700',
-    Custom: '#57534E',
-    External: '#9CA3AF',
+    UI: getNodeTypeColor('UI', 'circuit'),
+    API: getNodeTypeColor('API', 'circuit'),
+    UseCase: getNodeTypeColor('UseCase', 'circuit'),
+    DomainOp: getNodeTypeColor('DomainOp', 'circuit'),
+    Event: getNodeTypeColor('Event', 'circuit'),
+    EventHandler: getNodeTypeColor('EventHandler', 'circuit'),
+    Custom: getNodeTypeColor('Custom', 'circuit'),
+    External: getNodeTypeColor('External', 'circuit'),
   },
 }
 

--- a/apps/eclair/src/platform/infra/theme/ThemeContext.spec.tsx
+++ b/apps/eclair/src/platform/infra/theme/ThemeContext.spec.tsx
@@ -3,7 +3,7 @@ import {
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
-  ThemeProvider, useTheme 
+  ThemeProvider, useTheme,
 } from './ThemeContext'
 
 function TestConsumer(): React.ReactElement {
@@ -110,4 +110,5 @@ describe('ThemeContext', () => {
 
     consoleError.mockRestore()
   })
+
 })

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
@@ -18,6 +18,7 @@ describe('DomainNode', () => {
         data={{
           label: 'orders',
           nodeCount: 5,
+          systemType: 'domain',
         }}
       />,
     )
@@ -32,6 +33,7 @@ describe('DomainNode', () => {
         data={{
           label: 'orders',
           nodeCount: 5,
+          systemType: 'domain',
         }}
       />,
     )
@@ -45,6 +47,7 @@ describe('DomainNode', () => {
         data={{
           label: 'verylongdomainname',
           nodeCount: 5,
+          systemType: 'domain',
         }}
       />,
     )
@@ -58,6 +61,7 @@ describe('DomainNode', () => {
         data={{
           label: 'verylongdomainname',
           nodeCount: 5,
+          systemType: 'domain',
         }}
       />,
     )
@@ -72,6 +76,7 @@ describe('DomainNode', () => {
         data={{
           label: 'orders',
           nodeCount: 5,
+          systemType: 'domain',
         }}
       />,
     )
@@ -86,6 +91,7 @@ describe('DomainNode', () => {
         data={{
           label: 'orders',
           nodeCount: 5,
+          systemType: 'domain',
           dimmed: true,
         }}
       />,
@@ -102,6 +108,7 @@ describe('DomainNode', () => {
           data={{
             label: 'orders',
             nodeCount: 5,
+            systemType: 'domain',
           }}
         />,
       )
@@ -119,6 +126,7 @@ describe('DomainNode', () => {
           data={{
             label: 'orders',
             nodeCount: 5,
+            systemType: 'domain',
             calculatedSize: 200,
           }}
         />,
@@ -139,6 +147,7 @@ describe('DomainNode', () => {
           data={{
             label: 'Stripe',
             nodeCount: 3,
+            systemType: 'external',
             isExternal: true,
           }}
         />,
@@ -154,6 +163,7 @@ describe('DomainNode', () => {
           data={{
             label: 'Stripe',
             nodeCount: 3,
+            systemType: 'external',
             isExternal: true,
           }}
         />,
@@ -172,6 +182,7 @@ describe('DomainNode', () => {
           data={{
             label: 'Stripe',
             nodeCount: 3,
+            systemType: 'external',
             isExternal: true,
           }}
         />,
@@ -187,6 +198,7 @@ describe('DomainNode', () => {
           data={{
             label: 'Stripe',
             nodeCount: 3,
+            systemType: 'external',
             isExternal: true,
           }}
         />,
@@ -202,6 +214,7 @@ describe('DomainNode', () => {
           data={{
             label: 'orders',
             nodeCount: 5,
+            systemType: 'domain',
             isExternal: false,
           }}
         />,
@@ -217,6 +230,7 @@ describe('DomainNode', () => {
           data={{
             label: 'orders',
             nodeCount: 5,
+            systemType: 'domain',
           }}
         />,
       )
@@ -224,5 +238,19 @@ describe('DomainNode', () => {
       const icon = container.querySelector('i.ph-arrow-square-out')
       expect(icon).not.toBeInTheDocument()
     })
+  })
+
+  it('shows the declared domain type below the domain name', () => {
+    renderWithProvider(
+      <DomainNode
+        data={{
+          label: 'warehouse',
+          nodeCount: 2,
+          systemType: 'other',
+        }}
+      />,
+    )
+
+    expect(screen.getByText('other')).toHaveClass('domain-node-system-type')
   })
 })

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/react'
 import { ReactFlowProvider } from '@xyflow/react'
 import { DomainNode } from './DomainNode'
+import type { DomainMapSystemType } from '@/platform/domain/domain-node-types'
 
 function renderWithProvider(ui: React.ReactElement): ReturnType<typeof render> {
   return render(<ReactFlowProvider>{ui}</ReactFlowProvider>)
@@ -240,17 +241,45 @@ describe('DomainNode', () => {
     })
   })
 
-  it('shows the declared domain type below the domain name', () => {
-    renderWithProvider(
-      <DomainNode
-        data={{
-          label: 'warehouse',
-          nodeCount: 2,
-          systemType: 'other',
-        }}
-      />,
-    )
+  const domainTypeCases: ReadonlyArray<{
+    systemType: DomainMapSystemType
+    borderClass: string
+  }> = [
+    {
+      systemType: 'domain',
+      borderClass: 'border-[var(--primary)]',
+    },
+    {
+      systemType: 'bff',
+      borderClass: 'domain-node-bff',
+    },
+    {
+      systemType: 'ui',
+      borderClass: 'domain-node-ui',
+    },
+    {
+      systemType: 'other',
+      borderClass: 'domain-node-other',
+    },
+  ]
 
-    expect(screen.getByText('other')).toHaveClass('domain-node-system-type')
-  })
+  it.each(domainTypeCases)(
+    'shows the $systemType domain type with its border class',
+    ({
+      systemType, borderClass,
+    }) => {
+      const { container } = renderWithProvider(
+        <DomainNode
+          data={{
+            label: 'warehouse',
+            nodeCount: 2,
+            systemType,
+          }}
+        />,
+      )
+
+      expect(screen.getByText(systemType)).toHaveClass('domain-node-system-type')
+      expect(container.querySelector('div.flex[title]')).toHaveClass(borderClass)
+    },
+  )
 })

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
@@ -4,7 +4,9 @@ import {
 import type {
   NodeProps, Node 
 } from '@xyflow/react'
-import type { DomainNodeData } from '@/platform/domain/domain-node-types'
+import type {
+  DomainMapSystemType, DomainNodeData
+} from '@/platform/domain/domain-node-types'
 
 type DomainNodeProps = NodeProps<Node<DomainNodeData>>
 
@@ -16,6 +18,14 @@ const DIMMED_OPACITY = 0.3
 const FULL_OPACITY = 1
 const DOMAIN_FONT_SIZE = 14
 const EXTERNAL_FONT_SIZE = 12
+
+const DOMAIN_TYPE_CLASSES: Readonly<Record<DomainMapSystemType, string>> = {
+  domain: 'border-[var(--primary)]',
+  bff: 'domain-node-bff',
+  ui: 'domain-node-ui',
+  other: 'domain-node-other',
+  external: 'domain-node-external',
+}
 
 export function DomainNode(props: DomainNodeProps): React.ReactElement {
   const { data } = props
@@ -29,9 +39,8 @@ export function DomainNode(props: DomainNodeProps): React.ReactElement {
 
   const baseClasses =
     'flex items-center justify-center rounded-full border-2 text-center shadow-lg transition-all hover:shadow-xl'
-  const internalClasses = 'border-[var(--primary)] bg-[var(--bg-secondary)]'
-  const externalClasses = 'domain-node-external'
-  const domainNodeClasses = `${baseClasses} ${isExternal ? externalClasses : internalClasses}`
+  const typeClasses = DOMAIN_TYPE_CLASSES[data.systemType]
+  const domainNodeClasses = `${baseClasses} ${typeClasses} bg-[var(--bg-secondary)]`
 
   return (
     <>
@@ -61,14 +70,18 @@ export function DomainNode(props: DomainNodeProps): React.ReactElement {
             >
               {displayLabel}
             </span>
+            <span className="domain-node-system-type">External</span>
           </div>
         ) : (
-          <span
-            className="max-w-full overflow-hidden px-3 font-bold text-[var(--text-primary)] leading-tight"
-            style={{ fontSize }}
-          >
-            {displayLabel}
-          </span>
+          <div className="flex flex-col items-center gap-1">
+            <span
+              className="max-w-full overflow-hidden px-3 font-bold text-[var(--text-primary)] leading-tight"
+              style={{ fontSize }}
+            >
+              {displayLabel}
+            </span>
+            <span className="domain-node-system-type">{data.systemType}</span>
+          </div>
         )}
       </div>
     </>

--- a/apps/eclair/src/platform/infra/ui/NodeTypeBadge/NodeTypeBadge.spec.tsx
+++ b/apps/eclair/src/platform/infra/ui/NodeTypeBadge/NodeTypeBadge.spec.tsx
@@ -62,11 +62,11 @@ describe('NodeTypeBadge', () => {
     expect(badge).toHaveClass('badge-eventhandler')
   })
 
-  it('renders Custom type as JOB badge with indigo gradient', () => {
+  it('does not mislabel an unresolved Custom type as a Job', () => {
     render(<NodeTypeBadge type="Custom" />)
 
     const badge = screen.getByTestId('node-type-badge')
-    expect(badge).toHaveTextContent('JOB')
+    expect(badge).toHaveTextContent('Custom')
     expect(badge).toHaveClass('badge-custom')
   })
 })

--- a/apps/eclair/src/platform/infra/ui/NodeTypeBadge/NodeTypeBadge.tsx
+++ b/apps/eclair/src/platform/infra/ui/NodeTypeBadge/NodeTypeBadge.tsx
@@ -1,37 +1,38 @@
-import type { NodeType } from '@/platform/domain/eclair-types'
+import { getNodeTypeColor } from '@/platform/domain/node-type-presentation'
+import type { Theme } from '@/types/theme'
+import { DEFAULT_THEME } from '@/types/theme'
 
-interface NodeTypeBadgeProps {readonly type: NodeType}
-
-function getBadgeClass(type: NodeType): string {
-  switch (type) {
-    case 'UI':
-      return 'badge-ui'
-    case 'API':
-      return 'badge-api'
-    case 'UseCase':
-      return 'badge-usecase'
-    case 'DomainOp':
-      return 'badge-domainop'
-    case 'Event':
-      return 'badge-event'
-    case 'EventHandler':
-      return 'badge-eventhandler'
-    case 'Custom':
-      return 'badge-custom'
-  }
+interface NodeTypeBadgeProps {
+  readonly type: string
+  readonly description?: string | undefined
+  readonly theme?: Theme
 }
 
-function getDisplayLabel(type: NodeType): string {
-  if (type === 'Custom') return 'JOB'
-  return type
+const BADGE_CLASSES: Readonly<Record<string, string>> = {
+  UI: 'badge-ui',
+  API: 'badge-api',
+  UseCase: 'badge-usecase',
+  DomainOp: 'badge-domainop',
+  Event: 'badge-event',
+  EventHandler: 'badge-eventhandler',
+  Custom: 'badge-custom',
 }
 
-export function NodeTypeBadge({ type }: Readonly<NodeTypeBadgeProps>): React.ReactElement {
-  const badgeClass = getBadgeClass(type)
+export function NodeTypeBadge({
+  type,
+  description,
+  theme = DEFAULT_THEME,
+}: Readonly<NodeTypeBadgeProps>): React.ReactElement {
+  const badgeClass = BADGE_CLASSES[type] ?? 'badge-custom'
 
   return (
-    <span data-testid="node-type-badge" className={`node-type-badge ${badgeClass}`}>
-      {getDisplayLabel(type)}
+    <span
+      data-testid="node-type-badge"
+      className={`node-type-badge ${badgeClass}`}
+      style={{ backgroundColor: getNodeTypeColor(type, theme) }}
+      title={description}
+    >
+      {type}
     </span>
   )
 }

--- a/apps/eclair/src/shell/App.spec.tsx
+++ b/apps/eclair/src/shell/App.spec.tsx
@@ -113,6 +113,12 @@ describe('App routing', () => {
     expect(links.length).toBeGreaterThan(0)
   })
 
+  it('renders ModulesPage at /modules route', async () => {
+    renderWithRouter('/modules', { graph: mockGraph })
+
+    expect(await screen.findByRole('heading', { name: 'Modules' })).toBeInTheDocument()
+  })
+
   it('renders with app shell sidebar', async () => {
     renderWithRouter('/flows', { graph: mockGraph })
 
@@ -165,6 +171,12 @@ describe('App routing without graph', () => {
 
   it('renders EmptyState at /events route when no graph loaded', () => {
     renderWithRouter('/events')
+
+    expect(screen.getByText(/welcome to éclair/i)).toBeInTheDocument()
+  })
+
+  it('renders EmptyState at /modules route when no graph loaded', () => {
+    renderWithRouter('/modules')
 
     expect(screen.getByText(/welcome to éclair/i)).toBeInTheDocument()
   })

--- a/apps/eclair/src/shell/App.tsx
+++ b/apps/eclair/src/shell/App.tsx
@@ -17,6 +17,8 @@ import { EntitiesPage } from '@/features/entities/entrypoint/EntitiesPage'
 import { EventsPage } from '@/features/events/entrypoint/EventsPage'
 import { ComparisonPage } from '@/features/comparison/entrypoint/ComparisonPage'
 import { GraphError } from '@/platform/infra/errors/errors'
+import { ModulesPage } from '@/features/modules/entrypoint/ModulesPage'
+import { useTheme } from '@/platform/infra/theme/ThemeContext'
 
 export function useRequiredGraph(): RiviereGraph {
   const { graph } = useGraph()
@@ -29,7 +31,8 @@ export function useRequiredGraph(): RiviereGraph {
 }
 
 function Overview(): React.ReactElement {
-  return <OverviewPage graph={useRequiredGraph()} />
+  const { theme } = useTheme()
+  return <OverviewPage graph={useRequiredGraph()} theme={theme} />
 }
 
 function FullGraph(): React.ReactElement {
@@ -41,11 +44,13 @@ function DomainMap(): React.ReactElement {
 }
 
 function Flows(): React.ReactElement {
-  return <FlowsPage graph={useRequiredGraph()} />
+  const { theme } = useTheme()
+  return <FlowsPage graph={useRequiredGraph()} theme={theme} />
 }
 
 function DomainDetail(): React.ReactElement {
-  return <DomainDetailPage graph={useRequiredGraph()} />
+  const { theme } = useTheme()
+  return <DomainDetailPage graph={useRequiredGraph()} theme={theme} />
 }
 
 function Entities(): React.ReactElement {
@@ -54,6 +59,11 @@ function Entities(): React.ReactElement {
 
 function Events(): React.ReactElement {
   return <EventsPage graph={useRequiredGraph()} />
+}
+
+function Modules(): React.ReactElement {
+  const { theme } = useTheme()
+  return <ModulesPage graph={useRequiredGraph()} theme={theme} />
 }
 
 export function AppContent(): React.ReactElement {
@@ -81,6 +91,7 @@ export function AppContent(): React.ReactElement {
         <Route path="/flows" element={hasGraph ? <Flows /> : <EmptyState />} />
         <Route path="/entities" element={hasGraph ? <Entities /> : <EmptyState />} />
         <Route path="/events" element={hasGraph ? <Events /> : <EmptyState />} />
+        <Route path="/modules" element={hasGraph ? <Modules /> : <EmptyState />} />
         <Route path="/domains/:domainId" element={hasGraph ? <DomainDetail /> : <EmptyState />} />
         <Route path="/compare" element={<ComparisonPage />} />
       </Routes>

--- a/apps/eclair/src/shell/components/Sidebar/Sidebar.spec.tsx
+++ b/apps/eclair/src/shell/components/Sidebar/Sidebar.spec.tsx
@@ -37,6 +37,7 @@ describe('Sidebar', () => {
     'Domain Map',
     'Full Graph',
     'Entities',
+    'Modules',
     'Events',
     'About Rivière',
   ])('renders %s navigation link', (linkName) => {
@@ -69,6 +70,7 @@ describe('Sidebar', () => {
     'Domain Map',
     'Full Graph',
     'Entities',
+    'Modules',
     'Events',
   ])('disables %s when no graph loaded', (itemName) => {
     renderWithRouter(<Sidebar hasGraph={false} />)
@@ -85,6 +87,7 @@ describe('Sidebar', () => {
     'Domain Map',
     'Full Graph',
     'Entities',
+    'Modules',
     'Events',
   ])('enables %s link when graph is loaded', (linkName) => {
     renderWithRouter(<Sidebar hasGraph={true} />)

--- a/apps/eclair/src/shell/components/Sidebar/Sidebar.tsx
+++ b/apps/eclair/src/shell/components/Sidebar/Sidebar.tsx
@@ -191,6 +191,14 @@ export function Sidebar({
           collapsed={collapsed}
         />
         <NavItem
+          icon="stack"
+          label="Modules"
+          to="/modules"
+          active={currentPath === '/modules'}
+          disabled={!hasGraph}
+          collapsed={collapsed}
+        />
+        <NavItem
           icon="broadcast"
           label="Events"
           to="/events"

--- a/packages/riviere-query/src/features/querying/queries/compare-by-code-point.spec.ts
+++ b/packages/riviere-query/src/features/querying/queries/compare-by-code-point.spec.ts
@@ -15,4 +15,17 @@ describe('compareByCodePoint', () => {
   it('returns zero when strings are equal', () => {
     expect(compareByCodePoint('same', 'same')).toBe(0)
   })
+
+  it('orders Unicode scalar values instead of UTF-16 code units', () => {
+    expect(compareByCodePoint('\uFFFF', '\u{10000}')).toBe(-1)
+    expect(compareByCodePoint('\u{10000}', '\uFFFF')).toBe(1)
+  })
+
+  it('orders a shorter prefix before a longer string', () => {
+    expect(compareByCodePoint('same', 'same-value')).toBe(-1)
+  })
+
+  it('orders a longer string after its prefix', () => {
+    expect(compareByCodePoint('same-value', 'same')).toBe(1)
+  })
 })

--- a/packages/riviere-query/src/features/querying/queries/compare-by-code-point.ts
+++ b/packages/riviere-query/src/features/querying/queries/compare-by-code-point.ts
@@ -1,6 +1,23 @@
 /** @riviere-role query-model */
 export function compareByCodePoint(a: string, b: string): number {
-  if (a < b) return -1
-  if (a > b) return 1
+  const leftCodePoints = Array.from(a, toCodePoint)
+  const rightCodePoints = Array.from(b, toCodePoint)
+
+  for (const [index, leftCodePoint] of leftCodePoints.entries()) {
+    const rightCodePoint = rightCodePoints[index]
+    if (rightCodePoint === undefined) return 1
+    if (leftCodePoint < rightCodePoint) return -1
+    if (leftCodePoint > rightCodePoint) return 1
+  }
+
+  if (leftCodePoints.length < rightCodePoints.length) return -1
   return 0
+}
+
+function toCodePoint(character: string): number {
+  const firstCodeUnit = character.charCodeAt(0)
+  if (character.length === 1) return firstCodeUnit
+
+  const secondCodeUnit = character.charCodeAt(1)
+  return (firstCodeUnit - 0xd800) * 0x400 + secondCodeUnit - 0xdc00 + 0x10000
 }


### PR DESCRIPTION
## Summary

- preserve and present effective custom component types across Éclair, including dynamic filters, colours, descriptions, flow entry points, and domain connection details
- improve domain and full-graph readability with complete connection counts, responsive controls, clearer focus contrast, and declared domain types
- add a collapsible Modules view and polish flow cards, trace metadata, and domain-detail filters

## Testing

- `pnpm nx test eclair` (1,172 tests)
- `pnpm nx build eclair`
- `pnpm depcruise`
- `pnpm knip`
- `pnpm verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Modules view with expandable domains, modules, component details, and custom type badges.
  * Added support for custom node types, descriptions, colors, and theme-aware presentation across graph views.
  * Domain and flow filters now dynamically reflect available types.
  * Graph relationships display total connection counts and distinguish bidirectional links.
  * Domain nodes now show their system type, including external domains.

* **UI Improvements**
  * Improved responsive layouts, filter wrapping, tooltips, graph spacing, focused-domain controls, and flow metadata accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->