### PR TITLE
feat(riviere): add external service system type

### DIFF
--- a/apps/docs/public/schema/riviere.schema.json
+++ b/apps/docs/public/schema/riviere.schema.json
@@ -415,7 +415,7 @@
         },
         "systemType": {
           "type": "string",
-          "enum": ["domain", "bff", "ui", "other"],
+          "enum": ["domain", "bff", "ui", "external-service", "other"],
           "description": "Classification of domain's role in system"
         }
       },

--- a/apps/docs/reference/api/generated/riviere-query/interfaces/Domain.md
+++ b/apps/docs/reference/api/generated/riviere-query/interfaces/Domain.md
@@ -46,7 +46,7 @@ Domain name.
 
 ### systemType
 
-> **systemType**: `"domain"` \| `"bff"` \| `"ui"` \| `"other"`
+> **systemType**: `SystemType`
 
 Defined in: [packages/riviere-query/src/features/querying/queries/domain-types.ts:150](https://github.com/NTCoding/living-architecture/blob/main/packages/riviere-query/src/features/querying/queries/domain-types.ts#L150)
 

--- a/apps/docs/reference/cli/cli-reference.md
+++ b/apps/docs/reference/cli/cli-reference.md
@@ -83,7 +83,7 @@ riviere builder add-domain [options]
 |------|-------------|
 | `--name <name>` | Domain name |
 | `--description <description>` | Domain description |
-| `--system-type <type>` | System type (domain, bff, ui, other) |
+| `--system-type <type>` | System type (domain, bff, ui, external-service, other) |
 | `--graph <path>` | Custom graph file path (default: .riviere/graph.json) |
 
 **Optional:**

--- a/apps/docs/reference/schema/graph-structure.md
+++ b/apps/docs/reference/schema/graph-structure.md
@@ -251,7 +251,7 @@ Domains represent system boundaries (an ownership or deployment area you want to
 ```typescript
 interface DomainMetadata {
   description: string
-  systemType: 'domain' | 'bff' | 'ui' | 'other'
+  systemType: 'domain' | 'bff' | 'ui' | 'external-service' | 'other'
 }
 ```
 

--- a/apps/eclair/src/features/overview/entrypoint/OverviewPage.spec.tsx
+++ b/apps/eclair/src/features/overview/entrypoint/OverviewPage.spec.tsx
@@ -322,6 +322,10 @@ describe('OverviewPage', () => {
             description: 'Payment processing',
             systemType: 'other',
           },
+          alerts: {
+            description: 'External alert service',
+            systemType: 'external-service',
+          },
         }),
       },
     })
@@ -329,6 +333,7 @@ describe('OverviewPage', () => {
     renderWithRouter(<OverviewPage graph={graph} />)
 
     expect(screen.getByRole('button', { name: 'Domain' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'External Service' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Other' })).toBeInTheDocument()
   })
 
@@ -438,6 +443,32 @@ describe('OverviewPage', () => {
 
       expect(screen.getByText('order-domain')).toBeInTheDocument()
       expect(screen.getByText('payment-domain')).toBeInTheDocument()
+    })
+
+    it('filters domains by the external-service system type', async () => {
+      const user = userEvent.setup()
+      const graph = createTestGraph({
+        metadata: {
+          name: 'Test Architecture',
+          domains: parseDomainMetadata({
+            'order-domain': {
+              description: 'Order management',
+              systemType: 'domain',
+            },
+            alerts: {
+              description: 'External alert service',
+              systemType: 'external-service',
+            },
+          }),
+        },
+      })
+
+      renderWithRouter(<OverviewPage graph={graph} />)
+
+      await user.click(screen.getByRole('button', { name: 'External Service' }))
+
+      expect(screen.getByText('alerts')).toBeInTheDocument()
+      expect(screen.queryByText('order-domain')).not.toBeInTheDocument()
     })
 
     it('shows All domains when All filter is active', () => {

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
@@ -258,6 +258,10 @@ describe('DomainNode', () => {
       borderClass: 'domain-node-ui',
     },
     {
+      systemType: 'external-service',
+      borderClass: 'domain-node-external',
+    },
+    {
       systemType: 'other',
       borderClass: 'domain-node-other',
     },

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
@@ -23,6 +23,7 @@ const DOMAIN_TYPE_CLASSES: Readonly<Record<DomainMapSystemType, string>> = {
   domain: 'border-[var(--primary)]',
   bff: 'domain-node-bff',
   ui: 'domain-node-ui',
+  'external-service': 'domain-node-external',
   other: 'domain-node-other',
   external: 'domain-node-external',
 }

--- a/docs/architecture/domain-terminology/contextive/definitions.glossary.yml
+++ b/docs/architecture/domain-terminology/contextive/definitions.glossary.yml
@@ -20,7 +20,7 @@ contexts:
 
       # Domain/boundary concepts
       - name: Domain
-        definition: A logical grouping of related components. Each component belongs to exactly one domain. Domains have a systemType (domain, bff, ui, other).
+        definition: A logical grouping of related components. Each component belongs to exactly one domain. Domains have a systemType (domain, bff, ui, external-service, other).
 
       - name: Cross-domain Link
         definition: A link where source and target components belong to different domains. Represents integration between separate parts of the system.

--- a/docs/project/PRD/active/PRD-phase-13-extraction-workflows.md
+++ b/docs/project/PRD/active/PRD-phase-13-extraction-workflows.md
@@ -177,7 +177,7 @@ AI steps must run after deterministic steps because they read current builder st
 
 **Shared enum references.** Every enum field in the workflow schema that exists in `riviere-schema` is referenced via JSON Schema `$ref` rather than redeclared:
 
-- `domains.*.systemType` — `$ref`s `SystemType` from `riviere-schema` (currently `'domain' | 'bff' | 'ui' | 'other'`).
+- `domains.*.systemType` — `$ref`s `SystemType` from `riviere-schema` (currently `'domain' | 'bff' | 'ui' | 'external-service' | 'other'`).
 - Component-type enums in step configs (e.g. `selection.component-types`) — `$ref` the `ComponentType` enum from `riviere-schema`.
 - Link-type enums in step configs — `$ref` the `LinkType` enum from `riviere-schema`.
 

--- a/packages/riviere-cli/docs/generated/cli-reference.md
+++ b/packages/riviere-cli/docs/generated/cli-reference.md
@@ -83,7 +83,7 @@ riviere builder add-domain [options]
 |------|-------------|
 | `--name <name>` | Domain name |
 | `--description <description>` | Domain description |
-| `--system-type <type>` | System type (domain, bff, ui, other) |
+| `--system-type <type>` | System type (domain, bff, ui, external-service, other) |
 | `--graph <path>` | Custom graph file path (default: .riviere/graph.json) |
 
 **Optional:**

--- a/packages/riviere-cli/src/features/builder/entrypoint/add-domain/add-domain.spec.ts
+++ b/packages/riviere-cli/src/features/builder/entrypoint/add-domain/add-domain.spec.ts
@@ -100,6 +100,39 @@ describe('riviere builder add-domain', () => {
       })
     })
 
+    it('adds an external-service domain', async () => {
+      await createGraphWithDomain(ctx.testDir, 'orders')
+
+      const program = createProgram()
+      await program.parseAsync([
+        'node',
+        'riviere',
+        'builder',
+        'add-domain',
+        '--name',
+        'alerts',
+        '--description',
+        'External alert service',
+        '--system-type',
+        'external-service',
+      ])
+
+      const graphPath = join(ctx.testDir, '.riviere', 'graph.json')
+      const content = await readFile(graphPath, 'utf-8')
+      const graph: unknown = JSON.parse(content)
+
+      expect(graph).toMatchObject({
+        metadata: {
+          domains: {
+            alerts: {
+              description: 'External alert service',
+              systemType: 'external-service',
+            },
+          },
+        },
+      })
+    })
+
     it('returns DUPLICATE_DOMAIN error when domain already exists', async () => {
       await createGraphWithDomain(ctx.testDir, 'orders')
 

--- a/packages/riviere-cli/src/features/builder/entrypoint/add-domain/entrypoint.ts
+++ b/packages/riviere-cli/src/features/builder/entrypoint/add-domain/entrypoint.ts
@@ -35,7 +35,10 @@ Examples:
     )
     .requiredOption('--name <name>', 'Domain name')
     .requiredOption('--description <description>', 'Domain description')
-    .requiredOption('--system-type <type>', 'System type (domain, bff, ui, other)')
+    .requiredOption(
+      '--system-type <type>',
+      'System type (domain, bff, ui, external-service, other)',
+    )
     .option('--graph <path>', getDefaultGraphPathDescription())
     .option('--json', 'Output result as JSON')
     .action(async (options: AddDomainOptions) => {

--- a/packages/riviere-cli/src/features/builder/entrypoint/init/entrypoint.ts
+++ b/packages/riviere-cli/src/features/builder/entrypoint/init/entrypoint.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import type { SystemType } from '@living-architecture/riviere-schema'
 import {
   formatError, formatSuccess 
 } from '../../../../platform/infra/cli/presentation/output'
@@ -19,7 +20,7 @@ interface InitOptions {
 interface DomainInputParsed {
   description: string
   name: string
-  systemType: 'domain' | 'bff' | 'ui' | 'other'
+  systemType: SystemType
 }
 
 /** @riviere-role cli-entrypoint */

--- a/packages/riviere-cli/src/features/builder/entrypoint/init/init.spec.ts
+++ b/packages/riviere-cli/src/features/builder/entrypoint/init/init.spec.ts
@@ -133,6 +133,36 @@ describe('riviere builder init', () => {
       })
     })
 
+    it('includes an external-service domain', async () => {
+      const program = createProgram()
+
+      await program.parseAsync([
+        'node',
+        'riviere',
+        'builder',
+        'init',
+        '--source',
+        'https://github.com/org/repo',
+        '--domain',
+        '{"name":"alerts","description":"External alert service","systemType":"external-service"}',
+      ])
+
+      const graphPath = join(ctx.testDir, '.riviere', 'graph.json')
+      const content = await readFile(graphPath, 'utf-8')
+      const graph: unknown = JSON.parse(content)
+
+      expect(graph).toMatchObject({
+        metadata: {
+          domains: {
+            alerts: {
+              description: 'External alert service',
+              systemType: 'external-service',
+            },
+          },
+        },
+      })
+    })
+
     it('includes multiple domains when multiple --domain flags provided', async () => {
       const program = createProgram()
 

--- a/packages/riviere-cli/src/platform/infra/cli/input/component-types.ts
+++ b/packages/riviere-cli/src/platform/infra/cli/input/component-types.ts
@@ -66,7 +66,7 @@ export function normalizeComponentType(value: string): string {
   return normalized
 }
 
-export const VALID_SYSTEM_TYPES = ['domain', 'bff', 'ui', 'other'] as const
+export const VALID_SYSTEM_TYPES = ['domain', 'bff', 'ui', 'external-service', 'other'] as const
 type SystemTypeFlag = (typeof VALID_SYSTEM_TYPES)[number]
 
 /** @riviere-role cli-input-validator */

--- a/packages/riviere-cli/src/platform/infra/cli/presentation/component-types.spec.ts
+++ b/packages/riviere-cli/src/platform/infra/cli/presentation/component-types.spec.ts
@@ -90,8 +90,8 @@ describe('component-types', () => {
   })
 
   describe('VALID_SYSTEM_TYPES', () => {
-    it('contains domain, bff, ui, and other', () => {
-      expect(VALID_SYSTEM_TYPES).toStrictEqual(['domain', 'bff', 'ui', 'other'])
+    it('contains every supported system type', () => {
+      expect(VALID_SYSTEM_TYPES).toStrictEqual(['domain', 'bff', 'ui', 'external-service', 'other'])
     })
   })
 

--- a/packages/riviere-cli/src/platform/infra/cli/presentation/validation.spec.ts
+++ b/packages/riviere-cli/src/platform/infra/cli/presentation/validation.spec.ts
@@ -8,6 +8,7 @@ import {
   validateHttpMethod,
   isValidHttpMethod,
 } from '../input/validation'
+import { VALID_SYSTEM_TYPES } from '../input/component-types'
 import { CliErrorCode } from './error-codes'
 
 function parseErrorJson(errorJson: string | undefined): unknown {
@@ -109,7 +110,7 @@ describe('validation', () => {
   })
 
   describe('validateSystemType', () => {
-    it.each(['domain', 'bff', 'ui', 'other'])('returns valid for %s', (type) => {
+    it.each(VALID_SYSTEM_TYPES)('returns valid for %s', (type) => {
       expect(validateSystemType(type)).toStrictEqual({ valid: true })
     })
 

--- a/packages/riviere-query/src/features/querying/queries/domain-types.ts
+++ b/packages/riviere-query/src/features/querying/queries/domain-types.ts
@@ -147,7 +147,7 @@ export interface Domain {
   /** Domain description from graph metadata. */
   description: string
   /** System type classification. */
-  systemType: 'domain' | 'bff' | 'ui' | 'other'
+  systemType: import('@living-architecture/riviere-schema').SystemType
   /** Counts of components by type. */
   componentCounts: ComponentCounts
 }

--- a/packages/riviere-query/src/features/querying/queries/domains.spec.ts
+++ b/packages/riviere-query/src/features/querying/queries/domains.spec.ts
@@ -35,6 +35,19 @@ describe('domains', () => {
     ])
   })
 
+  it('returns the external-service system type from metadata', () => {
+    const graph = createMinimalValidGraph()
+    graph.metadata.domains['alerts'] = {
+      description: 'External alert service',
+      systemType: 'external-service',
+    }
+    const query = new RiviereQuery(graph)
+
+    const result = query.domains()
+
+    expect(result.find((domain) => domain.name === 'alerts')?.systemType).toBe('external-service')
+  })
+
   it('returns multiple domains with correct component counts per type', () => {
     const graph = createMinimalValidGraph()
     graph.metadata.domains['orders'] = {

--- a/packages/riviere-schema/riviere.schema.json
+++ b/packages/riviere-schema/riviere.schema.json
@@ -475,7 +475,7 @@
         },
         "systemType": {
           "type": "string",
-          "enum": ["domain", "bff", "ui", "other"],
+          "enum": ["domain", "bff", "ui", "external-service", "other"],
           "description": "Classification of domain's role in system"
         }
       },

--- a/packages/riviere-schema/src/schema.spec.ts
+++ b/packages/riviere-schema/src/schema.spec.ts
@@ -74,6 +74,26 @@ describe('parseRiviereGraph()', () => {
     expect(result.components).toHaveLength(0)
   })
 
+  it('parses a domain with the external-service system type', () => {
+    const input = {
+      version: '1.0',
+      metadata: {
+        domains: {
+          alerts: {
+            description: 'External alert service',
+            systemType: 'external-service',
+          },
+        },
+      },
+      components: [],
+      links: [],
+    }
+
+    const result = parseRiviereGraph(input)
+
+    expect(result.metadata.domains['alerts']?.systemType).toBe('external-service')
+  })
+
   it('throws RiviereSchemaValidationError on invalid component type', () => {
     const input = {
       version: '1.0',

--- a/packages/riviere-schema/src/schema.ts
+++ b/packages/riviere-schema/src/schema.ts
@@ -143,7 +143,7 @@ export interface ExternalLink {
   sourceLocation?: SourceLocation
 }
 
-export type SystemType = 'domain' | 'bff' | 'ui' | 'other'
+export type SystemType = 'domain' | 'bff' | 'ui' | 'external-service' | 'other'
 
 export interface DomainMetadata {
   description: string


### PR DESCRIPTION
## Problem

Rivière currently limits systemType to domain, bff, ui, or other. External services therefore have to be labelled as other, and the CLI rejects external-service even when that is the accurate type.

## Proposed outcome

Make external-service a standard SystemType supported consistently by the schema, CLI, query package, Éclair, and the published documentation.

## Changes

- Add external-service to the canonical TypeScript and JSON Schema enums.
- Accept and persist external-service in CLI init and add-domain flows.
- Use the canonical schema type in query-facing domain results and preserve the value.
- Render external services with the existing external-node styling and expose an External Service overview filter.
- Update generated schemas, CLI reference, schema documentation, glossary, and the active extraction PRD.
- Add schema, CLI, query, and Éclair coverage.

## Acceptance criteria

- The schema accepts external-service as a system type.
- CLI init and add-domain commands write external-service.
- Query results preserve external-service.
- Éclair renders and filters external services.
- Published schemas and current documentation list external-service.

## Validation

- Full pnpm verify passed under the repository CI Node.js version (Node 24), including linting, formatting, tests, builds, dependency checks, and role enforcement.
- Éclair test suite passed: 91 files, 1,185 tests.
- Schema, query, CLI, Éclair, and docs builds passed.
- Built CLI smoke test created and validated a graph containing an external-service node.

## Design decisions and constraints

- Reuse the existing external visual styling rather than introduce another presentation category.
- Consume the canonical SystemType definition where the type was duplicated.
- Leave archived PRDs and historical design-review records unchanged.

## Out of scope

- Updating the Silversea POC graph or regenerating Job node IDs; that is the following POC ticket.
- New Éclair semantics beyond standard styling and filtering for this type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `external-service` as a supported system type for domains.
  - The CLI now accepts `external-service` when creating or initializing domains.
  - External-service domains appear with dedicated styling in the overview.
  - Users can filter the overview to display only external-service domains.

- **Documentation**
  - Updated schema, CLI reference, glossary, and workflow documentation to include the new system type.

- **Tests**
  - Added coverage for validation, creation, querying, filtering, parsing, and visual presentation of external-service domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->