### PR TITLE
chore(ci): make release publishing retryable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,8 +230,13 @@ jobs:
       - name: Sync with remote
         run: git pull --rebase origin main
 
-      - name: Release
-        run: pnpm exec nx release --yes
+      - name: Version and tag release
+        run: pnpm exec nx release --yes --skip-publish
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: 0
+
+      # Keep publishing separate so a failed publish can be rerun without
+      # creating another set of versions and tags.
+      - name: Publish release
+        run: pnpm exec nx release publish


### PR DESCRIPTION
The combined Nx release command commits and tags versions before publishing. When publishing fails, rerunning the job detects no new changes and skips every package, producing a misleading green run while npm remains behind.

This separates the release into two steps:

- version and tag with --skip-publish
- publish the versions currently present in package manifests

A failed publish can now be rerun without creating another version or tag. Merging this chore should not bump packages; it should publish the versions already created by the failed release, validating the corrected npm trusted-publisher configuration and recovering those missing releases.

Validation:

- full pnpm verify passed
- role enforcement passed with 0 warnings and 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release process by separating versioning and package publishing into distinct steps.
  - Release tags and package publication are now handled independently, improving reliability and making release execution easier to monitor.
  - No changes were made to application functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->