### PR TITLE
chore(ci): remove conflicting release flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
         run: git pull --rebase origin main
 
       - name: Version and tag release
-        run: pnpm exec nx release --yes --skip-publish
+        run: pnpm exec nx release --skip-publish
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HUSKY: 0


### PR DESCRIPTION
## Problem

PR #434 introduced an invalid Nx command: pnpm exec nx release --yes --skip-publish. In Nx 22.5.2, --yes and --skip-publish are mutually exclusive because both answer the same publishing prompt. The publish job therefore stopped before versioning or publishing.

## Outcome

Keep versioning and publishing separate so failed publishing remains safely retryable, using the supported Nx flags.

## Change

Remove --yes from the version-and-tag step. The command becomes pnpm exec nx release --skip-publish. The separate pnpm exec nx release publish step is unchanged.

## Acceptance criteria

- the version-and-tag command runs non-interactively without an argument error
- publishing remains a separate retryable step
- no package bump is introduced solely by this CI repair

## Validation

- nx release --skip-publish --dry-run completed successfully and reported Skipped publishing packages
- full pnpm verify passed
- Prettier and git diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow’s version-and-tag command to run without automatic confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->