### PR TITLE
feat: show semantic relationship labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         name: Install pnpm
         with:
-          version: 10.30.2
+          version: 11.21.0
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -41,15 +41,6 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
-
-      # pnpm v10 does not run better-sqlite3's install script despite onlyBuiltDependencies.
-      # Manually trigger prebuild-install to download prebuilt native bindings.
-      - name: Build better-sqlite3 native bindings
-        run: |
-          BS3_DIR=$(find node_modules/.pnpm -path "*/better-sqlite3@*/node_modules/better-sqlite3/package.json" -exec dirname {} \; | head -1)
-          if [ -n "$BS3_DIR" ]; then
-            cd "$BS3_DIR" && npx --yes prebuild-install || npx --yes node-gyp rebuild --release
-          fi
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World
@@ -93,7 +84,7 @@ jobs:
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         name: Install pnpm
         with:
-          version: 10.30.2
+          version: 11.21.0
           run_install: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -131,7 +122,7 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 10.30.2
+          version: 11.21.0
           run_install: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -153,7 +144,7 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 10.30.2
+          version: 11.21.0
           run_install: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -213,7 +204,7 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 10.30.2
+          version: 11.21.0
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
-          version: 10.30.2
+          version: 11.21.0
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # living-architecture
 
-> ⚠️ **NEW WORKTREE?** Run `pnpm install --frozen-lockfile` then run the **"Build better-sqlite3 native bindings"** step from `.github/workflows/ci.yml` — otherwise `dev-workflow-v2` tests will fail.
+> ⚠️ **NEW WORKTREE?** Run `pnpm install --frozen-lockfile` before running tests or verification.
 
 Extract software architecture from code as living documentation, using Riviere schema for flow-based (not structural) architecture
 

--- a/apps/docs/reference/api/generated/riviere-query/interfaces/FlowStep.md
+++ b/apps/docs/reference/api/generated/riviere-query/interfaces/FlowStep.md
@@ -44,10 +44,10 @@ External links from this component to external systems.
 
 ***
 
-### linkType
+### outgoingLinks
 
-> **linkType**: [`LinkType`](../type-aliases/LinkType.md) \| `undefined`
+> **outgoingLinks**: `Link`[]
 
 Defined in: [packages/riviere-query/src/features/querying/queries/domain-types.ts:232](https://github.com/NTCoding/living-architecture/blob/main/packages/riviere-query/src/features/querying/queries/domain-types.ts#L232)
 
-Type of link leading to this step (undefined for entry point).
+Exact links leaving this component, preserving branching relationship semantics.

--- a/apps/docs/reference/api/generated/riviere-query/interfaces/SearchWithFlowOptions.md
+++ b/apps/docs/reference/api/generated/riviere-query/interfaces/SearchWithFlowOptions.md
@@ -4,7 +4,7 @@ pageClass: reference
 
 # Interface: SearchWithFlowOptions
 
-Defined in: [packages/riviere-query/src/features/querying/queries/flow-queries.ts:155](https://github.com/NTCoding/living-architecture/blob/main/packages/riviere-query/src/features/querying/queries/flow-queries.ts#L155)
+Defined in: [packages/riviere-query/src/features/querying/queries/flow-queries.ts:138](https://github.com/NTCoding/living-architecture/blob/main/packages/riviere-query/src/features/querying/queries/flow-queries.ts#L138)
 
 ## Riviere-role
 
@@ -16,4 +16,4 @@ query-model-use-case-input
 
 > **returnAllOnEmptyQuery**: `boolean`
 
-Defined in: [packages/riviere-query/src/features/querying/queries/flow-queries.ts:155](https://github.com/NTCoding/living-architecture/blob/main/packages/riviere-query/src/features/querying/queries/flow-queries.ts#L155)
+Defined in: [packages/riviere-query/src/features/querying/queries/flow-queries.ts:138](https://github.com/NTCoding/living-architecture/blob/main/packages/riviere-query/src/features/querying/queries/flow-queries.ts#L138)

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
@@ -32,6 +32,8 @@ import { DomainNode } from '@/platform/infra/ui/DomainNode/DomainNode'
 import { useDomainMapInteractions } from '../hooks/useDomainMapInteractions'
 import { NodeTypeBadge } from '@/platform/infra/ui/NodeTypeBadge/NodeTypeBadge'
 import { useTheme } from '@/platform/infra/theme/ThemeContext'
+import { relationshipDetail } from '../queries/relationship-presentation'
+import { RelationshipLegend } from '@/platform/infra/ui/RelationshipLegend/RelationshipLegend'
 
 interface DomainMapPageProps {readonly graph: RiviereGraph}
 
@@ -279,6 +281,7 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
           <span>{connectionText}</span>
         </div>
       </div>
+      <RelationshipLegend />
 
       {tooltip.visible &&
         (() => {
@@ -337,7 +340,7 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
               {inspector.connections.map((conn) => {
                 return (
                   <div
-                    key={`${conn.sourceName}-${conn.targetName}-${conn.type}-${conn.targetNodeType}`}
+                    key={`${conn.sourceName}-${conn.targetName}-${conn.type}-${conn.relationshipType ?? 'relationship'}-${conn.targetNodeType}`}
                     className="inspector-connection-item"
                   >
                     <div className="flex items-center gap-2">
@@ -348,6 +351,9 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
                     </div>
                     <div className="mt-2 text-sm text-[var(--text-primary)]">{conn.sourceName}</div>
                     <div className="text-xs text-[var(--text-secondary)]">→ {conn.targetName}</div>
+                    <div className="mt-1 text-xs font-semibold text-[var(--text-secondary)]">
+                      {relationshipDetail(conn)}
+                    </div>
                   </div>
                 )
               })}

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
@@ -340,7 +340,14 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
               {inspector.connections.map((conn) => {
                 return (
                   <div
-                    key={`${conn.sourceName}-${conn.targetName}-${conn.type}-${conn.relationshipType ?? 'relationship'}-${conn.targetNodeType}`}
+                    key={JSON.stringify([
+                      conn.sourceName,
+                      conn.targetName,
+                      conn.type,
+                      conn.relationshipType,
+                      conn.condition,
+                      conn.targetNodeType,
+                    ])}
                     className="inspector-connection-item"
                   >
                     <div className="flex items-center gap-2">

--- a/apps/eclair/src/features/domain-map/queries/edge-aggregation.ts
+++ b/apps/eclair/src/features/domain-map/queries/edge-aggregation.ts
@@ -33,6 +33,8 @@ export function aggregateDomainEdges(
       type: getEdgeType(edge.type),
       targetNodeType: targetInfo.type,
     }
+    if (edge.relationshipType !== undefined) connection.relationshipType = edge.relationshipType
+    if (edge.condition !== undefined) connection.condition = edge.condition
 
     recordEdgeAggregation(
       edgeAggregation,

--- a/apps/eclair/src/features/domain-map/queries/edgeAggregation.ts
+++ b/apps/eclair/src/features/domain-map/queries/edgeAggregation.ts
@@ -3,6 +3,19 @@ export interface ConnectionDetail {
   targetName: string
   type: 'sync' | 'async' | 'unknown'
   targetNodeType: string
+  relationshipType?: string
+  condition?: string
+}
+
+export function semanticRelationshipSummary(connections: ConnectionDetail[]): string | undefined {
+  const types = [
+    ...new Set(
+      connections.flatMap((connection) =>
+        connection.relationshipType === undefined ? [] : [connection.relationshipType],
+      ),
+    ),
+  ]
+  return types.length === 0 ? undefined : types.join(', ')
 }
 
 export function getEdgeType(type: string | undefined): 'sync' | 'async' | 'unknown' {

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.reactflow.spec.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.reactflow.spec.ts
@@ -320,7 +320,7 @@ describe('extractDomainMap React Flow compatibility', () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  it('labels a single cross-domain relationship', () => {
+  it('uses the semantic type as the primary cross-domain relationship label', () => {
     const graph = createMinimalGraph({
       components: [
         parseNode({
@@ -347,13 +347,14 @@ describe('extractDomainMap React Flow compatibility', () => {
           source: 'n1',
           target: 'n2',
           type: 'sync',
+          relationshipType: 'executes',
         }),
       ],
     })
 
     const result = extractDomainMap(graph)
 
-    expect(result.domainEdges[0]?.label).toBe('1 relationship')
+    expect(result.domainEdges[0]?.label).toBe('executes')
   })
 
   it('counts an event relationship without changing its meaning', () => {

--- a/apps/eclair/src/features/domain-map/queries/extract-domain-map.ts
+++ b/apps/eclair/src/features/domain-map/queries/extract-domain-map.ts
@@ -12,6 +12,7 @@ import {
   aggregateExternalEdges, createExternalNodeId 
 } from './external-domain-handling'
 import { getEffectiveNodeType } from '@/platform/domain/node-type-presentation'
+import { semanticRelationshipSummary } from './edgeAggregation'
 
 export type ConnectionDetail = DomainMapEdgeTypes.ConnectionDetail
 
@@ -215,6 +216,7 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
     const isEventOnly = agg.eventCount > 0 && agg.apiCount === 0
     const strokeColor = isEventOnly ? '#F59E0B' : '#06B6D4'
     const arrowMarker = isEventOnly ? 'url(#arrow-amber)' : 'url(#arrow-cyan)'
+    const semanticSummary = semanticRelationshipSummary(agg.connections)
 
     return {
       id: key,
@@ -222,7 +224,9 @@ export function extractDomainMap(graph: RiviereGraph): DomainMapData {
       target: agg.target,
       sourceHandle: handles.sourceHandle,
       targetHandle: handles.targetHandle,
-      label: `${agg.connectionCount} ${agg.connectionCount === 1 ? 'relationship' : 'relationships'}`,
+      label:
+        semanticSummary ??
+        `${agg.connectionCount} ${agg.connectionCount === 1 ? 'relationship' : 'relationships'}`,
       data: {
         connectionCount: agg.connectionCount,
         apiCount: agg.apiCount,

--- a/apps/eclair/src/features/domain-map/queries/relationship-presentation.ts
+++ b/apps/eclair/src/features/domain-map/queries/relationship-presentation.ts
@@ -1,0 +1,1 @@
+export { relationshipDetail } from '@/platform/domain/relationship-presentation'

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/ConnectionItem.spec.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/ConnectionItem.spec.tsx
@@ -81,4 +81,48 @@ describe('ConnectionItem', () => {
     expect(screen.getByText('1 API call')).toBeInTheDocument()
     expect(screen.getByText('1 event')).toBeInTheDocument()
   })
+
+  it('displays delivery type without a relationship type', () => {
+    const connection: AggregatedConnection = {
+      targetDomain: 'inventory',
+      direction: 'outgoing',
+      apiCount: 0,
+      eventCount: 0,
+      relationshipCount: 1,
+      deliveryTypes: ['sync'],
+    }
+
+    render(
+      <ConnectionItem
+        connection={connection}
+        currentDomainId="orders"
+        targetDomainId="inventory"
+      />,
+    )
+
+    expect(screen.getByText('sync')).toBeInTheDocument()
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument()
+  })
+
+  it('separates relationship and delivery types when both are present', () => {
+    const connection: AggregatedConnection = {
+      targetDomain: 'inventory',
+      direction: 'outgoing',
+      apiCount: 0,
+      eventCount: 0,
+      relationshipCount: 1,
+      relationshipTypes: ['calls'],
+      deliveryTypes: ['sync'],
+    }
+
+    render(
+      <ConnectionItem
+        connection={connection}
+        currentDomainId="orders"
+        targetDomainId="inventory"
+      />,
+    )
+
+    expect(screen.getByText('calls · sync')).toBeInTheDocument()
+  })
 })

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/ConnectionItem.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/ConnectionItem.tsx
@@ -43,6 +43,13 @@ export function ConnectionItem({
           </div>
         )}
       </div>
+      {connection.relationshipTypes !== undefined && connection.relationshipTypes.length > 0 && (
+        <div className="mt-2 text-xs font-semibold text-[var(--text-secondary)]">
+          {connection.relationshipTypes.join(', ')}
+          {connection.deliveryTypes !== undefined && connection.deliveryTypes.length > 0 &&
+            ` · ${connection.deliveryTypes.join('/')}`}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/ConnectionItem.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/ConnectionItem.tsx
@@ -6,6 +6,14 @@ interface ConnectionItemProps {
   readonly targetDomainId: string
 }
 
+function connectionMetadata(connection: AggregatedConnection): string | undefined {
+  const values = [
+    connection.relationshipTypes?.join(', '),
+    connection.deliveryTypes?.join('/'),
+  ].filter((value): value is string => value !== undefined && value.length > 0)
+  return values.length > 0 ? values.join(' · ') : undefined
+}
+
 export function ConnectionItem({
   connection,
   currentDomainId,
@@ -14,6 +22,7 @@ export function ConnectionItem({
   const isOutgoing = connection.direction === 'outgoing'
   const fromDomain = isOutgoing ? currentDomainId : targetDomainId
   const toDomain = isOutgoing ? targetDomainId : currentDomainId
+  const metadata = connectionMetadata(connection)
 
   return (
     <div className="rounded-md bg-[var(--bg-tertiary)] p-3">
@@ -43,11 +52,9 @@ export function ConnectionItem({
           </div>
         )}
       </div>
-      {connection.relationshipTypes !== undefined && connection.relationshipTypes.length > 0 && (
+      {metadata !== undefined && (
         <div className="mt-2 text-xs font-semibold text-[var(--text-secondary)]">
-          {connection.relationshipTypes.join(', ')}
-          {connection.deliveryTypes !== undefined && connection.deliveryTypes.length > 0 &&
-            ` · ${connection.deliveryTypes.join('/')}`}
+          {metadata}
         </div>
       )}
     </div>

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
@@ -7,6 +7,7 @@ import { DomainNode } from './DomainNode'
 import { DomainInfoModal } from './DomainInfoModal'
 import { LayoutError } from '@/platform/infra/errors/errors'
 import type { DomainPosition } from './domain-position'
+import { RelationshipLegend } from '@/platform/infra/ui/RelationshipLegend/RelationshipLegend'
 
 interface ViewTransform {
   scale: number
@@ -258,6 +259,8 @@ export function DomainContextGraph({
                 testId={`edge-${domainId}-${conn.targetDomain}`}
                 direction={conn.direction}
                 relationshipCount={conn.relationshipCount}
+                relationshipTypes={conn.relationshipTypes}
+                deliveryTypes={conn.deliveryTypes}
                 isBidirectional={isBidirectional}
               />
             )
@@ -322,6 +325,8 @@ export function DomainContextGraph({
           />
         </button>
       </div>
+
+      <RelationshipLegend />
 
       {selectedPosition !== undefined && selectedNodeId !== null && (
         <DomainInfoModal

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
@@ -39,6 +39,27 @@ describe('EdgeLine', () => {
     expect(group).toBeInTheDocument()
   })
 
+  it('uses semantic relationship types as the primary label', () => {
+    const { getByText } = render(
+      <svg>
+        <EdgeLine
+          from={from}
+          to={to}
+          fromRadius={30}
+          toRadius={30}
+          testId="semantic-edge"
+          direction="outgoing"
+          relationshipCount={2}
+          relationshipTypes={['reads', 'writes']}
+          deliveryTypes={['sync', 'async']}
+          isBidirectional={false}
+        />
+      </svg>,
+    )
+
+    expect(getByText('reads, writes · sync/async')).toBeInTheDocument()
+  })
+
   it('returns empty group when positions are identical', () => {
     const same: DomainPosition = {
       id: 'test',

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
@@ -8,10 +8,26 @@ interface EdgeLineProps {
   readonly testId: string
   readonly direction: 'incoming' | 'outgoing'
   readonly relationshipCount: number
+  readonly relationshipTypes?: readonly string[]
+  readonly deliveryTypes?: readonly ('sync' | 'async')[]
   readonly isBidirectional: boolean
 }
 
 const BIDIRECTIONAL_EDGE_SEPARATION = 8
+
+function formatEdgeLabel(
+  relationshipCount: number,
+  relationshipTypes: readonly string[] | undefined,
+  deliveryTypes: readonly ('sync' | 'async')[] | undefined,
+): string {
+  if (relationshipTypes === undefined || relationshipTypes.length === 0) {
+    const noun = relationshipCount === 1 ? 'relationship' : 'relationships'
+    return `${relationshipCount} ${noun}`
+  }
+  const semanticLabel = relationshipTypes.join(', ')
+  if (deliveryTypes === undefined || deliveryTypes.length === 0) return semanticLabel
+  return `${semanticLabel} · ${deliveryTypes.join('/')}`
+}
 
 export function EdgeLine({
   from,
@@ -21,6 +37,8 @@ export function EdgeLine({
   testId,
   direction,
   relationshipCount,
+  relationshipTypes,
+  deliveryTypes,
   isBidirectional,
 }: Readonly<EdgeLineProps>): React.ReactElement {
   const dx = to.x - from.x
@@ -39,6 +57,7 @@ export function EdgeLine({
   const startY = from.y + dy * startOffset + separationY
   const endX = to.x - dx * endOffset + separationX
   const endY = to.y - dy * endOffset + separationY
+  const edgeLabel = formatEdgeLabel(relationshipCount, relationshipTypes, deliveryTypes)
 
   return (
     <g data-testid={testId} data-direction={direction} data-bidirectional={isBidirectional}>
@@ -50,6 +69,7 @@ export function EdgeLine({
         style={{ stroke: 'var(--text-tertiary)' }}
         strokeWidth="1"
         strokeOpacity="0.6"
+        strokeDasharray={deliveryTypes?.length === 1 && deliveryTypes[0] === 'async' ? '5 3' : undefined}
         markerEnd="url(#arrow-marker)"
       />
       <text
@@ -58,7 +78,7 @@ export function EdgeLine({
         textAnchor="middle"
         className="fill-[var(--text-secondary)] text-[10px] font-semibold"
       >
-        {relationshipCount} {relationshipCount === 1 ? 'relationship' : 'relationships'}
+        {edgeLabel}
       </text>
     </g>
   )

--- a/apps/eclair/src/features/domains/components/DomainDetailModal/DomainDetailModal.tsx
+++ b/apps/eclair/src/features/domains/components/DomainDetailModal/DomainDetailModal.tsx
@@ -3,6 +3,7 @@ import {
 } from 'react'
 import type { DomainDetails } from '../../queries/extract-domain-details'
 import { NodeTypeBadge } from '@/platform/infra/ui/NodeTypeBadge/NodeTypeBadge'
+import { relationshipLabel } from '@/platform/domain/relationship-presentation'
 
 interface DomainDetailModalProps {
   readonly domain: DomainDetails | null
@@ -181,7 +182,7 @@ export function DomainDetailModal({
               <div className="domain-edges-list">
                 {domain.crossDomainEdges.map((edge) => (
                   <div
-                    key={`${edge.targetDomain}-${edge.edgeType ?? 'unknown'}`}
+                    key={`${edge.targetDomain}-${edge.relationshipType ?? 'relationship'}-${edge.edgeType ?? 'unknown'}-${edge.condition ?? 'unconditional'}`}
                     className="domain-edge-item"
                   >
                     <span
@@ -202,7 +203,14 @@ export function DomainDetailModal({
                         color: 'var(--text-tertiary)',
                       }}
                     >
-                      {edge.edgeType ?? 'unknown'}
+                      <strong>{relationshipLabel(edge)}</strong>
+                      {edge.edgeType !== undefined && (
+                        <>
+                          {' · '}
+                          <span>{edge.edgeType}</span>
+                        </>
+                      )}
+                      {edge.condition !== undefined && <> · when {edge.condition}</>}
                     </span>
                   </div>
                 ))}

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.advanced.spec.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.advanced.spec.ts
@@ -117,6 +117,8 @@ describe('extractDomainDetails - advanced tests', () => {
             source: 'order-evt',
             target: 'inv-handler',
             type: 'async',
+            relationshipType: 'publishes',
+            condition: 'reserved',
           }),
           createEdge({
             source: 'order-evt',
@@ -132,6 +134,8 @@ describe('extractDomainDetails - advanced tests', () => {
       expect(result?.crossDomainEdges).toContainEqual({
         targetDomain: 'inventory-domain',
         edgeType: 'async',
+        relationshipType: 'publishes',
+        condition: 'reserved',
       })
       expect(result?.crossDomainEdges).toContainEqual({
         targetDomain: 'shipping-domain',

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.advanced.spec.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.advanced.spec.ts
@@ -425,6 +425,7 @@ describe('extractDomainDetails - advanced tests', () => {
         apiCount: 1,
         eventCount: 1,
         relationshipCount: 2,
+        deliveryTypes: ['sync', 'async'],
       })
     })
 
@@ -473,6 +474,7 @@ describe('extractDomainDetails - advanced tests', () => {
         apiCount: 1,
         eventCount: 0,
         relationshipCount: 1,
+        deliveryTypes: ['sync'],
       })
     })
 

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.relationships.spec.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.relationships.spec.ts
@@ -1,0 +1,123 @@
+import {
+  describe, expect, it 
+} from 'vitest'
+import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import {
+  parseDomainKey,
+  parseDomainMetadata,
+  parseEdge,
+  parseNode,
+} from '@/platform/infra/__fixtures__/riviere-test-fixtures'
+import { extractDomainDetails } from './extract-domain-details'
+
+const sourceLocation = {
+  repository: 'test-repo',
+  filePath: 'src/test.ts',
+}
+
+const components: RiviereGraph['components'] = [
+  parseNode({
+    id: 'source-api',
+    type: 'API',
+    name: 'Source API',
+    domain: 'source-domain',
+    module: 'api',
+    sourceLocation,
+  }),
+  parseNode({
+    id: 'target-api',
+    type: 'API',
+    name: 'Target API',
+    domain: 'target-domain',
+    module: 'api',
+    sourceLocation,
+  }),
+]
+
+function createGraph(links: RiviereGraph['links']): RiviereGraph {
+  return {
+    version: '1.0',
+    metadata: {
+      name: 'Test Graph',
+      domains: parseDomainMetadata({
+        'source-domain': {
+          description: 'Source',
+          systemType: 'domain',
+        },
+        'target-domain': {
+          description: 'Target',
+          systemType: 'domain',
+        },
+      }),
+    },
+    components,
+    links,
+  }
+}
+
+describe('extractDomainDetails relationship metadata', () => {
+  it('keeps literal fallback values and colon-containing conditions distinct', () => {
+    const graph = createGraph([
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+      }),
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+        relationshipType: 'relationship',
+        condition: 'unconditional',
+      }),
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+        relationshipType: 'calls',
+        condition: 'status:ready',
+      }),
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+        relationshipType: 'calls',
+        condition: 'status:blocked',
+      }),
+    ])
+
+    const result = extractDomainDetails(graph, parseDomainKey('source-domain'))
+
+    expect(result?.crossDomainEdges).toHaveLength(4)
+    expect(result?.crossDomainEdges).toContainEqual({
+      targetDomain: 'target-domain',
+      edgeType: undefined,
+    })
+    expect(result?.crossDomainEdges).toContainEqual({
+      targetDomain: 'target-domain',
+      edgeType: undefined,
+      relationshipType: 'relationship',
+      condition: 'unconditional',
+    })
+    expect(result?.crossDomainEdges.map((edge) => edge.condition)).toStrictEqual(
+      expect.arrayContaining(['status:ready', 'status:blocked']),
+    )
+  })
+
+  it('collects delivery types from unnamed relationships', () => {
+    const graph = createGraph([
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+        type: 'sync',
+      }),
+    ])
+
+    const result = extractDomainDetails(graph, parseDomainKey('source-domain'))
+
+    expect(result?.aggregatedConnections).toContainEqual({
+      targetDomain: 'target-domain',
+      direction: 'outgoing',
+      apiCount: 1,
+      eventCount: 0,
+      relationshipCount: 1,
+      deliveryTypes: ['sync'],
+    })
+  })
+})

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.ts
@@ -26,6 +26,8 @@ export interface AggregatedConnection {
   apiCount: number
   eventCount: number
   relationshipCount: number
+  relationshipTypes?: string[]
+  deliveryTypes?: EdgeType[]
 }
 
 interface KnownSourceEventInfo {
@@ -58,6 +60,8 @@ export interface DomainEvents {
 export interface CrossDomainEdge {
   targetDomain: string
   edgeType: EdgeType | undefined
+  relationshipType?: string
+  condition?: string
 }
 
 export interface DomainDetails {
@@ -91,14 +95,21 @@ function buildCrossDomainEdges(graph: RiviereGraph, domainId: DomainName): Cross
       continue
     }
 
-    const key = `${targetDomain}:${edge.type ?? 'unknown'}`
+    const key = `${targetDomain}:${edge.relationshipType ?? 'relationship'}:${edge.type ?? 'unknown'}:${edge.condition ?? 'unconditional'}`
     if (crossDomainEdgeSet.has(key)) continue
 
     crossDomainEdgeSet.add(key)
-    crossDomainEdges.push({
+    const crossDomainEdge: CrossDomainEdge = {
       targetDomain,
       edgeType: edge.type,
-    })
+    }
+    if (edge.relationshipType !== undefined) {
+      crossDomainEdge.relationshipType = edge.relationshipType
+    }
+    if (edge.condition !== undefined) {
+      crossDomainEdge.condition = edge.condition
+    }
+    crossDomainEdges.push(crossDomainEdge)
   }
 
   return crossDomainEdges.sort((a, b) => compareByCodePoint(a.targetDomain, b.targetDomain))
@@ -212,9 +223,7 @@ function buildAggregatedConnections(graph: RiviereGraph, domainId: string): Aggr
       relationshipCount: 0,
     }
 
-    existing.relationshipCount += 1
-    if (target.type === 'API') existing.apiCount += 1
-    if (target.type === 'EventHandler') existing.eventCount += 1
+    updateAggregatedConnection(existing, link, target)
     connections.set(key, existing)
   }
 
@@ -223,4 +232,26 @@ function buildAggregatedConnections(graph: RiviereGraph, domainId: string): Aggr
     if (domainOrder !== 0) return domainOrder
     return compareByCodePoint(left.direction, right.direction)
   })
+}
+
+function appendUnique<T>(values: T[] | undefined, value: T | undefined): T[] | undefined {
+  if (value === undefined) return values
+  const currentValues = values ?? []
+  return currentValues.includes(value) ? currentValues : [...currentValues, value]
+}
+
+function updateAggregatedConnection(
+  connection: AggregatedConnection,
+  link: RiviereGraph['links'][number],
+  target: RiviereGraph['components'][number],
+): void {
+  connection.relationshipCount += 1
+  const relationshipTypes = appendUnique(connection.relationshipTypes, link.relationshipType)
+  if (relationshipTypes !== undefined) connection.relationshipTypes = relationshipTypes
+  if (link.relationshipType !== undefined) {
+    const deliveryTypes = appendUnique(connection.deliveryTypes, link.type)
+    if (deliveryTypes !== undefined) connection.deliveryTypes = deliveryTypes
+  }
+  if (target.type === 'API') connection.apiCount += 1
+  if (target.type === 'EventHandler') connection.eventCount += 1
 }

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.ts
@@ -95,7 +95,7 @@ function buildCrossDomainEdges(graph: RiviereGraph, domainId: DomainName): Cross
       continue
     }
 
-    const key = `${targetDomain}:${edge.relationshipType ?? 'relationship'}:${edge.type ?? 'unknown'}:${edge.condition ?? 'unconditional'}`
+    const key = JSON.stringify([targetDomain, edge.relationshipType, edge.type, edge.condition])
     if (crossDomainEdgeSet.has(key)) continue
 
     crossDomainEdgeSet.add(key)
@@ -248,10 +248,8 @@ function updateAggregatedConnection(
   connection.relationshipCount += 1
   const relationshipTypes = appendUnique(connection.relationshipTypes, link.relationshipType)
   if (relationshipTypes !== undefined) connection.relationshipTypes = relationshipTypes
-  if (link.relationshipType !== undefined) {
-    const deliveryTypes = appendUnique(connection.deliveryTypes, link.type)
-    if (deliveryTypes !== undefined) connection.deliveryTypes = deliveryTypes
-  }
+  const deliveryTypes = appendUnique(connection.deliveryTypes, link.type)
+  if (deliveryTypes !== undefined) connection.deliveryTypes = deliveryTypes
   if (target.type === 'API') connection.apiCount += 1
   if (target.type === 'EventHandler') connection.eventCount += 1
 }

--- a/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
+++ b/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import type { FlowStep } from '../../queries/extract-flows'
-import type { RiviereGraph } from '@living-architecture/riviere-schema'
+import {
+  createLinkId, type RiviereGraph
+} from '@living-architecture/riviere-schema'
 import { FlowGraphView } from './FlowGraphView'
 import { getNodeTypeColor } from '@/platform/domain/node-type-presentation'
 import type { Theme } from '@/types/theme'
@@ -105,7 +107,7 @@ export function FlowTrace({
                 {(step.outgoingLinks?.length ?? 0) > 0 && (
                   <div className="flow-step-edge">
                     {step.outgoingLinks?.map((link) => (
-                      <div key={link.id ?? `${link.source}->${link.target}`}>
+                      <div key={link.id ?? createLinkId(link)}>
                         {relationshipDetail(link)} → {componentNames.get(link.target) ?? link.target}
                       </div>
                     ))}

--- a/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
+++ b/apps/eclair/src/features/flows/components/FlowTrace/FlowTrace.tsx
@@ -5,6 +5,7 @@ import { FlowGraphView } from './FlowGraphView'
 import { getNodeTypeColor } from '@/platform/domain/node-type-presentation'
 import type { Theme } from '@/types/theme'
 import { DEFAULT_THEME } from '@/types/theme'
+import { relationshipDetail } from '@/platform/domain/relationship-presentation'
 
 type ViewMode = 'waterfall' | 'graph'
 
@@ -33,6 +34,7 @@ export function FlowTrace({
   steps, graph, theme = DEFAULT_THEME,
 }: Readonly<FlowTraceProps>): React.ReactElement {
   const [viewMode, setViewMode] = useState<ViewMode>('waterfall')
+  const componentNames = new Map(graph.components.map((component) => [component.id, component.name]))
 
   if (steps.length === 0) {
     return (
@@ -100,7 +102,19 @@ export function FlowTrace({
                     </div>
                   )}
                 </div>
-                {step.edgeType !== null && <div className="flow-step-edge">{step.edgeType} →</div>}
+                {(step.outgoingLinks?.length ?? 0) > 0 && (
+                  <div className="flow-step-edge">
+                    {step.outgoingLinks?.map((link) => (
+                      <div key={link.id ?? `${link.source}->${link.target}`}>
+                        {relationshipDetail(link)} → {componentNames.get(link.target) ?? link.target}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {step.outgoingLinks === undefined && step.edgeType !== null &&
+                  step.edgeType !== undefined && (
+                  <div className="flow-step-edge">{step.edgeType} →</div>
+                )}
               </div>
               {step.externalLinks.length > 0 && (
                 <div className="flow-external-links">

--- a/apps/eclair/src/features/flows/queries/extract-flows.spec.ts
+++ b/apps/eclair/src/features/flows/queries/extract-flows.spec.ts
@@ -258,24 +258,24 @@ describe('extractFlows', () => {
     expect(flows[0]?.entryPoint.path).toBe('/orders')
   })
 
-  it('steps include correct edge types', () => {
+  it('steps preserve outgoing links', () => {
     const graph = createTestGraph()
 
     const flows = extractFlows(graph)
     const steps = flows[0]?.steps
 
-    expect(steps?.[0]?.edgeType).toBe('sync')
-    expect(steps?.[3]?.edgeType).toBe('async')
+    expect(steps?.[0]?.outgoingLinks[0]?.type).toBe('sync')
+    expect(steps?.[3]?.outgoingLinks[0]?.type).toBe('async')
   })
 
-  it('last step has null edgeType', () => {
+  it('last step has no outgoing links', () => {
     const graph = createTestGraph()
 
     const flows = extractFlows(graph)
     const steps = flows[0]?.steps
     const lastStep = steps?.[steps.length - 1]
 
-    expect(lastStep?.edgeType).toBeNull()
+    expect(lastStep?.outgoingLinks).toStrictEqual([])
   })
 
   it('steps include correct depth values', () => {

--- a/apps/eclair/src/features/flows/queries/extract-flows.ts
+++ b/apps/eclair/src/features/flows/queries/extract-flows.ts
@@ -6,6 +6,7 @@ import {
 import type {
   Component,
   ExternalLink,
+  Link,
   RiviereGraph,
   SourceLocation,
 } from '@living-architecture/riviere-schema'
@@ -33,7 +34,9 @@ export interface FlowStepNode {
 
 export interface FlowStep {
   node: FlowStepNode
-  edgeType: 'sync' | 'async' | null
+  outgoingLinks?: Link[]
+  /** Compatibility for callers constructing legacy view fixtures. */
+  edgeType?: 'sync' | 'async' | null
   depth: number
   externalLinks: ExternalLink[]
 }
@@ -61,11 +64,9 @@ function componentToFlowStepNode(component: Component): FlowStepNode {
 
 function adaptFlowStep(queryStep: QueryFlowStep): FlowStep {
   const component = queryStep.component
-  const linkType = queryStep.linkType
-
   return {
     node: componentToFlowStepNode(component),
-    edgeType: linkType ?? null,
+    outgoingLinks: queryStep.outgoingLinks,
     depth: queryStep.depth,
     externalLinks: queryStep.externalLinks,
   }

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
@@ -21,15 +21,17 @@ const testSourceLocation = {
 }
 
 const {
-  capturedOnNodeHover, capturedOnBackgroundClick, capturedGraph,
+  capturedOnNodeHover, capturedOnBackgroundClick, capturedGraph, capturedRelationshipLabelMode,
 } = vi.hoisted(() => {
   const hoverRef: { current: ((data: TooltipData | null) => void) | undefined } = {current: undefined,}
   const backgroundClickRef: { current: (() => void) | undefined } = { current: undefined }
   const graphRef: { current: RiviereGraph | undefined } = { current: undefined }
+  const relationshipLabelModeRef: { current: 'detailed' | 'semantic-only' | undefined } = { current: undefined }
   return {
     capturedOnNodeHover: hoverRef,
     capturedOnBackgroundClick: backgroundClickRef,
     capturedGraph: graphRef,
+    capturedRelationshipLabelMode: relationshipLabelModeRef,
   }
 })
 
@@ -102,8 +104,10 @@ vi.mock('@/platform/infra/graph/ForceGraph/ForceGraph', () => ({
     onNodeHover?: (data: TooltipData | null) => void
     onBackgroundClick?: () => void
     highlightedNodeId?: string | null
+    relationshipLabelMode?: 'detailed' | 'semantic-only'
   }) => {
     capturedGraph.current = props.graph
+    capturedRelationshipLabelMode.current = props.relationshipLabelMode
     if (props.onNodeHover !== undefined) {
       capturedOnNodeHover.current = props.onNodeHover
     }
@@ -162,6 +166,12 @@ describe('FullGraphPage', () => {
   it('renders ForceGraph component', () => {
     renderWithRouter()
     expect(screen.getByTestId('force-graph-container')).toBeInTheDocument()
+  })
+
+  it('uses semantic-only relationship labels', () => {
+    renderWithRouter()
+
+    expect(capturedRelationshipLabelMode.current).toBe('semantic-only')
   })
 
   it('renders filter toggle button', () => {

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
@@ -257,6 +257,7 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
         onNodeClick={handleNodeClick}
         onNodeHover={handleNodeHover}
         onBackgroundClick={handleBackgroundClick}
+        relationshipLabelMode="semantic-only"
       />
 
       <GraphTooltip

--- a/apps/eclair/src/platform/domain/relationship-presentation.spec.ts
+++ b/apps/eclair/src/platform/domain/relationship-presentation.spec.ts
@@ -1,0 +1,26 @@
+import {
+  describe, expect, it 
+} from 'vitest'
+import {
+  relationshipDetail, relationshipLabel 
+} from './relationship-presentation'
+
+describe('relationship presentation', () => {
+  it('uses semantic relationship type as the primary label', () => {
+    expect(relationshipLabel({ relationshipType: 'executes' })).toBe('executes')
+  })
+
+  it('shows delivery and condition as secondary details', () => {
+    expect(
+      relationshipDetail({
+        relationshipType: 'reads',
+        type: 'sync',
+        condition: 'enabled',
+      }),
+    ).toBe('reads · sync · when enabled')
+  })
+
+  it('falls back without inventing semantics', () => {
+    expect(relationshipDetail({ type: 'async' })).toBe('relationship · async')
+  })
+})

--- a/apps/eclair/src/platform/domain/relationship-presentation.ts
+++ b/apps/eclair/src/platform/domain/relationship-presentation.ts
@@ -1,0 +1,16 @@
+interface RelationshipPresentation {
+  relationshipType?: string
+  type?: string
+  condition?: string
+}
+
+export function relationshipLabel(link: RelationshipPresentation): string {
+  return link.relationshipType ?? 'relationship'
+}
+
+export function relationshipDetail(link: RelationshipPresentation): string {
+  const details = [relationshipLabel(link)]
+  if (link.type !== undefined) details.push(link.type)
+  if (link.condition !== undefined) details.push(`when ${link.condition}`)
+  return details.join(' · ')
+}

--- a/apps/eclair/src/platform/infra/__fixtures__/riviere-test-fixtures.ts
+++ b/apps/eclair/src/platform/infra/__fixtures__/riviere-test-fixtures.ts
@@ -78,6 +78,8 @@ export interface RawEdge {
   source: string
   target: string
   type?: EdgeType
+  relationshipType?: string
+  condition?: string
   payload?: {
     type?: string
     schema?: string
@@ -257,6 +259,8 @@ export function parseEdge(data: RawEdge): Edge {
 
   if (id !== undefined) result.id = id
   if (data.type !== undefined) result.type = data.type
+  if (data.relationshipType !== undefined) result.relationshipType = data.relationshipType
+  if (data.condition !== undefined) result.condition = data.condition
   if (data.payload !== undefined) result.payload = data.payload
   if (data.sourceLocation !== undefined) result.sourceLocation = data.sourceLocation
   if (data.metadata !== undefined) result.metadata = data.metadata

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
@@ -51,6 +51,7 @@ interface ForceGraphProps {
   readonly onNodeClick?: (nodeId: string) => void
   readonly onNodeHover?: (data: TooltipData | null) => void
   readonly onBackgroundClick?: () => void
+  readonly relationshipLabelMode?: 'detailed' | 'semantic-only'
 }
 
 interface ApplyDomainFocusParams {
@@ -92,6 +93,7 @@ export function ForceGraph({
   onNodeClick,
   onNodeHover,
   onBackgroundClick,
+  relationshipLabelMode = 'detailed',
 }: Readonly<ForceGraphProps>): React.ReactElement {
   const svgRef = useRef<SVGSVGElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -164,9 +166,7 @@ export function ForceGraph({
     [onNodeClick],
   )
 
-  const handleNodeHover = useCallback((data: TooltipData | null) => {
-    onNodeHoverRef.current?.(data)
-  }, [])
+  const handleNodeHover = useCallback((data: TooltipData | null) => onNodeHoverRef.current?.(data), [])
 
   const handleBackgroundClick = useCallback(() => {
     onBackgroundClick?.()
@@ -296,7 +296,7 @@ export function ForceGraph({
       getSemanticEdgeColor,
       isAsyncEdge,
     })
-    const linkLabel = setupLinkLabels(linkGroup, links)
+    const linkLabel = setupLinkLabels(linkGroup, links, relationshipLabelMode)
 
     const node = setupNodes({
       nodeGroup,
@@ -381,6 +381,7 @@ export function ForceGraph({
     applyVisualization,
     setupNodeEvents,
     handleBackgroundClick,
+    relationshipLabelMode,
   ])
 
   useEffect(() => {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
@@ -16,6 +16,7 @@ import {
   getLinkNodeId,
   calculateFitViewportTransform,
   setupLinks,
+  setupLinkLabels,
   setupNodes,
   createUpdatePositionsFunction,
   applyDagrePositions,
@@ -38,6 +39,7 @@ import {
   truncateName,
   getDomainColor,
 } from './VisualizationDataAdapters'
+import { RelationshipLegend } from '@/platform/infra/ui/RelationshipLegend/RelationshipLegend'
 
 interface ForceGraphProps {
   readonly graph: RiviereGraph
@@ -294,6 +296,7 @@ export function ForceGraph({
       getSemanticEdgeColor,
       isAsyncEdge,
     })
+    const linkLabel = setupLinkLabels(linkGroup, links)
 
     const node = setupNodes({
       nodeGroup,
@@ -347,6 +350,7 @@ export function ForceGraph({
 
     const updatePositions = createUpdatePositionsFunction({
       link,
+      linkLabel,
       node,
       nodePositionMap: nodeMap,
       getNodeRadius,
@@ -430,6 +434,7 @@ export function ForceGraph({
         className="relative z-10"
         data-testid="force-graph-svg"
       />
+      <RelationshipLegend />
     </div>
   )
 }

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
@@ -2,13 +2,14 @@ import * as d3 from 'd3'
 import {
   describe, expect, it 
 } from 'vitest'
-import { setupLinkLabels } from './GraphRenderingSetup'
-import type { SimulationLink } from '../graph-types'
+import * as GraphRenderingSetup from './GraphRenderingSetup'
+import type * as GraphTypes from '../graph-types'
+import { parseNode } from '@/platform/infra/__fixtures__/riviere-test-fixtures'
 
 describe('relationship labels', () => {
   it('renders semantic type first with delivery and condition details', () => {
     const group = d3.select(document.body).append('svg').append('g')
-    const links: SimulationLink[] = [
+    const links: GraphTypes.SimulationLink[] = [
       {
         source: 'source',
         target: 'target',
@@ -23,14 +24,149 @@ describe('relationship labels', () => {
       },
     ]
 
-    setupLinkLabels(group, links)
+    GraphRenderingSetup.setupLinkLabels(group, links)
 
     expect(group.select('text').text()).toBe('publishes · async · when on success')
+    expect(group.select('text').attr('dy')).toBe('0')
+  })
+
+  it('stacks labels for parallel relationships between the same nodes', () => {
+    const group = d3.select(document.body).append('svg').append('g')
+    const links: GraphTypes.SimulationLink[] = ['reads', 'writes', 'writes'].map(
+      (relationshipType) => ({
+        source: 'source',
+        target: 'target',
+        type: 'sync',
+        originalEdge: {
+          source: 'source',
+          target: 'target',
+          type: 'sync',
+          relationshipType,
+        },
+      }),
+    )
+
+    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+
+    const labels = group.selectAll<SVGTextElement, GraphTypes.SimulationLink>('text')
+    expect(labels.filter((_link, index) => index === 0).attr('dy')).toBe('-16')
+    expect(labels.filter((_link, index) => index === 1).attr('dy')).toBe('0')
+    expect(labels.filter((_link, index) => index === 2).attr('dy')).toBe('16')
+  })
+
+  it('stacks labels when relationships run in opposite directions', () => {
+    const group = d3.select(document.body).append('svg').append('g')
+    const links: GraphTypes.SimulationLink[] = [
+      {
+        source: 'source',
+        target: 'target',
+        type: 'sync',
+        originalEdge: {
+          source: 'source',
+          target: 'target',
+          type: 'sync',
+          relationshipType: 'queries',
+        },
+      },
+      {
+        source: 'target',
+        target: 'source',
+        type: 'sync',
+        originalEdge: {
+          source: 'target',
+          target: 'source',
+          type: 'sync',
+          relationshipType: 'proxies',
+        },
+      },
+    ]
+
+    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+
+    const labels = group.selectAll<SVGTextElement, GraphTypes.SimulationLink>('text')
+    expect(labels.filter((_link, index) => index === 0).attr('dy')).toBe('-8')
+    expect(labels.filter((_link, index) => index === 1).attr('dy')).toBe('8')
+  })
+
+  it('stacks labels when different relationships have the same rendered midpoint', () => {
+    const group = d3.select(document.body).append('svg').append('g')
+    const links: GraphTypes.SimulationLink[] = [
+      {
+        source: 'top-left',
+        target: 'bottom-right',
+        type: 'sync',
+        originalEdge: {
+          source: 'top-left',
+          target: 'bottom-right',
+          type: 'sync',
+          relationshipType: 'reads',
+        },
+      },
+      {
+        source: 'bottom-left',
+        target: 'top-right',
+        type: 'sync',
+        originalEdge: {
+          source: 'bottom-left',
+          target: 'top-right',
+          type: 'sync',
+          relationshipType: 'writes',
+        },
+      },
+    ]
+    const positions = [
+      ['top-left', 0, 0],
+      ['bottom-right', 100, 100],
+      ['bottom-left', 0, 100],
+      ['top-right', 100, 0],
+    ] as const
+    const nodePositionMap = new Map(
+      positions.map(([id, x, y]) => [
+        id,
+        {
+          id,
+          x,
+          y,
+          type: 'Custom',
+          name: id,
+          domain: 'test',
+          originalNode: parseNode({
+            id,
+            type: 'Custom',
+            customTypeName: 'TestNode',
+            name: id,
+            domain: 'test',
+            module: 'test',
+            sourceLocation: {
+              repository: 'test-repo',
+              filePath: 'src/test.ts',
+            },
+          }),
+        } satisfies GraphTypes.SimulationNode,
+      ]),
+    )
+    const link = group
+      .selectAll<SVGPathElement, GraphTypes.SimulationLink>('path')
+      .data(links)
+      .join('path')
+    const linkLabel = GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+    const node = group.selectAll<SVGGElement, GraphTypes.SimulationNode>('g')
+
+    GraphRenderingSetup.createUpdatePositionsFunction({
+      link,
+      linkLabel,
+      node,
+      nodePositionMap,
+      getNodeRadius: () => 12,
+    })()
+
+    expect(linkLabel.filter((_link, index) => index === 0).attr('dy')).toBe('-8')
+    expect(linkLabel.filter((_link, index) => index === 1).attr('dy')).toBe('8')
   })
 
   it('renders only the semantic type with details available on hover', () => {
     const group = d3.select(document.body).append('svg').append('g')
-    const links: SimulationLink[] = [
+    const links: GraphTypes.SimulationLink[] = [
       {
         source: 'source',
         target: 'target',
@@ -45,7 +181,7 @@ describe('relationship labels', () => {
       },
     ]
 
-    setupLinkLabels(group, links, 'semantic-only')
+    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
 
     const label = group.select('text')
     expect(label.html()).toBe('publishes<title>publishes · async · when on success</title>')
@@ -62,7 +198,7 @@ describe('relationship labels', () => {
 
   it('does not add a semantic label when the relationship type is absent', () => {
     const group = d3.select(document.body).append('svg').append('g')
-    const links: SimulationLink[] = [
+    const links: GraphTypes.SimulationLink[] = [
       {
         source: 'source',
         target: 'target',
@@ -75,7 +211,7 @@ describe('relationship labels', () => {
       },
     ]
 
-    setupLinkLabels(group, links)
+    GraphRenderingSetup.setupLinkLabels(group, links)
 
     expect(group.selectAll('text').size()).toBe(0)
   })

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
@@ -30,7 +30,7 @@ describe('relationship labels', () => {
     expect(group.select('text').attr('dy')).toBe('0')
   })
 
-  it('stacks labels for parallel relationships between the same nodes', () => {
+  it('shows each relationship type once and stacks the unique labels', () => {
     const group = d3.select(document.body).append('svg').append('g')
     const links: GraphTypes.SimulationLink[] = ['reads', 'writes', 'writes'].map(
       (relationshipType) => ({
@@ -49,9 +49,54 @@ describe('relationship labels', () => {
     GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
 
     const labels = group.selectAll<SVGTextElement, GraphTypes.SimulationLink>('text')
-    expect(labels.filter((_link, index) => index === 0).attr('dy')).toBe('-16')
-    expect(labels.filter((_link, index) => index === 1).attr('dy')).toBe('0')
-    expect(labels.filter((_link, index) => index === 2).attr('dy')).toBe('16')
+    expect(labels.size()).toBe(2)
+    expect(labels.nodes().map((label) => label.childNodes[0]?.textContent)).toStrictEqual([
+      'reads',
+      'writes',
+    ])
+    expect(labels.filter((_link, index) => index === 0).attr('dy')).toBe('-8')
+    expect(labels.filter((_link, index) => index === 1).attr('dy')).toBe('8')
+  })
+
+  it('combines distinct details behind a unique relationship label', () => {
+    const group = d3.select(document.body).append('svg').append('g')
+    const links: GraphTypes.SimulationLink[] = [
+      {
+        source: 'source',
+        target: 'target',
+        type: 'sync',
+        originalEdge: {
+          source: 'source',
+          target: 'target',
+          type: 'sync',
+          relationshipType: 'executes',
+          condition: 'ready',
+        },
+      },
+      {
+        source: 'source',
+        target: 'target',
+        type: 'async',
+        originalEdge: {
+          source: 'source',
+          target: 'target',
+          type: 'async',
+          relationshipType: 'executes',
+          condition: 'forced',
+        },
+      },
+    ]
+
+    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+
+    const label = group.select('text')
+    expect(group.selectAll('text').size()).toBe(1)
+    expect(label.attr('aria-label')).toBe(
+      'executes · sync · when ready\nexecutes · async · when forced',
+    )
+    expect(label.select('title').text()).toBe(
+      'executes · sync · when ready\nexecutes · async · when forced',
+    )
   })
 
   it('stacks labels when relationships run in opposite directions', () => {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
@@ -1,0 +1,50 @@
+import * as d3 from 'd3'
+import {
+  describe, expect, it 
+} from 'vitest'
+import { setupLinkLabels } from './GraphRenderingSetup'
+import type { SimulationLink } from '../graph-types'
+
+describe('relationship labels', () => {
+  it('renders semantic type first with delivery and condition details', () => {
+    const group = d3.select(document.body).append('svg').append('g')
+    const links: SimulationLink[] = [
+      {
+        source: 'source',
+        target: 'target',
+        type: 'async',
+        originalEdge: {
+          source: 'source',
+          target: 'target',
+          type: 'async',
+          relationshipType: 'publishes',
+          condition: 'on success',
+        },
+      },
+    ]
+
+    setupLinkLabels(group, links)
+
+    expect(group.select('text').text()).toBe('publishes · async · when on success')
+  })
+
+  it('does not add a semantic label when the relationship type is absent', () => {
+    const group = d3.select(document.body).append('svg').append('g')
+    const links: SimulationLink[] = [
+      {
+        source: 'source',
+        target: 'target',
+        type: 'sync',
+        originalEdge: {
+          source: 'source',
+          target: 'target',
+          type: 'sync',
+        },
+      },
+    ]
+
+    setupLinkLabels(group, links)
+
+    expect(group.selectAll('text').size()).toBe(0)
+  })
+})

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
@@ -28,6 +28,38 @@ describe('relationship labels', () => {
     expect(group.select('text').text()).toBe('publishes · async · when on success')
   })
 
+  it('renders only the semantic type with details available on hover', () => {
+    const group = d3.select(document.body).append('svg').append('g')
+    const links: SimulationLink[] = [
+      {
+        source: 'source',
+        target: 'target',
+        type: 'async',
+        originalEdge: {
+          source: 'source',
+          target: 'target',
+          type: 'async',
+          relationshipType: 'publishes',
+          condition: 'on success',
+        },
+      },
+    ]
+
+    setupLinkLabels(group, links, 'semantic-only')
+
+    const label = group.select('text')
+    expect(label.html()).toBe('publishes<title>publishes · async · when on success</title>')
+    expect(label.select('title').text()).toBe('publishes · async · when on success')
+    expect(label.attr('aria-label')).toBe('publishes · async · when on success')
+    expect({
+      cursor: label.attr('cursor'),
+      fontWeight: label.attr('font-weight'),
+    }).toStrictEqual({
+      cursor: 'help',
+      fontWeight: '500',
+    })
+  })
+
   it('does not add a semantic label when the relationship type is absent', () => {
     const group = d3.select(document.body).append('svg').append('g')
     const links: SimulationLink[] = [

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.ts
@@ -4,6 +4,7 @@ export {
   applyResetModeLinkStyles,
   applyResetModeTextStyles,
   setupLinks,
+  setupLinkLabels,
   setupNodes,
   createUpdatePositionsFunction,
 } from './graph-rendering-setup'

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
@@ -8,6 +8,7 @@ import { getLinkNodeId } from './FocusModeStyling'
 import {
   LayoutError, RenderingError 
 } from '@/platform/infra/errors/errors'
+import { relationshipDetail } from '@/platform/domain/relationship-presentation'
 
 export {
   getLinkNodeId,
@@ -81,6 +82,25 @@ export function setupLinks({
     })
 }
 
+export function setupLinkLabels(
+  linkGroup: d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>,
+  links: SimulationLink[],
+): d3.Selection<SVGTextElement, SimulationLink, SVGGElement, unknown> {
+  return linkGroup
+    .selectAll<SVGTextElement, SimulationLink>('text')
+    .data(links.filter((link) => link.originalEdge.relationshipType !== undefined))
+    .join('text')
+    .attr('class', 'graph-link-label')
+    .attr('text-anchor', 'middle')
+    .attr('font-size', '10px')
+    .attr('font-weight', 600)
+    .attr('fill', 'var(--text-secondary)')
+    .attr('stroke', 'var(--surface-primary)')
+    .attr('stroke-width', 3)
+    .attr('paint-order', 'stroke')
+    .text((link) => relationshipDetail(link.originalEdge))
+}
+
 export interface SetupNodesParams {
   nodeGroup: d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>
   nodes: SimulationNode[]
@@ -142,6 +162,7 @@ export function setupNodes({
 
 export interface UpdatePositionsParams {
   link: d3.Selection<SVGPathElement, SimulationLink, SVGGElement, unknown>
+  linkLabel?: d3.Selection<SVGTextElement, SimulationLink, SVGGElement, unknown>
   node: d3.Selection<SVGGElement, SimulationNode, SVGGElement, unknown>
   nodePositionMap: Map<string, SimulationNode>
   getNodeRadius: (type: NodeType) => number
@@ -149,7 +170,7 @@ export interface UpdatePositionsParams {
 
 export function createUpdatePositionsFunction(params: UpdatePositionsParams): () => void {
   const {
-    link, node, nodePositionMap, getNodeRadius 
+    link, linkLabel, node, nodePositionMap, getNodeRadius 
   } = params
 
   return function updatePositions(): void {
@@ -204,6 +225,17 @@ export function createUpdatePositionsFunction(params: UpdatePositionsParams): ()
       const endY = targetY - (dy / dist) * targetRadius
 
       return `M${startX},${startY}L${endX},${endY}`
+    })
+
+    linkLabel?.attr('x', (d) => {
+      const source = nodePositionMap.get(getLinkNodeId(d.source))
+      const target = nodePositionMap.get(getLinkNodeId(d.target))
+      return ((source?.x ?? 0) + (target?.x ?? 0)) / 2
+    })
+    linkLabel?.attr('y', (d) => {
+      const source = nodePositionMap.get(getLinkNodeId(d.source))
+      const target = nodePositionMap.get(getLinkNodeId(d.target))
+      return ((source?.y ?? 0) + (target?.y ?? 0)) / 2 - 6
     })
 
     node.attr('transform', (d) => {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
@@ -3,6 +3,7 @@ import type {
   SimulationNode, SimulationLink 
 } from '../graph-types'
 import type { NodeType } from '@/platform/domain/eclair-types'
+import { compareByCodePoint } from '@/platform/domain/compare-by-code-point'
 import type { Theme } from '@/types/theme'
 import { getLinkNodeId } from './FocusModeStyling'
 import {
@@ -18,6 +19,21 @@ export {
 } from './FocusModeStyling'
 
 type SemanticEdgeType = 'event' | 'eventHandler' | 'external' | 'default'
+
+const PARALLEL_LABEL_GAP = 16
+
+function getVerticalLabelOffsets(
+  links: SimulationLink[],
+  getGroupKey: (link: SimulationLink) => string,
+): Map<SimulationLink, number> {
+  const offsets = new Map<SimulationLink, number>()
+  for (const groupedLinks of d3.group(links, getGroupKey).values()) {
+    groupedLinks.forEach((link, index) => {
+      offsets.set(link, (index - (groupedLinks.length - 1) / 2) * PARALLEL_LABEL_GAP)
+    })
+  }
+  return offsets
+}
 
 export interface SetupLinksParams {
   linkGroup: d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>
@@ -104,6 +120,14 @@ export function setupLinkLabels(
         ? relationshipPresentation.relationshipLabel(link.originalEdge)
         : relationshipPresentation.relationshipDetail(link.originalEdge),
     )
+
+  const verticalOffsets = getVerticalLabelOffsets(labels.data(), (link) => {
+    const nodePair = [getLinkNodeId(link.source), getLinkNodeId(link.target)].sort(
+      compareByCodePoint,
+    )
+    return JSON.stringify(nodePair)
+  })
+  labels.attr('dy', (link) => verticalOffsets.get(link) ?? 0)
 
   if (mode === 'semantic-only') {
     labels
@@ -242,16 +266,28 @@ export function createUpdatePositionsFunction(params: UpdatePositionsParams): ()
       return `M${startX},${startY}L${endX},${endY}`
     })
 
-    linkLabel?.attr('x', (d) => {
-      const source = nodePositionMap.get(getLinkNodeId(d.source))
-      const target = nodePositionMap.get(getLinkNodeId(d.target))
-      return ((source?.x ?? 0) + (target?.x ?? 0)) / 2
-    })
-    linkLabel?.attr('y', (d) => {
-      const source = nodePositionMap.get(getLinkNodeId(d.source))
-      const target = nodePositionMap.get(getLinkNodeId(d.target))
-      return ((source?.y ?? 0) + (target?.y ?? 0)) / 2 - 6
-    })
+    if (linkLabel !== undefined) {
+      linkLabel.attr('x', (d) => {
+        const source = nodePositionMap.get(getLinkNodeId(d.source))
+        const target = nodePositionMap.get(getLinkNodeId(d.target))
+        return ((source?.x ?? 0) + (target?.x ?? 0)) / 2
+      })
+      linkLabel.attr('y', (d) => {
+        const source = nodePositionMap.get(getLinkNodeId(d.source))
+        const target = nodePositionMap.get(getLinkNodeId(d.target))
+        return ((source?.y ?? 0) + (target?.y ?? 0)) / 2 - 6
+      })
+
+      const verticalOffsets = getVerticalLabelOffsets(linkLabel.data(), (labelLink) => {
+        const source = nodePositionMap.get(getLinkNodeId(labelLink.source))
+        const target = nodePositionMap.get(getLinkNodeId(labelLink.target))
+        return JSON.stringify([
+          (source?.x ?? 0) + (target?.x ?? 0),
+          (source?.y ?? 0) + (target?.y ?? 0),
+        ])
+      })
+      linkLabel.attr('dy', (labelLink) => verticalOffsets.get(labelLink) ?? 0)
+    }
 
     node.attr('transform', (d) => {
       /* v8 ignore next 3 -- @preserve defensive: D3 callback, coordinates set by simulation */

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
@@ -3,13 +3,13 @@ import type {
   SimulationNode, SimulationLink 
 } from '../graph-types'
 import type { NodeType } from '@/platform/domain/eclair-types'
-import { compareByCodePoint } from '@/platform/domain/compare-by-code-point'
 import type { Theme } from '@/types/theme'
 import { getLinkNodeId } from './FocusModeStyling'
 import {
   LayoutError, RenderingError 
 } from '@/platform/infra/errors/errors'
 import * as relationshipPresentation from '@/platform/domain/relationship-presentation'
+import * as linkLabelPositioning from './link-label-positioning'
 
 export {
   getLinkNodeId,
@@ -19,21 +19,6 @@ export {
 } from './FocusModeStyling'
 
 type SemanticEdgeType = 'event' | 'eventHandler' | 'external' | 'default'
-
-const PARALLEL_LABEL_GAP = 16
-
-function getVerticalLabelOffsets(
-  links: SimulationLink[],
-  getGroupKey: (link: SimulationLink) => string,
-): Map<SimulationLink, number> {
-  const offsets = new Map<SimulationLink, number>()
-  for (const groupedLinks of d3.group(links, getGroupKey).values()) {
-    groupedLinks.forEach((link, index) => {
-      offsets.set(link, (index - (groupedLinks.length - 1) / 2) * PARALLEL_LABEL_GAP)
-    })
-  }
-  return offsets
-}
 
 export interface SetupLinksParams {
   linkGroup: d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>
@@ -103,9 +88,13 @@ export function setupLinkLabels(
   links: SimulationLink[],
   mode: 'detailed' | 'semantic-only' = 'detailed',
 ): d3.Selection<SVGTextElement, SimulationLink, SVGGElement, unknown> {
+  const labelLinks =
+    mode === 'semantic-only'
+      ? linkLabelPositioning.getUniqueRelationshipLabelLinks(links)
+      : links.filter((link) => link.originalEdge.relationshipType !== undefined)
   const labels = linkGroup
     .selectAll<SVGTextElement, SimulationLink>('text')
-    .data(links.filter((link) => link.originalEdge.relationshipType !== undefined))
+    .data(labelLinks)
     .join('text')
     .attr('class', 'graph-link-label')
     .attr('text-anchor', 'middle')
@@ -121,20 +110,18 @@ export function setupLinkLabels(
         : relationshipPresentation.relationshipDetail(link.originalEdge),
     )
 
-  const verticalOffsets = getVerticalLabelOffsets(labels.data(), (link) => {
-    const nodePair = [getLinkNodeId(link.source), getLinkNodeId(link.target)].sort(
-      compareByCodePoint,
-    )
-    return JSON.stringify(nodePair)
-  })
+  const verticalOffsets = linkLabelPositioning.getVerticalLabelOffsets(
+    labels.data(),
+    linkLabelPositioning.getUnorderedNodePairKey,
+  )
   labels.attr('dy', (link) => verticalOffsets.get(link) ?? 0)
 
   if (mode === 'semantic-only') {
-    labels
-      .attr('cursor', 'help')
-      .attr('aria-label', (link) => relationshipPresentation.relationshipDetail(link.originalEdge))
-      .append('title')
-      .text((link) => relationshipPresentation.relationshipDetail(link.originalEdge))
+    const getDetails = (link: SimulationLink): string =>
+      linkLabelPositioning.getRelationshipLabelDetails(links, link, (detailLink) =>
+        relationshipPresentation.relationshipDetail(detailLink.originalEdge),
+      )
+    labels.attr('cursor', 'help').attr('aria-label', getDetails).append('title').text(getDetails)
   }
 
   return labels
@@ -278,14 +265,17 @@ export function createUpdatePositionsFunction(params: UpdatePositionsParams): ()
         return ((source?.y ?? 0) + (target?.y ?? 0)) / 2 - 6
       })
 
-      const verticalOffsets = getVerticalLabelOffsets(linkLabel.data(), (labelLink) => {
-        const source = nodePositionMap.get(getLinkNodeId(labelLink.source))
-        const target = nodePositionMap.get(getLinkNodeId(labelLink.target))
-        return JSON.stringify([
-          (source?.x ?? 0) + (target?.x ?? 0),
-          (source?.y ?? 0) + (target?.y ?? 0),
-        ])
-      })
+      const verticalOffsets = linkLabelPositioning.getVerticalLabelOffsets(
+        linkLabel.data(),
+        (labelLink) => {
+          const source = nodePositionMap.get(getLinkNodeId(labelLink.source))
+          const target = nodePositionMap.get(getLinkNodeId(labelLink.target))
+          return JSON.stringify([
+            (source?.x ?? 0) + (target?.x ?? 0),
+            (source?.y ?? 0) + (target?.y ?? 0),
+          ])
+        },
+      )
       linkLabel.attr('dy', (labelLink) => verticalOffsets.get(labelLink) ?? 0)
     }
 

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
@@ -8,7 +8,7 @@ import { getLinkNodeId } from './FocusModeStyling'
 import {
   LayoutError, RenderingError 
 } from '@/platform/infra/errors/errors'
-import { relationshipDetail } from '@/platform/domain/relationship-presentation'
+import * as relationshipPresentation from '@/platform/domain/relationship-presentation'
 
 export {
   getLinkNodeId,
@@ -85,20 +85,35 @@ export function setupLinks({
 export function setupLinkLabels(
   linkGroup: d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>,
   links: SimulationLink[],
+  mode: 'detailed' | 'semantic-only' = 'detailed',
 ): d3.Selection<SVGTextElement, SimulationLink, SVGGElement, unknown> {
-  return linkGroup
+  const labels = linkGroup
     .selectAll<SVGTextElement, SimulationLink>('text')
     .data(links.filter((link) => link.originalEdge.relationshipType !== undefined))
     .join('text')
     .attr('class', 'graph-link-label')
     .attr('text-anchor', 'middle')
     .attr('font-size', '10px')
-    .attr('font-weight', 600)
+    .attr('font-weight', mode === 'semantic-only' ? 500 : 600)
     .attr('fill', 'var(--text-secondary)')
     .attr('stroke', 'var(--surface-primary)')
     .attr('stroke-width', 3)
     .attr('paint-order', 'stroke')
-    .text((link) => relationshipDetail(link.originalEdge))
+    .text((link) =>
+      mode === 'semantic-only'
+        ? relationshipPresentation.relationshipLabel(link.originalEdge)
+        : relationshipPresentation.relationshipDetail(link.originalEdge),
+    )
+
+  if (mode === 'semantic-only') {
+    labels
+      .attr('cursor', 'help')
+      .attr('aria-label', (link) => relationshipPresentation.relationshipDetail(link.originalEdge))
+      .append('title')
+      .text((link) => relationshipPresentation.relationshipDetail(link.originalEdge))
+  }
+
+  return labels
 }
 
 export interface SetupNodesParams {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/link-label-positioning.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/link-label-positioning.ts
@@ -1,0 +1,68 @@
+import type * as GraphTypes from '../graph-types'
+
+const PARALLEL_LABEL_GAP = 16
+
+function relationshipLabelKey(link: GraphTypes.SimulationLink): string {
+  return JSON.stringify([
+    link.originalEdge.source,
+    link.originalEdge.target,
+    link.originalEdge.relationshipType,
+  ])
+}
+
+export function getUniqueRelationshipLabelLinks(
+  links: GraphTypes.SimulationLink[],
+): GraphTypes.SimulationLink[] {
+  const seenKeys = new Set<string>()
+  return links.filter((link) => {
+    if (link.originalEdge.relationshipType === undefined) return false
+
+    const key = relationshipLabelKey(link)
+    if (seenKeys.has(key)) return false
+
+    seenKeys.add(key)
+    return true
+  })
+}
+
+export function getRelationshipLabelDetails(
+  links: GraphTypes.SimulationLink[],
+  labelLink: GraphTypes.SimulationLink,
+  formatDetail: (link: GraphTypes.SimulationLink) => string,
+): string {
+  const labelKey = relationshipLabelKey(labelLink)
+  return [
+    ...new Set(
+      links
+        .filter((link) => relationshipLabelKey(link) === labelKey)
+        .map((link) => formatDetail(link)),
+    ),
+  ].join('\n')
+}
+
+export function getUnorderedNodePairKey(link: GraphTypes.SimulationLink): string {
+  const source = link.originalEdge.source
+  const target = link.originalEdge.target
+  return JSON.stringify(source < target ? [source, target] : [target, source])
+}
+
+export function getVerticalLabelOffsets(
+  links: GraphTypes.SimulationLink[],
+  getGroupKey: (link: GraphTypes.SimulationLink) => string,
+): Map<GraphTypes.SimulationLink, number> {
+  const groupedLinks = new Map<string, GraphTypes.SimulationLink[]>()
+  for (const link of links) {
+    const key = getGroupKey(link)
+    const group = groupedLinks.get(key)
+    if (group === undefined) groupedLinks.set(key, [link])
+    else group.push(link)
+  }
+
+  const offsets = new Map<GraphTypes.SimulationLink, number>()
+  for (const group of groupedLinks.values()) {
+    group.forEach((link, index) => {
+      offsets.set(link, (index - (group.length - 1) / 2) * PARALLEL_LABEL_GAP)
+    })
+  }
+  return offsets
+}

--- a/apps/eclair/src/platform/infra/ui/RelationshipLegend/RelationshipLegend.spec.tsx
+++ b/apps/eclair/src/platform/infra/ui/RelationshipLegend/RelationshipLegend.spec.tsx
@@ -1,0 +1,21 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'vitest'
+import {
+  render, screen
+} from '@testing-library/react'
+import { RelationshipLegend } from './RelationshipLegend'
+
+describe('RelationshipLegend', () => {
+  it('explains semantic labels, delivery style and conditions', () => {
+    render(<RelationshipLegend />)
+
+    const legend = screen.getByLabelText('Relationship legend')
+    expect(legend.textContent).toContain('Label: semantic relationship')
+    expect(legend.textContent).toContain('sync')
+    expect(legend.textContent).toContain('async')
+    expect(legend.textContent).toContain('when: condition')
+  })
+})

--- a/apps/eclair/src/platform/infra/ui/RelationshipLegend/RelationshipLegend.tsx
+++ b/apps/eclair/src/platform/infra/ui/RelationshipLegend/RelationshipLegend.tsx
@@ -1,0 +1,13 @@
+export function RelationshipLegend(): React.ReactElement {
+  return (
+    <div
+      aria-label="Relationship legend"
+      className="floating-panel pointer-events-none absolute bottom-4 left-4 z-20 flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--text-secondary)]"
+    >
+      <span><strong>Label</strong>: semantic relationship</span>
+      <span>━━━━ sync</span>
+      <span>┄┄┄┄ async</span>
+      <span><strong>when</strong>: condition</span>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@living-architecture/source",
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "packageManager": "pnpm@10.30.2",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "build": "nx run-many -t build",
     "build:deploy": "cd packages/riviere-schema && npx tsc --build tsconfig.lib.json && cd ../riviere-query && npx tsc --build tsconfig.lib.json && cd ../../apps/docs && cp ../../packages/riviere-cli/docs/workflow/step-*.md extract/ai-assisted/ && cp ../../packages/riviere-cli/docs/generated/cli-reference.md reference/cli/cli-reference.md && NODE_OPTIONS='--max-old-space-size=4096' npx vitepress build && cd ../eclair && npx vite build && cd ../.. && rm -rf dist && mkdir -p dist/eclair && cp -r apps/docs/.vitepress/dist/* dist/ && cp -r apps/eclair/dist/* dist/eclair/",
@@ -82,15 +82,5 @@
         }
       }
     }
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "better-sqlite3",
-      "esbuild",
-      "nx",
-      "unrs-resolver"
-    ],
-    "ignoredBuiltDependencies": []
   }
 }

--- a/packages/riviere-query/src/features/querying/queries/domain-types.ts
+++ b/packages/riviere-query/src/features/querying/queries/domain-types.ts
@@ -228,8 +228,8 @@ export type LinkType = 'sync' | 'async'
 export interface FlowStep {
   /** The component at this step. */
   component: Component
-  /** Type of link leading to this step (undefined for entry point). */
-  linkType: LinkType | undefined
+  /** Exact links leaving this component, preserving branching relationship semantics. */
+  outgoingLinks: Link[]
   /** Depth from entry point (0 = entry point). */
   depth: number
   /** External links from this component to external systems. */

--- a/packages/riviere-query/src/features/querying/queries/flow-queries.ts
+++ b/packages/riviere-query/src/features/querying/queries/flow-queries.ts
@@ -1,5 +1,8 @@
 import type {
-  RiviereGraph, Component, ExternalLink 
+  RiviereGraph,
+  Component,
+  ExternalLink,
+  Link,
 } from '@living-architecture/riviere-schema'
 import type {
   ComponentId, LinkId, Flow, SearchWithFlowResult 
@@ -77,22 +80,18 @@ export function queryFlows(graph: RiviereGraph): Flow[] {
       const component = componentByIdMap.get(nodeId)
       if (!component) return
 
-      const edges = outgoingEdges.get(nodeId)
-      const firstEdge = edges !== undefined && edges.length > 0 ? edges[0] : undefined
-      const linkType = firstEdge === undefined ? undefined : firstEdge.type
+      const edges = outgoingEdges.get(nodeId) ?? []
       const externalLinks = externalLinksBySource.get(nodeId) ?? []
 
       steps.push({
         component,
-        linkType,
+        outgoingLinks: edges,
         depth,
         externalLinks,
       })
 
-      if (edges) {
-        for (const edge of edges) {
-          traverse(edge.target, depth + 1)
-        }
+      for (const edge of edges) {
+        traverse(edge.target, depth + 1)
       }
     }
 
@@ -122,30 +121,14 @@ function buildExternalLinksBySource(graph: RiviereGraph): Map<string, ExternalLi
   return bySource
 }
 
-function buildOutgoingEdges(graph: RiviereGraph): Map<
-  string,
-  Array<{
-    target: string
-    type: 'sync' | 'async' | undefined
-  }>
-> {
-  const edges = new Map<
-    string,
-    Array<{
-      target: string
-      type: 'sync' | 'async' | undefined
-    }>
-  >()
+function buildOutgoingEdges(graph: RiviereGraph): Map<string, Link[]> {
+  const edges = new Map<string, Link[]>()
   for (const link of graph.links) {
-    const entry = {
-      target: link.target,
-      type: link.type,
-    }
     const existing = edges.get(link.source)
     if (existing) {
-      existing.push(entry)
+      existing.push(link)
     } else {
-      edges.set(link.source, [entry])
+      edges.set(link.source, [link])
     }
   }
   return edges

--- a/packages/riviere-query/src/features/querying/queries/flows.spec.ts
+++ b/packages/riviere-query/src/features/querying/queries/flows.spec.ts
@@ -25,7 +25,7 @@ describe('RiviereQuery.flows()', () => {
     expect(flow.steps[0]?.component.id).toBe('test:mod:ui:page')
   })
 
-  it('sets first step depth to 0 with undefined linkType', () => {
+  it('sets first step depth to 0 and preserves its outgoing links', () => {
     const query = new RiviereQuery(createMinimalValidGraph())
 
     const result = query.flows()
@@ -33,7 +33,7 @@ describe('RiviereQuery.flows()', () => {
     const flow = assertDefined(result[0], 'Expected flow to exist')
     const firstStep = assertDefined(flow.steps[0], 'Expected first step to exist')
     expect(firstStep.depth).toBe(0)
-    expect(firstStep.linkType).toBeUndefined()
+    expect(firstStep.outgoingLinks).toStrictEqual(createMinimalValidGraph().links)
   })
 
   describe('when entry point has outgoing links', () => {
@@ -106,7 +106,7 @@ describe('RiviereQuery.flows()', () => {
     )
   })
 
-  it('sets linkType from outgoing link and undefined for last step', () => {
+  it('preserves the exact outgoing links for every step', () => {
     const graph = createMinimalValidGraph()
     graph.components.push(
       createAPIComponent({
@@ -127,9 +127,11 @@ describe('RiviereQuery.flows()', () => {
         type: 'sync',
       },
       {
-        source: 'test:api:a',
+        source: 'test:mod:ui:page',
         target: 'test:uc:b',
         type: 'async',
+        relationshipType: 'publishes',
+        condition: 'on success',
       },
     ]
     const query = new RiviereQuery(graph)
@@ -141,9 +143,9 @@ describe('RiviereQuery.flows()', () => {
     const step0 = assertDefined(flow.steps[0], 'Expected step 0')
     const step1 = assertDefined(flow.steps[1], 'Expected step 1')
     const step2 = assertDefined(flow.steps[2], 'Expected step 2')
-    expect(step0.linkType).toBe('sync')
-    expect(step1.linkType).toBe('async')
-    expect(step2.linkType).toBeUndefined()
+    expect(step0.outgoingLinks).toStrictEqual(graph.links)
+    expect(step1.outgoingLinks).toStrictEqual([])
+    expect(step2.outgoingLinks).toStrictEqual([])
   })
 
   it('returns multiple flows when graph has multiple entry points with no incoming links', () => {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,9 @@ packages:
 
 autoInstallPeers: true
 
-onlyBuiltDependencies:
-  - better-sqlite3
+allowBuilds:
+  '@swc/core': true
+  better-sqlite3: true
+  esbuild: true
+  nx: true
+  unrs-resolver: true


### PR DESCRIPTION
## Problem

Éclair receives semantic relationship names, delivery modes and conditions from Rivière graphs, but several views either discard that metadata or render only the low-level delivery mode. Full Graph labels also become noisy when every secondary detail is shown directly on the canvas.

The repository setup also pins an outdated pnpm release.

## Proposed outcome

Relationship names are the primary description across Éclair. Delivery mode and condition remain available as secondary context without overwhelming the Full Graph. Existing graphs without semantic relationship names continue to render safely.

The repository uses pnpm 11.21.0 consistently in local setup and CI.

## Changes

- upgrade the repository and CI setup to pnpm 11.21.0
- preserve exact outgoing relationships in flow query results
- retain relationship names, delivery modes and conditions through domain and flow queries
- show semantic relationship names across Flow, Domain Map, domain context and Full Graph views
- render only the relationship name on Full Graph links, with delivery mode and condition in hover details
- retain solid and dashed link styling for synchronous and asynchronous delivery
- add a shared relationship legend and focused regression coverage

## Acceptance criteria

- [x] semantic relationship names are the primary labels where supplied
- [x] delivery mode and conditions remain available as secondary details
- [x] Full Graph labels omit delivery mode and conditions by default
- [x] Full Graph relationship labels use a help cursor and expose full hover details
- [x] branching outgoing relationships remain distinct in flow and domain views
- [x] graphs without semantic relationship names remain supported
- [x] repository setup and CI use pnpm 11.21.0

## Validation

- full repository verification passes
- Eclair build, lint and test targets pass
- commit hooks pass without bypassing
- Chromium, Firefox and WebKit browser suites pass in CI
- security analysis, CodeQL, Semgrep, SonarCloud and validation checks pass
- local browser validation with a synthetic SQL Server graph confirms 44 shortened Full Graph labels, full hover metadata and no console errors
- repository, branch, diff and commit-message confidentiality scans pass
- CodeRabbit reviewed the latest commit and generated no actionable comments

## Design decisions and constraints

- Full Graph uses semantic-only visible labels to reduce overlap; other graph consumers keep their existing detailed labels
- synchronous and asynchronous delivery remains encoded by solid and dashed link styles
- native SVG title content and an accessible label expose the complete relationship detail
- relationship metadata remains optional for backward compatibility

## Out of scope

- changing graph layout or collision avoidance
- changing the Rivière schema
- changing existing flow-view label density


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer relationship labels across domain maps, full graphs, domain details, and flow traces.
  * Relationship labels can show semantic types, delivery modes, and conditions.
  * Added a legend explaining relationship, synchronous, asynchronous, and conditional connectors.
  * Asynchronous-only connections now use dashed lines.
  * Flow views preserve and display all outgoing relationships, including branching links.

* **Chores**
  * Updated project tooling to pnpm 11.21.0 and simplified installation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->