### PR TITLE
fix(eclair): repair domain focus and relationship labels

### DIFF
--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.spec.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.spec.tsx
@@ -163,9 +163,11 @@ describe('DomainMapPage', () => {
 
     const ordersNode = container.querySelector('[data-id="orders"]')
     const paymentsNode = container.querySelector('[data-id="payments"]')
+    const ordersDomain = ordersNode?.querySelector('[title="orders"]')
+    const paymentsDomain = paymentsNode?.querySelector('[title="payments"]')
 
-    expect(ordersNode).toBeInTheDocument()
-    expect(paymentsNode).toBeInTheDocument()
+    expect(ordersDomain).toHaveAttribute('data-focused', 'true')
+    expect(paymentsDomain).toHaveAttribute('data-focused', 'false')
   })
 
   describe('inspector panel design', () => {

--- a/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
+++ b/apps/eclair/src/features/domain-map/entrypoint/DomainMapPage.tsx
@@ -171,6 +171,7 @@ export function DomainMapPage({ graph }: DomainMapPageProps): React.ReactElement
         data: {
           ...node.data,
           dimmed: isDimmed,
+          focused: isFocused,
         },
       }
     })

--- a/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.spec.ts
+++ b/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.spec.ts
@@ -1,9 +1,5 @@
-import {
-  describe, it, expect 
-} from 'vitest'
-import {
-  renderHook, act 
-} from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
 import { useDomainMapInteractions } from './useDomainMapInteractions'
 import type { ConnectionDetail } from '../queries/extract-domain-map'
 
@@ -187,6 +183,17 @@ describe('useDomainMapInteractions', () => {
       )
 
       expect(result.current.focusedDomain).toBe('orders')
+    })
+
+    it('updates the focused domain when the route-provided domain changes', () => {
+      const hook = renderHook(
+        ({ initialFocusedDomain }: { initialFocusedDomain: string | null }) =>
+          useDomainMapInteractions({ initialFocusedDomain }),
+        { initialProps: { initialFocusedDomain: 'orders' } },
+      )
+      hook.rerender({ initialFocusedDomain: 'payments' })
+
+      expect(hook.result.current.focusedDomain).toBe('payments')
     })
 
     it('sets focused domain on selectDomain', () => {

--- a/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.ts
+++ b/apps/eclair/src/features/domain-map/hooks/useDomainMapInteractions.ts
@@ -1,10 +1,6 @@
-import {
-  useState, useCallback 
-} from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import type { ConnectionDetail } from '../queries/extract-domain-map'
-import {
-  pluralizeComponent, pluralizeConnection 
-} from '@/platform/domain/text/pluralize'
+import { pluralizeComponent, pluralizeConnection } from '@/platform/domain/text/pluralize'
 
 interface TooltipState {
   visible: boolean
@@ -86,6 +82,10 @@ export function useDomainMapInteractions(
   })
 
   const [focusedDomain, setFocusedDomain] = useState<string | null>(initialFocusedDomain)
+
+  useEffect(() => {
+    setFocusedDomain(initialFocusedDomain)
+  }, [initialFocusedDomain])
 
   const showNodeTooltip = useCallback((x: number, y: number, label: string, nodeCount: number) => {
     setTooltip({

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/DomainContextGraph.tsx
@@ -261,6 +261,7 @@ export function DomainContextGraph({
                 relationshipCount={conn.relationshipCount}
                 relationshipTypes={conn.relationshipTypes}
                 deliveryTypes={conn.deliveryTypes}
+                conditions={conn.conditions}
                 isBidirectional={isBidirectional}
               />
             )

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
@@ -108,7 +108,7 @@ describe('EdgeLine', () => {
     expect(group).toBeInTheDocument()
   })
 
-  it('separates the paths and labels for opposite relationship directions', () => {
+  it('separates long labels for opposite relationship directions', () => {
     const { container } = render(
       <svg>
         <EdgeLine
@@ -119,6 +119,8 @@ describe('EdgeLine', () => {
           testId="outgoing-edge"
           direction="outgoing"
           relationshipCount={2}
+          relationshipTypes={['proxies']}
+          deliveryTypes={['sync']}
           isBidirectional
         />
         <EdgeLine
@@ -129,6 +131,8 @@ describe('EdgeLine', () => {
           testId="incoming-edge"
           direction="incoming"
           relationshipCount={1}
+          relationshipTypes={['proxies']}
+          deliveryTypes={['sync']}
           isBidirectional
         />
       </svg>,
@@ -140,7 +144,17 @@ describe('EdgeLine', () => {
     const incomingLabel = container.querySelector('[data-testid="incoming-edge"] text')
 
     expect(outgoingLine?.getAttribute('x1')).not.toBe(incomingLine?.getAttribute('x2'))
-    expect(outgoingLabel?.getAttribute('x')).not.toBe(incomingLabel?.getAttribute('x'))
-    expect(outgoingLabel?.getAttribute('y')).not.toBe(incomingLabel?.getAttribute('y'))
+    const outgoingLabelX = Number(outgoingLabel?.getAttribute('x'))
+    const outgoingLabelY = Number(outgoingLabel?.getAttribute('y'))
+    const incomingLabelX = Number(incomingLabel?.getAttribute('x'))
+    const incomingLabelY = Number(incomingLabel?.getAttribute('y'))
+    const labelSeparation = Math.hypot(
+      outgoingLabelX - incomingLabelX,
+      outgoingLabelY - incomingLabelY,
+    )
+
+    expect(outgoingLabel).toHaveTextContent('proxies · sync')
+    expect(incomingLabel).toHaveTextContent('proxies · sync')
+    expect(labelSeparation).toBeGreaterThan(24)
   })
 })

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
@@ -39,7 +39,7 @@ describe('EdgeLine', () => {
     expect(group).toBeInTheDocument()
   })
 
-  it('shows only semantic relationships while retaining delivery details on hover', () => {
+  it('shows only semantic relationships while retaining delivery and condition details on hover', () => {
     const { container } = render(
       <svg>
         <EdgeLine
@@ -52,6 +52,7 @@ describe('EdgeLine', () => {
           relationshipCount={2}
           relationshipTypes={['reads', 'writes']}
           deliveryTypes={['sync', 'async']}
+          conditions={['ready', 'authorised']}
           isBidirectional={false}
         />
       </svg>,
@@ -59,8 +60,13 @@ describe('EdgeLine', () => {
 
     const label = container.querySelector('[data-testid="semantic-edge"] text')
     expect(label?.childNodes[0]?.textContent).toBe('reads, writes')
-    expect(label).toHaveAttribute('aria-label', 'reads, writes · sync/async')
-    expect(label?.querySelector('title')).toHaveTextContent('reads, writes · sync/async')
+    expect(label).toHaveAttribute(
+      'aria-label',
+      'reads, writes · sync/async · when ready/authorised',
+    )
+    expect(label?.querySelector('title')).toHaveTextContent(
+      'reads, writes · sync/async · when ready/authorised',
+    )
   })
 
   it('returns empty group when positions are identical', () => {

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.spec.tsx
@@ -39,8 +39,8 @@ describe('EdgeLine', () => {
     expect(group).toBeInTheDocument()
   })
 
-  it('uses semantic relationship types as the primary label', () => {
-    const { getByText } = render(
+  it('shows only semantic relationships while retaining delivery details on hover', () => {
+    const { container } = render(
       <svg>
         <EdgeLine
           from={from}
@@ -57,7 +57,10 @@ describe('EdgeLine', () => {
       </svg>,
     )
 
-    expect(getByText('reads, writes · sync/async')).toBeInTheDocument()
+    const label = container.querySelector('[data-testid="semantic-edge"] text')
+    expect(label?.childNodes[0]?.textContent).toBe('reads, writes')
+    expect(label).toHaveAttribute('aria-label', 'reads, writes · sync/async')
+    expect(label?.querySelector('title')).toHaveTextContent('reads, writes · sync/async')
   })
 
   it('returns empty group when positions are identical', () => {
@@ -109,7 +112,9 @@ describe('EdgeLine', () => {
   })
 
   it('separates long labels for opposite relationship directions', () => {
-    const { container } = render(
+    const {
+      container, getAllByLabelText,
+    } = render(
       <svg>
         <EdgeLine
           from={from}
@@ -153,8 +158,9 @@ describe('EdgeLine', () => {
       outgoingLabelY - incomingLabelY,
     )
 
-    expect(outgoingLabel).toHaveTextContent('proxies · sync')
-    expect(incomingLabel).toHaveTextContent('proxies · sync')
+    expect(
+      getAllByLabelText('proxies · sync').map((label) => label.childNodes[0]?.textContent),
+    ).toStrictEqual(['proxies', 'proxies'])
     expect(labelSeparation).toBeGreaterThan(24)
   })
 })

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
@@ -10,6 +10,7 @@ interface EdgeLineProps {
   readonly relationshipCount: number
   readonly relationshipTypes?: readonly string[]
   readonly deliveryTypes?: readonly ('sync' | 'async')[]
+  readonly conditions?: readonly string[]
   readonly isBidirectional: boolean
 }
 
@@ -30,9 +31,18 @@ function formatEdgeLabel(
 function formatEdgeDetail(
   edgeLabel: string,
   deliveryTypes: readonly ('sync' | 'async')[] | undefined,
+  conditions: readonly string[] | undefined,
 ): string {
-  if (deliveryTypes === undefined || deliveryTypes.length === 0) return edgeLabel
-  return `${edgeLabel} · ${deliveryTypes.join('/')}`
+  const details = [
+    edgeLabel,
+    deliveryTypes === undefined || deliveryTypes.length === 0
+      ? undefined
+      : deliveryTypes.join('/'),
+    conditions === undefined || conditions.length === 0
+      ? undefined
+      : `when ${conditions.join('/')}`,
+  ]
+  return details.filter((detail) => detail !== undefined).join(' · ')
 }
 
 export function EdgeLine({
@@ -45,6 +55,7 @@ export function EdgeLine({
   relationshipCount,
   relationshipTypes,
   deliveryTypes,
+  conditions,
   isBidirectional,
 }: Readonly<EdgeLineProps>): React.ReactElement {
   const dx = to.x - from.x
@@ -64,7 +75,7 @@ export function EdgeLine({
   const endX = to.x - dx * endOffset + separationX
   const endY = to.y - dy * endOffset + separationY
   const edgeLabel = formatEdgeLabel(relationshipCount, relationshipTypes)
-  const edgeDetail = formatEdgeDetail(edgeLabel, deliveryTypes)
+  const edgeDetail = formatEdgeDetail(edgeLabel, deliveryTypes, conditions)
   const labelPosition = isBidirectional ? BIDIRECTIONAL_LABEL_POSITION_FROM_SOURCE : 0.5
   const labelX = startX + (endX - startX) * labelPosition
   const labelY = startY + (endY - startY) * labelPosition - 6

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
@@ -19,15 +19,20 @@ const BIDIRECTIONAL_LABEL_POSITION_FROM_SOURCE = 0.35
 function formatEdgeLabel(
   relationshipCount: number,
   relationshipTypes: readonly string[] | undefined,
-  deliveryTypes: readonly ('sync' | 'async')[] | undefined,
 ): string {
   if (relationshipTypes === undefined || relationshipTypes.length === 0) {
     const noun = relationshipCount === 1 ? 'relationship' : 'relationships'
     return `${relationshipCount} ${noun}`
   }
-  const semanticLabel = relationshipTypes.join(', ')
-  if (deliveryTypes === undefined || deliveryTypes.length === 0) return semanticLabel
-  return `${semanticLabel} · ${deliveryTypes.join('/')}`
+  return relationshipTypes.join(', ')
+}
+
+function formatEdgeDetail(
+  edgeLabel: string,
+  deliveryTypes: readonly ('sync' | 'async')[] | undefined,
+): string {
+  if (deliveryTypes === undefined || deliveryTypes.length === 0) return edgeLabel
+  return `${edgeLabel} · ${deliveryTypes.join('/')}`
 }
 
 export function EdgeLine({
@@ -58,7 +63,8 @@ export function EdgeLine({
   const startY = from.y + dy * startOffset + separationY
   const endX = to.x - dx * endOffset + separationX
   const endY = to.y - dy * endOffset + separationY
-  const edgeLabel = formatEdgeLabel(relationshipCount, relationshipTypes, deliveryTypes)
+  const edgeLabel = formatEdgeLabel(relationshipCount, relationshipTypes)
+  const edgeDetail = formatEdgeDetail(edgeLabel, deliveryTypes)
   const labelPosition = isBidirectional ? BIDIRECTIONAL_LABEL_POSITION_FROM_SOURCE : 0.5
   const labelX = startX + (endX - startX) * labelPosition
   const labelY = startY + (endY - startY) * labelPosition - 6
@@ -81,8 +87,10 @@ export function EdgeLine({
         y={labelY}
         textAnchor="middle"
         className="fill-[var(--text-secondary)] text-[10px] font-semibold"
+        aria-label={edgeDetail}
       >
         {edgeLabel}
+        <title>{edgeDetail}</title>
       </text>
     </g>
   )

--- a/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
+++ b/apps/eclair/src/features/domains/components/DomainContextGraph/EdgeLine.tsx
@@ -14,6 +14,7 @@ interface EdgeLineProps {
 }
 
 const BIDIRECTIONAL_EDGE_SEPARATION = 8
+const BIDIRECTIONAL_LABEL_POSITION_FROM_SOURCE = 0.35
 
 function formatEdgeLabel(
   relationshipCount: number,
@@ -58,6 +59,9 @@ export function EdgeLine({
   const endX = to.x - dx * endOffset + separationX
   const endY = to.y - dy * endOffset + separationY
   const edgeLabel = formatEdgeLabel(relationshipCount, relationshipTypes, deliveryTypes)
+  const labelPosition = isBidirectional ? BIDIRECTIONAL_LABEL_POSITION_FROM_SOURCE : 0.5
+  const labelX = startX + (endX - startX) * labelPosition
+  const labelY = startY + (endY - startY) * labelPosition - 6
 
   return (
     <g data-testid={testId} data-direction={direction} data-bidirectional={isBidirectional}>
@@ -73,8 +77,8 @@ export function EdgeLine({
         markerEnd="url(#arrow-marker)"
       />
       <text
-        x={(startX + endX) / 2}
-        y={(startY + endY) / 2 - 6}
+        x={labelX}
+        y={labelY}
         textAnchor="middle"
         className="fill-[var(--text-secondary)] text-[10px] font-semibold"
       >

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.relationships.spec.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.relationships.spec.ts
@@ -1,6 +1,4 @@
-import {
-  describe, expect, it 
-} from 'vitest'
+import { describe, expect, it } from 'vitest'
 import type { RiviereGraph } from '@living-architecture/riviere-schema'
 import {
   parseDomainKey,
@@ -97,6 +95,38 @@ describe('extractDomainDetails relationship metadata', () => {
     })
     expect(result?.crossDomainEdges.map((edge) => edge.condition)).toStrictEqual(
       expect.arrayContaining(['status:ready', 'status:blocked']),
+    )
+  })
+
+  it('collects distinct conditions for aggregated domain connections', () => {
+    const graph = createGraph([
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+        relationshipType: 'calls',
+        condition: 'status:ready',
+      }),
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+        relationshipType: 'calls',
+        condition: 'status:blocked',
+      }),
+      parseEdge({
+        source: 'source-api',
+        target: 'target-api',
+        relationshipType: 'calls',
+        condition: 'status:ready',
+      }),
+    ])
+
+    const result = extractDomainDetails(graph, parseDomainKey('source-domain'))
+
+    expect(result?.aggregatedConnections).toContainEqual(
+      expect.objectContaining({
+        targetDomain: 'target-domain',
+        conditions: ['status:ready', 'status:blocked'],
+      }),
     )
   })
 

--- a/apps/eclair/src/features/domains/queries/extract-domain-details.ts
+++ b/apps/eclair/src/features/domains/queries/extract-domain-details.ts
@@ -1,6 +1,4 @@
-import type {
-  RiviereGraph, SystemType, SourceLocation 
-} from '@living-architecture/riviere-schema'
+import type { RiviereGraph, SystemType, SourceLocation } from '@living-architecture/riviere-schema'
 import {
   nodeIdSchema,
   type DomainName,
@@ -8,16 +6,10 @@ import {
   type EntryPoint,
   type NodeId,
 } from '@/platform/domain/eclair-types'
-import {
-  RiviereQuery, type Entity 
-} from '@living-architecture/riviere-query'
+import { RiviereQuery, type Entity } from '@living-architecture/riviere-query'
 import { compareByCodePoint } from '@/platform/domain/compare-by-code-point'
-import type {
-  NodeBreakdown, DomainNode 
-} from './domain-node-breakdown'
-import {
-  countNodesByType, formatDomainNodes, extractEntryPoints 
-} from './domain-node-breakdown'
+import type { NodeBreakdown, DomainNode } from './domain-node-breakdown'
+import { countNodesByType, formatDomainNodes, extractEntryPoints } from './domain-node-breakdown'
 import type { DomainEvent } from '@/platform/domain/domain-event-types'
 
 export interface AggregatedConnection {
@@ -28,6 +20,7 @@ export interface AggregatedConnection {
   relationshipCount: number
   relationshipTypes?: string[]
   deliveryTypes?: EdgeType[]
+  conditions?: string[]
 }
 
 interface KnownSourceEventInfo {
@@ -250,6 +243,8 @@ function updateAggregatedConnection(
   if (relationshipTypes !== undefined) connection.relationshipTypes = relationshipTypes
   const deliveryTypes = appendUnique(connection.deliveryTypes, link.type)
   if (deliveryTypes !== undefined) connection.deliveryTypes = deliveryTypes
+  const conditions = appendUnique(connection.conditions, link.condition)
+  if (conditions !== undefined) connection.conditions = conditions
   if (target.type === 'API') connection.apiCount += 1
   if (target.type === 'EventHandler') connection.eventCount += 1
 }

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.spec.tsx
@@ -21,17 +21,15 @@ const testSourceLocation = {
 }
 
 const {
-  capturedOnNodeHover, capturedOnBackgroundClick, capturedGraph, capturedRelationshipLabelMode,
+  capturedOnNodeHover, capturedOnBackgroundClick, capturedGraph,
 } = vi.hoisted(() => {
   const hoverRef: { current: ((data: TooltipData | null) => void) | undefined } = {current: undefined,}
   const backgroundClickRef: { current: (() => void) | undefined } = { current: undefined }
   const graphRef: { current: RiviereGraph | undefined } = { current: undefined }
-  const relationshipLabelModeRef: { current: 'detailed' | 'semantic-only' | undefined } = { current: undefined }
   return {
     capturedOnNodeHover: hoverRef,
     capturedOnBackgroundClick: backgroundClickRef,
     capturedGraph: graphRef,
-    capturedRelationshipLabelMode: relationshipLabelModeRef,
   }
 })
 
@@ -104,10 +102,8 @@ vi.mock('@/platform/infra/graph/ForceGraph/ForceGraph', () => ({
     onNodeHover?: (data: TooltipData | null) => void
     onBackgroundClick?: () => void
     highlightedNodeId?: string | null
-    relationshipLabelMode?: 'detailed' | 'semantic-only'
   }) => {
     capturedGraph.current = props.graph
-    capturedRelationshipLabelMode.current = props.relationshipLabelMode
     if (props.onNodeHover !== undefined) {
       capturedOnNodeHover.current = props.onNodeHover
     }
@@ -166,12 +162,6 @@ describe('FullGraphPage', () => {
   it('renders ForceGraph component', () => {
     renderWithRouter()
     expect(screen.getByTestId('force-graph-container')).toBeInTheDocument()
-  })
-
-  it('uses semantic-only relationship labels', () => {
-    renderWithRouter()
-
-    expect(capturedRelationshipLabelMode.current).toBe('semantic-only')
   })
 
   it('renders filter toggle button', () => {

--- a/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
+++ b/apps/eclair/src/features/full-graph/entrypoint/FullGraphPage.tsx
@@ -257,7 +257,6 @@ export function FullGraphPage({ graph }: Readonly<FullGraphPageProps>): React.Re
         onNodeClick={handleNodeClick}
         onNodeHover={handleNodeHover}
         onBackgroundClick={handleBackgroundClick}
-        relationshipLabelMode="semantic-only"
       />
 
       <GraphTooltip

--- a/apps/eclair/src/platform/domain/domain-node-types.ts
+++ b/apps/eclair/src/platform/domain/domain-node-types.ts
@@ -8,5 +8,6 @@ export interface DomainNodeData {
   systemType: DomainMapSystemType
   calculatedSize?: number
   dimmed?: boolean
+  focused?: boolean
   isExternal?: boolean
 }

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/ForceGraph.tsx
@@ -51,7 +51,6 @@ interface ForceGraphProps {
   readonly onNodeClick?: (nodeId: string) => void
   readonly onNodeHover?: (data: TooltipData | null) => void
   readonly onBackgroundClick?: () => void
-  readonly relationshipLabelMode?: 'detailed' | 'semantic-only'
 }
 
 interface ApplyDomainFocusParams {
@@ -93,7 +92,6 @@ export function ForceGraph({
   onNodeClick,
   onNodeHover,
   onBackgroundClick,
-  relationshipLabelMode = 'detailed',
 }: Readonly<ForceGraphProps>): React.ReactElement {
   const svgRef = useRef<SVGSVGElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -296,7 +294,7 @@ export function ForceGraph({
       getSemanticEdgeColor,
       isAsyncEdge,
     })
-    const linkLabel = setupLinkLabels(linkGroup, links, relationshipLabelMode)
+    const linkLabel = setupLinkLabels(linkGroup, links)
 
     const node = setupNodes({
       nodeGroup,
@@ -381,7 +379,6 @@ export function ForceGraph({
     applyVisualization,
     setupNodeEvents,
     handleBackgroundClick,
-    relationshipLabelMode,
   ])
 
   useEffect(() => {

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/GraphRenderingSetup.relationshipLabels.spec.ts
@@ -1,13 +1,11 @@
 import * as d3 from 'd3'
-import {
-  describe, expect, it 
-} from 'vitest'
+import { describe, expect, it } from 'vitest'
 import * as GraphRenderingSetup from './GraphRenderingSetup'
 import type * as GraphTypes from '../graph-types'
 import { parseNode } from '@/platform/infra/__fixtures__/riviere-test-fixtures'
 
 describe('relationship labels', () => {
-  it('renders semantic type first with delivery and condition details', () => {
+  it('renders only the semantic type with delivery and condition details on hover', () => {
     const group = d3.select(document.body).append('svg').append('g')
     const links: GraphTypes.SimulationLink[] = [
       {
@@ -26,7 +24,10 @@ describe('relationship labels', () => {
 
     GraphRenderingSetup.setupLinkLabels(group, links)
 
-    expect(group.select('text').text()).toBe('publishes · async · when on success')
+    const label = group.select('text')
+    expect(label.html()).toBe('publishes<title>publishes · async · when on success</title>')
+    expect(label.attr('aria-label')).toBe('publishes · async · when on success')
+    expect(label.select('title').text()).toBe('publishes · async · when on success')
     expect(group.select('text').attr('dy')).toBe('0')
   })
 
@@ -46,7 +47,7 @@ describe('relationship labels', () => {
       }),
     )
 
-    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+    GraphRenderingSetup.setupLinkLabels(group, links)
 
     const labels = group.selectAll<SVGTextElement, GraphTypes.SimulationLink>('text')
     expect(labels.size()).toBe(2)
@@ -87,7 +88,7 @@ describe('relationship labels', () => {
       },
     ]
 
-    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+    GraphRenderingSetup.setupLinkLabels(group, links)
 
     const label = group.select('text')
     expect(group.selectAll('text').size()).toBe(1)
@@ -126,7 +127,7 @@ describe('relationship labels', () => {
       },
     ]
 
-    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+    GraphRenderingSetup.setupLinkLabels(group, links)
 
     const labels = group.selectAll<SVGTextElement, GraphTypes.SimulationLink>('text')
     expect(labels.filter((_link, index) => index === 0).attr('dy')).toBe('-8')
@@ -194,7 +195,7 @@ describe('relationship labels', () => {
       .selectAll<SVGPathElement, GraphTypes.SimulationLink>('path')
       .data(links)
       .join('path')
-    const linkLabel = GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+    const linkLabel = GraphRenderingSetup.setupLinkLabels(group, links)
     const node = group.selectAll<SVGGElement, GraphTypes.SimulationNode>('g')
 
     GraphRenderingSetup.createUpdatePositionsFunction({
@@ -226,7 +227,7 @@ describe('relationship labels', () => {
       },
     ]
 
-    GraphRenderingSetup.setupLinkLabels(group, links, 'semantic-only')
+    GraphRenderingSetup.setupLinkLabels(group, links)
 
     const label = group.select('text')
     expect(label.html()).toBe('publishes<title>publishes · async · when on success</title>')

--- a/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
+++ b/apps/eclair/src/platform/infra/graph/ForceGraph/graph-rendering-setup.ts
@@ -1,13 +1,9 @@
 import * as d3 from 'd3'
-import type {
-  SimulationNode, SimulationLink 
-} from '../graph-types'
+import type { SimulationNode, SimulationLink } from '../graph-types'
 import type { NodeType } from '@/platform/domain/eclair-types'
 import type { Theme } from '@/types/theme'
 import { getLinkNodeId } from './FocusModeStyling'
-import {
-  LayoutError, RenderingError 
-} from '@/platform/infra/errors/errors'
+import { LayoutError, RenderingError } from '@/platform/infra/errors/errors'
 import * as relationshipPresentation from '@/platform/domain/relationship-presentation'
 import * as linkLabelPositioning from './link-label-positioning'
 
@@ -86,12 +82,8 @@ export function setupLinks({
 export function setupLinkLabels(
   linkGroup: d3.Selection<SVGGElement, unknown, d3.BaseType, unknown>,
   links: SimulationLink[],
-  mode: 'detailed' | 'semantic-only' = 'detailed',
 ): d3.Selection<SVGTextElement, SimulationLink, SVGGElement, unknown> {
-  const labelLinks =
-    mode === 'semantic-only'
-      ? linkLabelPositioning.getUniqueRelationshipLabelLinks(links)
-      : links.filter((link) => link.originalEdge.relationshipType !== undefined)
+  const labelLinks = linkLabelPositioning.getUniqueRelationshipLabelLinks(links)
   const labels = linkGroup
     .selectAll<SVGTextElement, SimulationLink>('text')
     .data(labelLinks)
@@ -99,16 +91,12 @@ export function setupLinkLabels(
     .attr('class', 'graph-link-label')
     .attr('text-anchor', 'middle')
     .attr('font-size', '10px')
-    .attr('font-weight', mode === 'semantic-only' ? 500 : 600)
+    .attr('font-weight', 500)
     .attr('fill', 'var(--text-secondary)')
     .attr('stroke', 'var(--surface-primary)')
     .attr('stroke-width', 3)
     .attr('paint-order', 'stroke')
-    .text((link) =>
-      mode === 'semantic-only'
-        ? relationshipPresentation.relationshipLabel(link.originalEdge)
-        : relationshipPresentation.relationshipDetail(link.originalEdge),
-    )
+    .text((link) => relationshipPresentation.relationshipLabel(link.originalEdge))
 
   const verticalOffsets = linkLabelPositioning.getVerticalLabelOffsets(
     labels.data(),
@@ -116,13 +104,11 @@ export function setupLinkLabels(
   )
   labels.attr('dy', (link) => verticalOffsets.get(link) ?? 0)
 
-  if (mode === 'semantic-only') {
-    const getDetails = (link: SimulationLink): string =>
-      linkLabelPositioning.getRelationshipLabelDetails(links, link, (detailLink) =>
-        relationshipPresentation.relationshipDetail(detailLink.originalEdge),
-      )
-    labels.attr('cursor', 'help').attr('aria-label', getDetails).append('title').text(getDetails)
-  }
+  const getDetails = (link: SimulationLink): string =>
+    linkLabelPositioning.getRelationshipLabelDetails(links, link, (detailLink) =>
+      relationshipPresentation.relationshipDetail(detailLink.originalEdge),
+    )
+  labels.attr('cursor', 'help').attr('aria-label', getDetails).append('title').text(getDetails)
 
   return labels
 }

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
@@ -102,6 +102,24 @@ describe('DomainNode', () => {
     expect(nodeDiv).toHaveStyle({ opacity: '0.3' })
   })
 
+  it('renders a visible halo without replacing the domain type border when focused', () => {
+    const { container } = renderWithProvider(
+      <DomainNode
+        data={{
+          label: 'orders',
+          nodeCount: 5,
+          systemType: 'other',
+          focused: true,
+        }}
+      />,
+    )
+
+    const nodeDiv = container.querySelector('div.flex[title]')
+    expect(nodeDiv).toHaveAttribute('data-focused', 'true')
+    expect(nodeDiv).toHaveClass('domain-node-other')
+    expect(nodeDiv).toHaveStyle({ boxShadow: '0 0 0 6px var(--primary), 0 0 24px var(--primary)' })
+  })
+
   describe('consistent sizing', () => {
     it('uses consistent 120px size for all domain nodes', () => {
       const { container } = renderWithProvider(

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
@@ -16,6 +16,7 @@ const DOMAIN_NODE_SIZE = 120
 const EXTERNAL_NODE_SIZE = 100
 const DIMMED_OPACITY = 0.3
 const FULL_OPACITY = 1
+const FOCUSED_HALO = '0 0 0 6px var(--primary), 0 0 24px var(--primary)'
 const DOMAIN_FONT_SIZE = 14
 const EXTERNAL_FONT_SIZE = 12
 
@@ -59,7 +60,9 @@ export function DomainNode(props: DomainNodeProps): React.ReactElement {
           width: size,
           height: size,
           opacity,
+          boxShadow: data.focused === true ? FOCUSED_HALO : undefined,
         }}
+        data-focused={data.focused === true ? 'true' : 'false'}
         title={data.label}
       >
         {isExternal ? (


### PR DESCRIPTION
## Summary

- fit the domain map after route changes so the selected domain remains visible
- preserve domain node types while navigating to a focused domain
- show only semantic relationship names on graph lines
- retain delivery type and conditions in hover and accessibility details
- offset labels on opposing directional edges so relationships remain readable

## Validation

- `pnpm nx test eclair` - 95 test files and 1,204 tests passed
- Eclair production build passed
- repository verification suite passed
