### PR TITLE
fix(eclair): wrap long domain type labels

### DIFF
--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.spec.tsx
@@ -304,4 +304,21 @@ describe('DomainNode', () => {
       expect(container.querySelector('div.flex[title]')).toHaveClass(borderClass)
     },
   )
+
+  it('wraps the complete external-service type inside the domain bubble', () => {
+    renderWithProvider(
+      <DomainNode
+        data={{
+          label: 'alerts',
+          nodeCount: 1,
+          systemType: 'external-service',
+        }}
+      />,
+    )
+
+    const systemType = screen.getByText('external-service')
+    expect(systemType).toHaveTextContent('external-service')
+    expect(systemType).toHaveClass('max-w-full', 'break-words', 'px-2')
+    expect(systemType.parentElement).toHaveClass('w-full')
+  })
 })

--- a/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
+++ b/apps/eclair/src/platform/infra/ui/DomainNode/DomainNode.tsx
@@ -66,7 +66,7 @@ export function DomainNode(props: DomainNodeProps): React.ReactElement {
         title={data.label}
       >
         {isExternal ? (
-          <div className="flex flex-col items-center gap-1">
+          <div className="flex w-full flex-col items-center gap-1">
             <i className="ph ph-arrow-square-out domain-node-external-icon" aria-hidden="true" />
             <span
               className="max-w-full overflow-hidden px-2 font-bold text-[var(--text-primary)] leading-tight"
@@ -77,14 +77,16 @@ export function DomainNode(props: DomainNodeProps): React.ReactElement {
             <span className="domain-node-system-type">External</span>
           </div>
         ) : (
-          <div className="flex flex-col items-center gap-1">
+          <div className="flex w-full flex-col items-center gap-1">
             <span
               className="max-w-full overflow-hidden px-3 font-bold text-[var(--text-primary)] leading-tight"
               style={{ fontSize }}
             >
               {displayLabel}
             </span>
-            <span className="domain-node-system-type">{data.systemType}</span>
+            <span className="domain-node-system-type max-w-full break-words px-2">
+              {data.systemType}
+            </span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- keep long domain-type labels within fixed-size domain nodes by allowing safe wrapping
- preserve the complete system-type value and existing domain styling
- add regression coverage for the `external-service` label

## Validation

- `pnpm nx test eclair` - 95 test files and 1,205 tests passed
- `pnpm nx test:browser eclair` - 285 test files and 3,606 tests passed across Chromium, Firefox and WebKit; 9 skipped
- Eclair production build passed
- repository verification suite passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved domain node layouts so system-type labels use the available width.
  - Long labels, including `external-service`, now wrap correctly instead of overflowing.
  - Added consistent horizontal padding and word breaking for clearer, more readable node content.
  - Updated external and non-external domain nodes for more consistent sizing and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->