### PR TITLE
fix: add repository metadata to use-case packages

### DIFF
--- a/packages/riviere-builder/use-cases/package.json
+++ b/packages/riviere-builder/use-cases/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NTCoding/living-architecture.git",
+    "directory": "packages/riviere-builder/use-cases"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/riviere-extract-ts/use-cases/package.json
+++ b/packages/riviere-extract-ts/use-cases/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NTCoding/living-architecture.git",
+    "directory": "packages/riviere-extract-ts/use-cases"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/riviere-role-enforcement/use-cases/package.json
+++ b/packages/riviere-role-enforcement/use-cases/package.json
@@ -4,6 +4,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NTCoding/living-architecture.git",
+    "directory": "packages/riviere-role-enforcement/use-cases"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Problem

The 2026-08-14 release publish failed with npm E422 because the three use-case package manifests did not include repository metadata. npm trusted-publishing provenance expected the package repository to match `https://github.com/NTCoding/living-architecture`, but the packed manifests had an empty repository URL.

## Change

Add the repository type, URL, and package directory to:

- `packages/riviere-role-enforcement/use-cases/package.json`
- `packages/riviere-extract-ts/use-cases/package.json`
- `packages/riviere-builder/use-cases/package.json`

## Acceptance criteria

- Each package publishes with repository metadata matching the GitHub provenance repository.
- No unrelated package or release configuration changes are included.

## Validation

- `pnpm verify`
- `git diff --check`

The release run partially published packages before failing, so the next release still needs the existing published versions reconciled before retrying.