### PR TITLE
fix(workflow): make Codex runner work from a fresh install

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,7 @@
         "executor": "nx:run-commands",
         "outputs": ["{projectRoot}/test-output/vitest"],
         "options": {
-          "command": "vitest",
+          "command": "vitest run",
           "cwd": "apps/docs"
         }
       },

--- a/nx.json
+++ b/nx.json
@@ -38,7 +38,7 @@
       "options": {
         "testTargetName": "test",
         "ciTargetName": "test-ci",
-        "testMode": "watch"
+        "testMode": "run"
       }
     }
   ],

--- a/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
@@ -18,7 +18,15 @@ const args = operationArgs[0] === sessionId ? operationArgs.slice(1) : operation
 const cliPath = join(dirname(fileURLToPath(import.meta.url)), 'codex-cli.ts')
 const require = createRequire(import.meta.url)
 const tsxCliPath = require.resolve('tsx/cli')
-const result = spawnSync(process.execPath, [tsxCliPath, cliPath, operation, sessionId, ...args], {stdio: 'inherit',})
+const sourceCondition = '--conditions=@living-architecture/source'
+const nodeOptions = [process.env.NODE_OPTIONS, sourceCondition].filter(Boolean).join(' ')
+const result = spawnSync(process.execPath, [tsxCliPath, cliPath, operation, sessionId, ...args], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    NODE_OPTIONS: nodeOptions,
+  },
+})
 
 if (result.error !== undefined) {
   throw result.error


### PR DESCRIPTION
## Problem

The documented Codex workflow command fails after a fresh install because workspace package exports resolve to missing dist files. Repository verification also leaves Vitest targets running in watch mode.

## Fix

- Make the Codex runner propagate the repository source export condition to its child process.
- Configure Nx Vitest targets for run mode.
- Change the docs test target from bare `vitest` to `vitest run`.

## Validation

- Fresh-install smoke test: `pnpm exec tsx tools/dev-workflow-v2/src/shell/codex-workflow-command.ts get-state`
- `pnpm nx run-many -t lint test typecheck --projects=dev-workflow-v2`
- `pnpm nx test docs --outputStyle=stream`
- `pnpm verify`
- Normal pre-commit hook completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development workflow command compatibility by preserving required runtime settings when launching subprocesses.
* **Chores**
  * Updated documentation tests to run once and exit automatically.
  * Updated project test configuration for consistent non-watch execution, improving reliability in automated and local test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->