### PR TITLE
chore(workflow): update Codex adapter to 0.4.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,8 +421,8 @@ importers:
         specifier: 0.4.0
         version: 0.4.0
       '@nt-ai-lab/deterministic-agent-workflow-codex':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.4.1
+        version: 0.4.1
       '@nt-ai-lab/deterministic-agent-workflow-engine':
         specifier: 0.4.0
         version: 0.4.0
@@ -1885,8 +1885,8 @@ packages:
   '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.0':
     resolution: {integrity: sha512-ugYkeZdFH9/JdnUnyoadtsobLGXTW/kdRYviHap1btKFRF0aQesNsK5IrkBn07/dmrg79BP8TI5Q5jsayuLi0g==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.0':
-    resolution: {integrity: sha512-pZfevU3QjO1IgLQq4/AXBcCK2Pg8CByiQI9xAZ36l7ATHh2nN5d2A0WNQWHLExJkUULYvDM90jIivigC2AOC9w==}
+  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.1':
+    resolution: {integrity: sha512-9J38/jx0zKyl4Yq9evGpzmBzOLFfmxi6NTBYq1RcQ9X36lTG+GYMhtkkDYIAwgY21EApB5pcbgbCbe6IZk3wzQ==}
 
   '@nt-ai-lab/deterministic-agent-workflow-dsl@0.3.6':
     resolution: {integrity: sha512-HluSmsDvoIgYIepnNn8GcGMZs65AtJ3ydoZW0b9H4BlU38Qr6BHz08aEj9+OetDcy4pkFqQj4JfAlxaacl+wnQ==}
@@ -8979,7 +8979,7 @@ snapshots:
       '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.0
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.0':
+  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.1':
     dependencies:
       '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.0
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.0

--- a/tools/dev-workflow-v2/package.json
+++ b/tools/dev-workflow-v2/package.json
@@ -11,7 +11,7 @@
     "@living-architecture/dev-workflow-v2-use-cases": "workspace:*",
     "@nt-ai-lab/deterministic-agent-workflow-claude-code": "0.4.0",
     "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.0",
-    "@nt-ai-lab/deterministic-agent-workflow-codex": "0.4.0",
+    "@nt-ai-lab/deterministic-agent-workflow-codex": "0.4.1",
     "@nt-ai-lab/deterministic-agent-workflow-engine": "0.4.0",
     "@nt-ai-lab/deterministic-agent-workflow-event-store": "0.4.0",
     "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.4.0",


### PR DESCRIPTION
## Summary

- Update the dev-workflow-v2 Codex adapter from 0.4.0 to the publicly released 0.4.1.
- Refresh pnpm-lock.yaml with the 0.4.1 package integrity and snapshot entries.

Version 0.4.1 includes the Codex Stop-hook continuation fix from deterministic-agent-workflows PRs #18 and #19.

Published package: https://www.npmjs.com/package/@nt-ai-lab/deterministic-agent-workflow-codex/v/0.4.1
Release workflow: https://github.com/NTCoding/deterministic-agent-workflows/actions/runs/31885180305

## Validation

- pnpm verify
- pnpm nx test dev-workflow-v2 (60 tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deterministic workflow package to version 0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->