### PR TITLE
chore: configure CodeScene quality gates

### DIFF
--- a/.codescene/custom-quality-gates.json
+++ b/.codescene/custom-quality-gates.json
@@ -2,8 +2,8 @@
   "usage": "CodeScene PR quality gates for this repository.",
   "rule_sets": [
     {
-      "quality_gates": "bare_minimum",
-      "quality_gates_doc": "Start with CodeScene's recommended minimum safety net for an existing codebase.",
+      "quality_gates": "clean_code_collective",
+      "quality_gates_doc": "Enforce critical and advisory Code Health rules across the repository.",
       "matching_content_path": "**/*",
       "matching_content_path_doc": "Apply the profile to all repository paths."
     }

--- a/.codescene/custom-quality-gates.json
+++ b/.codescene/custom-quality-gates.json
@@ -1,0 +1,11 @@
+{
+  "usage": "CodeScene PR quality gates for this repository.",
+  "rule_sets": [
+    {
+      "quality_gates": "bare_minimum",
+      "quality_gates_doc": "Start with CodeScene's recommended minimum safety net for an existing codebase.",
+      "matching_content_path": "**/*",
+      "matching_content_path_doc": "Apply the profile to all repository paths."
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

The repository has no checked in CodeScene pull request quality gate configuration.

## Proposed outcome

Add CodeScene configuration as code using the `clean_code_collective` profile. The profile applies to all repository paths and provides critical and advisory Code Health findings for the repository.

The configuration is in `.codescene/custom-quality-gates.json`.

## Acceptance criteria

- CodeScene can use the checked in quality gate configuration for pull request reviews.
- The initial profile applies to the complete repository.
- No secrets, tokens, extra CI jobs, or changes to the existing quality gates are added.

## Setup required after this PR

1. Create or sign in to a CodeScene Cloud account.
2. Select the free plan for this public open source repository.
3. Connect `NTCoding/living-architecture` as a CodeScene project.
4. Install the CodeScene Access GitHub App for the repository, or use GitHub OAuth if an organisation owner cannot install the App.
5. Enable pull request integration for the project and select the checked in configuration as the quality profile.

CodeScene reads the repository and publishes pull request checks or comments. It does not write to source files.

## Configuration options to discuss

- Keep `clean_code_collective` and tune the rollout as the project gets used to CodeScene feedback.
- Move to `pay_down_tech_debt` if the priority changes to technical debt reduction.
- Use `pay_down_tech_debt` when the team wants CodeScene goals to gate pull requests.
- Add path specific rules if different parts of this monorepo need different quality bars.
- Add CodeScene coverage gates later. That would need a coverage upload step, a CodeScene access token, and a decision on thresholds.

## Validation

- `jq empty .codescene/custom-quality-gates.json`
- `git diff --check`
- `pnpm install --frozen-lockfile`
- `NX_PARALLEL=1 pnpm verify`

The full verification passed. Nx reported the existing `riviere-extract-conventions-published-language:typecheck` task as flaky, so the commit hook used `NX_PARALLEL=1` to avoid the parallel task race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-wide code quality checks using a standardized Code Health profile.
  * Configured enforcement for critical and advisory quality rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->