### PR TITLE
fix: publish packages built with TypeScript 7

### DIFF
--- a/apps/cli/src/features/builder/entrypoint/link-http/link-http.spec.ts
+++ b/apps/cli/src/features/builder/entrypoint/link-http/link-http.spec.ts
@@ -15,7 +15,7 @@ interface ApiComponentDef {
 
 describe('riviere builder link-http', () => {
   describe('command registration', () => {
-    it('registers link-http command under builder', () => {
+    it('registers link-http command under builder.', () => {
       const program = createProgram()
       const builderCmd = program.commands.find((cmd) => cmd.name() === 'builder')
       expect(builderCmd?.commands.find((cmd) => cmd.name() === 'link-http')?.name()).toBe(

--- a/packages/riviere-builder/domain-model/src/domain/linking/builder-link-occurrences.spec.ts
+++ b/packages/riviere-builder/domain-model/src/domain/linking/builder-link-occurrences.spec.ts
@@ -38,7 +38,7 @@ function replaceFirstLinkId(graph: ReturnType<RiviereBuilder['build']>, id: stri
 }
 
 describe('RiviereBuilder Link occurrences', () => {
-  it('rejects duplicate Links with the same source, target, and source location', () => {
+  it('rejects duplicate Links with the same source, target, and source location.', () => {
     const builder = createBuilder()
     const source = addSource(builder)
     const input = {

--- a/packages/riviere-builder/use-cases/src/features/builder/commands/error-coverage.spec.ts
+++ b/packages/riviere-builder/use-cases/src/features/builder/commands/error-coverage.spec.ts
@@ -59,7 +59,7 @@ describe('builder command coverage', () => {
     vi.restoreAllMocks()
   })
 
-  it('returns graph corrupted for add-source and check-consistency', async () => {
+  it('returns graph corrupted for add-source and check-consistency.', async () => {
     const graphPath = await createInvalidGraphPath(ctx.testDir)
 
     const repo = new RiviereBuilderRepository()

--- a/packages/riviere-extract-config/published-language/src/published-language/validation-required-fields.spec.ts
+++ b/packages/riviere-extract-config/published-language/src/published-language/validation-required-fields.spec.ts
@@ -1,7 +1,7 @@
 import { validateExtractionConfig, createMutableConfig } from './__fixtures__/validation-fixtures'
 
 describe('required extraction rules validation', () => {
-  it('returns error when api detection defined but apiType extraction missing', () => {
+  it('returns error when api detection defined but apiType extraction missing.', () => {
     const { config, module } = createMutableConfig()
     module.api = {
       find: 'classes',

--- a/packages/riviere-extract-conventions/published-language/src/published-language/eslint-plugin/event-publisher-method-signature.spec.ts
+++ b/packages/riviere-extract-conventions/published-language/src/published-language/eslint-plugin/event-publisher-method-signature.spec.ts
@@ -68,7 +68,7 @@ const nonPublicMethodError = (methodName: string, className: string, accessibili
 })
 
 describe('event-publisher-method-signature', () => {
-  it('is a valid ESLint rule', () => {
+  it('is a valid ESLint rule.', () => {
     expect(rule).toBeDefined()
   })
 

--- a/packages/riviere-extract-ts/domain-model/src/domain/component-extraction/extractor-module-resolution.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/component-extraction/extractor-module-resolution.spec.ts
@@ -53,7 +53,7 @@ function createModuleResolutionConfig(
 }
 
 describe('extractComponents — module resolution', () => {
-  it('resolves module name from file path using {module} placeholder', () => {
+  it('resolves module name from file path using {module} placeholder.', () => {
     const project = createTestProject()
     project.createSourceFile(
       'src/checkout/use-cases/create-order.ts',

--- a/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/extraction-project/extraction-project-repository.spec.ts
+++ b/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/extraction-project/extraction-project-repository.spec.ts
@@ -51,7 +51,7 @@ function writeExtendsConfig(dir: string, extendsRef: string): void {
 }
 
 describe('ExtractionProjectRepository', () => {
-  it('loadFromFullProject returns a project with source files loaded', () => {
+  it('loadFromFullProject returns a project with source files loaded.', () => {
     withWorkspace((dir) => {
       writeFileSync(join(dir, 'component.ts'), 'export class Order {}')
       writeFileSync(join(dir, 'extract.config.yml'), VALID_CONFIG)

--- a/packages/riviere-role-enforcement/domain-model/src/domain/location-configuration.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/location-configuration.spec.ts
@@ -6,7 +6,7 @@ import {
 } from './role-enforcement-builder'
 
 describe('location configuration', () => {
-  it('keeps location import rules and disabled role enforcement', () => {
+  it('keeps location import rules and disabled role enforcement.', () => {
     const result = roleEnforcementConfiguration({
       configurations: {
         'packages/app': {

--- a/packages/riviere-role-enforcement/use-cases/src/features/enforcement/data-access/role-enforcement/role-enforcement-project-repository.spec.ts
+++ b/packages/riviere-role-enforcement/use-cases/src/features/enforcement/data-access/role-enforcement/role-enforcement-project-repository.spec.ts
@@ -44,7 +44,7 @@ function configurationWithPackageAssignments(params: {
 }
 
 describe('RoleEnforcementProjectRepository', () => {
-  it('discovers every package declared by the workspace', () => {
+  it('discovers every package declared by the workspace.', () => {
     const findFilesMatchingPatterns = vi.fn((): string[] => [])
     const repository = new RoleEnforcementProjectRepository({
       findFilesMatchingPatterns,

--- a/packages/riviere-schema/published-language/src/minlength-component-fields.spec.ts
+++ b/packages/riviere-schema/published-language/src/minlength-component-fields.spec.ts
@@ -28,7 +28,7 @@ describe('minLength validation: component fields', () => {
   }
 
   describe('apiRestComponent.path', () => {
-    it('rejects empty path', () => {
+    it('rejects empty path.', () => {
       const input = {
         ...baseGraph,
         components: [


### PR DESCRIPTION
## Summary

Follow up to #454. Publish all packages rebuilt by the TypeScript 7 migration.

The previous TypeScript 7 migration merged with a `chore` commit, so the main release workflow did not create new package versions. This is a `fix` commit touching every publishable package through harmless test description changes. When this PR is merged, the existing `main` workflow will calculate and publish all package versions. This PR does not run or perform a release locally.

## Verification

- No package dependencies or build configuration are changed.
- Package builds and tests are left for the required GitHub checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test descriptions by adding missing terminal punctuation.
  * Improved consistency and readability across command, validation, extraction, enforcement, and schema test suites.
  * No functional behavior or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->