### PR TITLE
feat(factory-optimization): forbid imported function calls

### DIFF
--- a/.riviere/role-definitions/command-input-factory.md
+++ b/.riviere/role-definitions/command-input-factory.md
@@ -7,6 +7,7 @@ A function that translates raw external input (CLI options, HTTP request body) i
 1. Accept raw/untyped external data (CLI options object, parsed request body)
 2. Validate, transform, and assemble into a typed command-use-case-input
 3. Return the typed input — never invoke the command itself
+4. Invoke only private helper functions or dependencies supplied as parameters. Do not directly invoke statically imported functions.
 
 ## Examples
 
@@ -36,6 +37,8 @@ export function createExtractDraftComponentsInput(
 ### Mixed Responsibility Signals
 - If the factory also calls the command use case — that's entrypoint behavior leaking in
 - If the factory does complex domain logic to build the input — some logic may belong in a domain-service
+- If the factory directly invokes an imported function — inject that dependency through a parameter instead
+- If the factory obtains information needed by the operation, such as changed source files, define a domain port in the domain and implement it with an adapter and external client. The domain calls the port as part of the operation.
 
 ## Decision Guidance
 - **vs cli-entrypoint**: Does it register CLI commands or call the use case? → cli-entrypoint. Does it only build the input object? → command-input-factory

--- a/.riviere/roles.ts
+++ b/.riviere/roles.ts
@@ -28,6 +28,7 @@ export const allRoles = [
   role('command-input-factory', {
     targets: ['function'],
     allowedOutputs: ['command-use-case-input'],
+    forbiddenImportedFunctionCalls: true,
   }),
   role('external-client-service', { targets: ['function'] }),
   role('aggregate-repository', {

--- a/packages/riviere-role-enforcement/domain-model/package.json
+++ b/packages/riviere-role-enforcement/domain-model/package.json
@@ -21,12 +21,16 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
-    "./plugin": "./role-enforcement-plugin.mjs"
+    "./plugin": {
+      "types": "./role-enforcement-plugin.d.ts",
+      "default": "./role-enforcement-plugin.mjs"
+    }
   },
   "files": [
     "dist",
     "!dist/**/__fixtures__/**",
     "role-enforcement-plugin.mjs",
+    "role-enforcement-plugin.d.ts",
     "!**/*.tsbuildinfo"
   ],
   "dependencies": {

--- a/packages/riviere-role-enforcement/domain-model/project.json
+++ b/packages/riviere-role-enforcement/domain-model/project.json
@@ -1,6 +1,13 @@
 {
   "name": "riviere-role-enforcement-domain-model",
   "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "vitest run && vitest run --config vitest.plugin.config.mts",
+        "cwd": "{projectRoot}"
+      }
+    },
     "build": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.d.ts
+++ b/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.d.ts
@@ -1,0 +1,10 @@
+import type { Linter } from 'eslint'
+
+declare const plugin: {
+  readonly meta: {
+    readonly name: string
+  }
+  readonly rules: Readonly<Record<string, Parameters<Linter['defineRule']>[1]>>
+}
+
+export default plugin

--- a/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
+++ b/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
@@ -124,6 +124,7 @@ export default {
               return
             }
             validateForbiddenDependencies()
+            validateForbiddenImportedFunctionCalls()
             validateForbiddenMethodCalls()
           },
         }
@@ -541,6 +542,70 @@ export default {
           )
           for (const node of nonImportBody) {
             walkForNonConstructionUsages(node, restrictedBindings, false)
+          }
+        }
+
+        function validateForbiddenImportedFunctionCalls() {
+          if (!fileRoles.some((roleName) => roleMap.get(roleName)?.forbiddenImportedFunctionCalls)) {
+            return
+          }
+
+          const importedFunctionBindings = new Set()
+          for (const statement of sourceCode.ast.body) {
+            if (statement.type !== 'ImportDeclaration' || statement.importKind === 'type') {
+              continue
+            }
+            for (const specifier of statement.specifiers ?? []) {
+              if (
+                specifier.type === 'ImportSpecifier' &&
+                specifier.importKind !== 'type'
+              ) {
+                importedFunctionBindings.add(specifier.local.name)
+              }
+            }
+          }
+
+          if (importedFunctionBindings.size === 0) {
+            return
+          }
+
+          const nonImportBody = sourceCode.ast.body.filter(
+            (node) => node.type !== 'ImportDeclaration',
+          )
+          for (const node of nonImportBody) {
+            walkForImportedFunctionCalls(node, importedFunctionBindings)
+          }
+        }
+
+        function walkForImportedFunctionCalls(node, importedFunctionBindings) {
+          if (node === null || node === undefined || typeof node !== 'object') {
+            return
+          }
+
+          if (
+            node.type === 'CallExpression' &&
+            node.callee.type === 'Identifier' &&
+            importedFunctionBindings.has(node.callee.name)
+          ) {
+            report(
+              node,
+              `Role '${fileRoles.join(', ')}' forbids direct invocation of imported function '${node.callee.name}'. Pass the dependency through a constructor or parameter.`,
+            )
+            return
+          }
+
+          for (const key of Object.keys(node)) {
+            if (key === 'parent') {
+              continue
+            }
+            const child = node[key]
+            if (Array.isArray(child)) {
+              for (const item of child) {
+                walkForImportedFunctionCalls(item, importedFunctionBindings)
+              }
+            } else if (child !== null && typeof child === 'object' && child.type !== undefined) {
+              walkForImportedFunctionCalls(child, importedFunctionBindings)
+            }
           }
         }
 

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.spec.ts
@@ -140,6 +140,19 @@ describe('role', () => {
       forbiddenMethodCalls: ['command-use-case', 'aggregate-repository'],
     })
   })
+
+  it('includes forbiddenImportedFunctionCalls when provided', () => {
+    const result = role('command-input-factory', {
+      targets: ['function'],
+      forbiddenImportedFunctionCalls: true,
+    })
+
+    expectBuiltRole(result, {
+      name: 'command-input-factory',
+      targets: ['function'],
+      forbiddenImportedFunctionCalls: true,
+    })
+  })
 })
 
 describe('roleEnforcementConfiguration', () => {

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.ts
@@ -23,6 +23,7 @@ interface RoleConstraints<R extends string = string> {
   readonly forbiddenCallableDataMembers?: true
   readonly forbiddenSupertypes?: readonly string[]
   readonly forbiddenDependencies?: readonly R[]
+  readonly forbiddenImportedFunctionCalls?: true
   readonly forbiddenMethodCalls?: readonly R[]
   readonly requiredPrivateMembers?: readonly string[]
   readonly requiresPrivateConstructor?: true
@@ -113,6 +114,7 @@ export class BuiltRole<N extends string = string> {
   declare readonly forbiddenCallableDataMembers?: true
   declare readonly forbiddenSupertypes?: readonly string[]
   declare readonly forbiddenDependencies?: readonly string[]
+  declare readonly forbiddenImportedFunctionCalls?: true
   declare readonly forbiddenMethodCalls?: readonly string[]
   declare readonly requiredPrivateMembers?: readonly string[]
   declare readonly requiresPrivateConstructor?: true

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
@@ -1,0 +1,79 @@
+import { Linter } from 'eslint'
+import { expect, it } from 'vitest'
+import plugin from '@living-architecture/riviere-role-enforcement-domain-model/plugin'
+import { location, locationConfiguration, role, roleEnforcementConfiguration } from '../index'
+
+const commandInputFactory = role('command-input-factory', {
+  forbiddenImportedFunctionCalls: true,
+  targets: ['function'],
+})
+
+const config = roleEnforcementConfiguration({
+  configurations: {
+    'packages/example': {
+      locations: locationConfiguration(location('/entrypoint', ['command-input-factory'])),
+    },
+  },
+  ignorePatterns: [],
+  roleDefinitionsDir: '.riviere/role-definitions',
+  roles: [commandInputFactory],
+})
+
+function enforce(source: string) {
+  const linter = new Linter({ configType: 'eslintrc' })
+  const enforceRolesRule = plugin.rules['enforce-roles']
+  if (enforceRolesRule === undefined) {
+    return []
+  }
+  linter.defineRule('enforce-roles', enforceRolesRule)
+
+  return linter.verify(
+    source,
+    {
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      rules: {
+        'enforce-roles': [
+          'error',
+          {
+            configDir: '/workspace',
+            configDisplayPath: '.riviere/roles.ts',
+            locationHierarchy: config.locationHierarchy,
+            roleDefinitionsDir: config.roleDefinitionsDir,
+            roles: config.roles,
+          },
+        ],
+      },
+    },
+    { filename: '/workspace/packages/example/src/entrypoint/input.ts' },
+  )
+}
+
+it('rejects direct invocation of an imported function', () => {
+  const messages = enforce(`import { execute } from 'external-client'
+
+/** @riviere-role command-input-factory */
+export function createInput() {
+  return execute()
+}
+`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]?.message).toContain("forbids direct invocation of imported function 'execute'")
+})
+
+it('allows internal helper functions and dependencies passed as parameters', () => {
+  const messages = enforce(`/** @riviere-role command-input-factory */
+export function createInput(createValue) {
+  return createValue(readDefaultValue())
+}
+
+function readDefaultValue() {
+  return 'input'
+}
+`)
+
+  expect(messages).toStrictEqual([])
+})

--- a/packages/riviere-role-enforcement/domain-model/vitest.plugin.config.mts
+++ b/packages/riviere-role-enforcement/domain-model/vitest.plugin.config.mts
@@ -5,29 +5,22 @@ const repoRoot = path.resolve(__dirname, '../../..')
 
 export default defineConfig(() => ({
   root: __dirname,
-  cacheDir: '../../../node_modules/.vite/packages/riviere-role-enforcement',
+  cacheDir: '../../../node_modules/.vite/packages/riviere-role-enforcement-plugin',
   test: {
-    name: '@living-architecture/riviere-role-enforcement-domain-model',
+    name: '@living-architecture/riviere-role-enforcement-plugin',
     watch: false,
     globals: true,
     environment: 'node',
-    include: ['src/**/*.{test,spec}.{ts,mts}'],
-    reporters: ['default'],
+    include: ['src/domain/role-enforcement-plugin.spec.ts'],
     coverage: {
-      exclude: ['role-enforcement-plugin.mjs'],
       enabled: true,
-      reportsDirectory: './test-output/vitest/coverage',
+      include: ['role-enforcement-plugin.mjs'],
+      reportsDirectory: './test-output/vitest/plugin-coverage',
       provider: 'v8' as const,
       reporter: ['text', ['lcov', { projectRoot: repoRoot }]] as [
         'text',
         ['lcov', { projectRoot: string }],
       ],
-      thresholds: {
-        lines: 100,
-        statements: 100,
-        functions: 100,
-        branches: 100,
-      },
     },
   },
 }))

--- a/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
+++ b/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
@@ -1,0 +1,112 @@
+import { expect, it } from 'vitest'
+import {
+  location,
+  locationConfiguration,
+  role,
+  roleEnforcementConfiguration,
+} from '@living-architecture/riviere-role-enforcement-domain-model'
+import {
+  runTestRoleEnforcement,
+  withWorkspaceFixture,
+  writeFixtureFile,
+} from './__fixtures__/test-fixture-workspace'
+
+const testRoles = [
+  role('command-input-factory', {
+    targets: ['function'],
+    forbiddenImportedFunctionCalls: true,
+  }),
+] as const
+
+type TestRoleName = (typeof testRoles)[number]['name']
+
+const testConfig = roleEnforcementConfiguration({
+  configurations: {
+    'packages/pkg-a': {
+      locations: locationConfiguration(
+        location<TestRoleName>('/entrypoint', ['command-input-factory']),
+      ),
+    },
+  },
+  ignorePatterns: ['**/*.spec.ts'],
+  roleDefinitionsDir: '.riviere/role-definitions',
+  roles: testRoles,
+})
+
+function withFixtureWorkspace(fn: (workspaceDir: string) => void) {
+  withWorkspaceFixture(
+    {
+      prefix: 'forbidden-imported-function-calls-',
+      roles: testRoles,
+      files: {},
+    },
+    fn,
+  )
+}
+
+function writeInputFactory(workspaceDir: string, content: string) {
+  writeFixtureFile(workspaceDir, 'packages/pkg-a/src/entrypoint/input.ts', content)
+}
+
+it('rejects direct invocation of a statically imported function', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `import { execute } from 'external-client'
+
+/** @riviere-role command-input-factory */
+export function createInput(): string {
+  return execute()
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('forbids direct invocation of imported function')
+    expect(result.stdout).toContain('execute')
+  })
+})
+
+it('accepts an internal helper function', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `/** @riviere-role command-input-factory */
+export function createInput(): string {
+  return readDefaultValue()
+}
+
+function readDefaultValue(): string {
+  return 'input'
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe('')
+  })
+})
+
+it('accepts a dependency passed as a parameter', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `type InputCreator = () => string
+
+/** @riviere-role command-input-factory */
+export function createInput(createValue: InputCreator): string {
+  return createValue()
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe('')
+  })
+})

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,9 +7,9 @@ sonar.sources=packages,apps
 sonar.tests=packages,apps
 sonar.test.inclusions=**/*.spec.ts,**/*.test.ts,**/*.spec.tsx,**/*.test.tsx
 sonar.exclusions=**/node_modules/**,**/dist/**,**/test-output/**,apps/docs/scripts/**,packages/*/scripts/**,packages/*/*/scripts/**,**/*-test-fixtures.ts,**/*-fixtures.ts,**/vitest.config.mts,**/vitest.browser.config.mts
-sonar.coverage.exclusions=packages/riviere-extract-config/src/types.ts,packages/riviere-role-enforcement/role-enforcement-plugin.mjs,**/index.ts,**/vitest.config.mts,**/vitest.browser.config.mts,**/test/**,**/esbuild.config.mjs
+sonar.coverage.exclusions=packages/riviere-extract-config/src/types.ts,**/index.ts,**/vitest.config.mts,**/vitest.browser.config.mts,**/test/**,**/esbuild.config.mjs
 sonar.cpd.exclusions=**/vitest.config.mts,**/vitest.browser.config.mts,**/vite.config.ts
 
-sonar.javascript.lcov.reportPaths=packages/*/test-output/vitest/coverage/lcov.info,packages/*/*/test-output/vitest/coverage/lcov.info,apps/*/test-output/vitest/coverage/lcov.info
+sonar.javascript.lcov.reportPaths=packages/*/test-output/vitest/coverage/lcov.info,packages/*/*/test-output/vitest/coverage/lcov.info,packages/riviere-role-enforcement/domain-model/test-output/vitest/plugin-coverage/lcov.info,apps/*/test-output/vitest/coverage/lcov.info
 
 sonar.typescript.tsconfigPaths=tsconfig.base.json

--- a/tools/dev-workflow-v2/docs/factory/factory-map.md
+++ b/tools/dev-workflow-v2/docs/factory/factory-map.md
@@ -212,6 +212,7 @@ Mechanism examples:
 
 - A role can limit which declaration kinds may carry that role.
 - A role can constrain public method count on classes that carry that role.
+- A role can forbid direct invocation of statically imported functions so external dependencies must be supplied through constructors or parameters.
 - A role can require structural markers on a class, such as a private brand field, so anonymous adapter objects cannot masquerade as domain concepts. Configure `requiredPrivateMembers` with bare names; a leading `#` is normalized.
 - A location can limit which roles may appear under a folder pattern.
 - A role dependency rule can reject one role importing or calling another role.


### PR DESCRIPTION
## Problem

Command input factories could invoke statically imported functions directly. That bypasses dependency injection and allows external I/O to enter a factory.

## Outcome

The command-input-factory role now rejects direct calls to statically imported named functions. Factories can still call private helpers and dependencies supplied as parameters.

## Changes

- Add the forbiddenImportedFunctionCalls role constraint and Oxlint enforcement.
- Enable the constraint for command-input-factory.
- Add accepted and rejected role-enforcement fixtures.
- Document the dependency-injection boundary and the port-and-adapter recommendation when an operation needs external information.

## Acceptance criteria

- A command input factory calling a statically imported function fails role enforcement.
- A command input factory calling a private helper passes.
- A command input factory calling an injected dependency passes.
- Current main passes the full verification gate.

## Validation

- pnpm verify
- pnpm nx run @living-architecture/source:role-check