### PR TITLE
feat(role-enforcement): forbid entrypoint dependencies

### DIFF
--- a/.riviere/role-definitions/cli-entrypoint.md
+++ b/.riviere/role-definitions/cli-entrypoint.md
@@ -37,6 +37,7 @@ export function createExtractCommand(): Command {
 ### Mixed Responsibility Signals
 - If the entrypoint constructs complex objects or does validation beyond basic CLI parsing — factory or command logic leaking in
 - If the entrypoint calls multiple command use cases in sequence — composition should be in a single command or separate CLI commands
+- If the entrypoint imports another cli-entrypoint — the imported declaration is a helper, not an entrypoint. Classify it by its responsibility before implementing it.
 - If the entrypoint directly accesses repositories or datastores — command-use-case responsibility leaking in
 
 ## Decision Guidance

--- a/.riviere/roles.ts
+++ b/.riviere/roles.ts
@@ -1,7 +1,10 @@
 import { role } from '@living-architecture/riviere-role-enforcement-domain-model'
 
 export const allRoles = [
-  role('cli-entrypoint', { targets: ['function'] }),
+  role('cli-entrypoint', {
+    targets: ['function'],
+    forbiddenDependencies: ['cli-entrypoint'],
+  }),
   role('command-use-case', {
     targets: ['class', 'function'],
     allowedInputs: ['command-use-case-input'],

--- a/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
+++ b/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
@@ -685,7 +685,7 @@ export default {
               }
               report(
                 statement,
-                `Forbidden dependency: this file (${forbiddenByRoles.join(', ')}) cannot import from a file exporting '${importedRole}'. ${referenceForKnownRole(options, importedRole)}`,
+                `Forbidden dependency: this file (${forbiddenByRoles.join(', ')}) cannot import from a file exporting '${importedRole}'. ${referenceForKnownRole(options, importedRole)} Read '${options.roleDefinitionsDir}/index.md' and the relevant role definitions before changing the code. Classify the responsibility first; do not choose a role only to make a dependency pass.`,
               )
             }
           }

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Linter } from 'eslint'
 import { expect, it } from 'vitest'
 import plugin from '@living-architecture/riviere-role-enforcement-domain-model/plugin'
@@ -8,18 +11,26 @@ const commandInputFactory = role('command-input-factory', {
   targets: ['function'],
 })
 
+const cliEntrypoint = role('cli-entrypoint', {
+  forbiddenDependencies: ['cli-entrypoint'],
+  targets: ['function'],
+})
+
 const config = roleEnforcementConfiguration({
   configurations: {
     'packages/example': {
-      locations: locationConfiguration(location('/entrypoint', ['command-input-factory'])),
+      locations: locationConfiguration(
+        location('/entrypoint', ['command-input-factory', 'cli-entrypoint']),
+      ),
     },
   },
   ignorePatterns: [],
   roleDefinitionsDir: '.riviere/role-definitions',
-  roles: [commandInputFactory],
+  roles: [commandInputFactory, cliEntrypoint],
 })
 
-function enforce(source: string) {
+function enforce(source: string, options: { configDir?: string; filename?: string } = {}) {
+  const configDir = options.configDir ?? '/workspace'
   const linter = new Linter({ configType: 'eslintrc' })
   const enforceRolesRule = plugin.rules['enforce-roles']
   if (enforceRolesRule === undefined) {
@@ -38,7 +49,7 @@ function enforce(source: string) {
         'enforce-roles': [
           'error',
           {
-            configDir: '/workspace',
+            configDir,
             configDisplayPath: '.riviere/roles.ts',
             locationHierarchy: config.locationHierarchy,
             roleDefinitionsDir: config.roleDefinitionsDir,
@@ -47,7 +58,7 @@ function enforce(source: string) {
         ],
       },
     },
-    { filename: '/workspace/packages/example/src/entrypoint/input.ts' },
+    { filename: options.filename ?? '/workspace/packages/example/src/entrypoint/input.ts' },
   )
 }
 
@@ -76,4 +87,41 @@ function readDefaultValue() {
 `)
 
   expect(messages).toStrictEqual([])
+})
+
+it('explains how to correct a forbidden entrypoint dependency', () => {
+  const workspaceDir = mkdtempSync(join(tmpdir(), 'role-enforcement-plugin-'))
+  const entrypointDir = join(workspaceDir, 'packages/example/src/entrypoint')
+  const helperPath = join(entrypointDir, 'helper.ts')
+  const entrypointPath = join(entrypointDir, 'entrypoint.ts')
+
+  try {
+    mkdirSync(entrypointDir, { recursive: true })
+    writeFileSync(
+      helperPath,
+      `/** @riviere-role cli-entrypoint */
+export function createHelper(): string {
+  return 'helper'
+}
+`,
+      { encoding: 'utf8', flag: 'w' },
+    )
+
+    const messages = enforce(
+      `import { createHelper } from './helper'
+
+/** @riviere-role cli-entrypoint */
+export function createCommand() {
+  return createHelper()
+}
+`,
+      { configDir: workspaceDir, filename: entrypointPath },
+    )
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.message).toContain("cannot import from a file exporting 'cli-entrypoint'")
+    expect(messages[0]?.message).toContain('Classify the responsibility first')
+  } finally {
+    rmSync(workspaceDir, { force: true, recursive: true })
+  }
 })

--- a/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-entrypoint-dependencies.spec.ts
+++ b/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-entrypoint-dependencies.spec.ts
@@ -1,0 +1,69 @@
+import { expect, it } from 'vitest'
+import {
+  location,
+  locationConfiguration,
+  role,
+  roleEnforcementConfiguration,
+} from '@living-architecture/riviere-role-enforcement-domain-model'
+import {
+  runTestRoleEnforcement,
+  withWorkspaceFixture,
+  writeFixtureFile,
+} from './__fixtures__/test-fixture-workspace'
+
+const testRoles = [
+  role('cli-entrypoint', {
+    targets: ['function'],
+    forbiddenDependencies: ['cli-entrypoint'],
+  }),
+] as const
+
+type TestRoleName = (typeof testRoles)[number]['name']
+
+const testConfig = roleEnforcementConfiguration({
+  configurations: {
+    'packages/pkg-a': {
+      locations: locationConfiguration(location<TestRoleName>('/entrypoint', ['cli-entrypoint'])),
+    },
+  },
+  ignorePatterns: ['**/*.spec.ts'],
+  roleDefinitionsDir: '.riviere/role-definitions',
+  roles: testRoles,
+})
+
+it('rejects an entrypoint importing another entrypoint', () => {
+  withWorkspaceFixture(
+    {
+      prefix: 'forbidden-entrypoint-dependencies-',
+      roles: testRoles,
+      files: {
+        'packages/pkg-a/src/entrypoint/helper.ts': `/** @riviere-role cli-entrypoint */
+export function createHelper(): string {
+  return 'helper'
+}
+`,
+      },
+    },
+    (workspaceDir) => {
+      writeFixtureFile(
+        workspaceDir,
+        'packages/pkg-a/src/entrypoint/entrypoint.ts',
+        `import { createHelper } from './helper'
+
+/** @riviere-role cli-entrypoint */
+export function createCommand(): string {
+  return createHelper()
+}
+`,
+      )
+
+      const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stdout).toContain(
+        "Forbidden dependency: this file (cli-entrypoint) cannot import from a file exporting 'cli-entrypoint'",
+      )
+      expect(result.stdout).toContain('Classify the responsibility first')
+    },
+  )
+})


### PR DESCRIPTION
## Specification

A declaration with the `cli-entrypoint` role must not import another `cli-entrypoint`. An entrypoint is a composition boundary, not a reusable helper.

Forbidden-dependency diagnostics must direct implementers to read the role definitions and classify responsibility before changing code.

## Validation

- `CI=true pnpm verify`
- Role-enforcement fixture rejects an entrypoint importing another entrypoint.
- Direct plugin test covers the diagnostic path.