### PR TITLE
feat(role-enforcement): constrain CLI input parsers

### DIFF
--- a/.riviere/role-definitions/entrypoint-cli-input-parser.md
+++ b/.riviere/role-definitions/entrypoint-cli-input-parser.md
@@ -10,6 +10,7 @@ Parses or validates raw CLI input using the meaning of a specific entrypoint.
 2. May coordinate multiple CLI options.
 3. May produce entrypoint or application input types.
 4. Does not own reusable domain validation rules.
+5. Invokes only private helper functions or dependencies supplied as parameters. It does not directly invoke statically imported functions.
 
 ## Canonical Example
 
@@ -112,9 +113,11 @@ Do not extract a one-use primitive function merely to make the entrypoint file s
 - Reusable domain validation belongs to the domain that owns the rule.
 - Reuse within one feature changes the `_platform` scope, not the role or location.
 - Similar code in separate features does not by itself justify a shared abstraction. Domain-aware validation belongs in the subdomain use case and domain model.
+- If the parser obtains information that an operation needs, such as the source files to extract, define a domain port in the domain and implement it with an adapter and external client. The domain calls the port as part of the operation.
 
 ## Anti-Patterns
 
 - Placing this role in an infrastructure layer.
 - Duplicating a parser in several entrypoints instead of moving it to their narrowest common entrypoint `_platform`.
 - Moving a parser to infra solely because several entrypoints use it.
+- Calling Git, the filesystem, or another imported service directly from a parser.

--- a/.riviere/roles.ts
+++ b/.riviere/roles.ts
@@ -101,7 +101,10 @@ export const allRoles = [
   }),
   role('external-client-model', { targets: ['interface', 'type-alias', 'class'] }),
   role('external-client-error', { targets: ['class'] }),
-  role('entrypoint-cli-input-parser', { targets: ['function'] }),
+  role('entrypoint-cli-input-parser', {
+    targets: ['function'],
+    forbiddenImportedFunctionCalls: true,
+  }),
   role('cli-error', { targets: ['class'] }),
   role('main', {
     targets: ['function'],

--- a/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
+++ b/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
@@ -589,7 +589,7 @@ export default {
           ) {
             report(
               node,
-              `Role '${fileRoles.join(', ')}' forbids direct invocation of imported function '${node.callee.name}'. Pass the dependency through a constructor or parameter.`,
+              `Role '${fileRoles.join(', ')}' forbids direct invocation of imported function '${node.callee.name}'. Pass the dependency through a constructor or parameter. Read '${options.roleDefinitionsDir}/index.md' and the relevant role definitions before changing the code. Classify the responsibility first; do not choose a role only to make a dependency pass.`,
             )
             return
           }

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
@@ -11,6 +11,11 @@ const commandInputFactory = role('command-input-factory', {
   targets: ['function'],
 })
 
+const cliInputParser = role('entrypoint-cli-input-parser', {
+  forbiddenImportedFunctionCalls: true,
+  targets: ['function'],
+})
+
 const cliEntrypoint = role('cli-entrypoint', {
   forbiddenDependencies: ['cli-entrypoint'],
   targets: ['function'],
@@ -20,13 +25,17 @@ const config = roleEnforcementConfiguration({
   configurations: {
     'packages/example': {
       locations: locationConfiguration(
-        location('/entrypoint', ['command-input-factory', 'cli-entrypoint']),
+        location('/entrypoint', [
+          'command-input-factory',
+          'entrypoint-cli-input-parser',
+          'cli-entrypoint',
+        ]),
       ),
     },
   },
   ignorePatterns: [],
   roleDefinitionsDir: '.riviere/role-definitions',
-  roles: [commandInputFactory, cliEntrypoint],
+  roles: [commandInputFactory, cliInputParser, cliEntrypoint],
 })
 
 function enforce(source: string, options: { configDir?: string; filename?: string } = {}) {
@@ -67,6 +76,20 @@ it('rejects direct invocation of an imported function', () => {
 
 /** @riviere-role command-input-factory */
 export function createInput() {
+  return execute()
+}
+`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]?.message).toContain("forbids direct invocation of imported function 'execute'")
+  expect(messages[0]?.message).toContain('Classify the responsibility first')
+})
+
+it('rejects direct invocation of an imported function from a CLI input parser', () => {
+  const messages = enforce(`import { execute } from 'external-client'
+
+/** @riviere-role entrypoint-cli-input-parser */
+export function parseInput() {
   return execute()
 }
 `)

--- a/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
+++ b/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
@@ -16,6 +16,10 @@ const testRoles = [
     targets: ['function'],
     forbiddenImportedFunctionCalls: true,
   }),
+  role('entrypoint-cli-input-parser', {
+    targets: ['function'],
+    forbiddenImportedFunctionCalls: true,
+  }),
 ] as const
 
 type TestRoleName = (typeof testRoles)[number]['name']
@@ -24,7 +28,10 @@ const testConfig = roleEnforcementConfiguration({
   configurations: {
     'packages/pkg-a': {
       locations: locationConfiguration(
-        location<TestRoleName>('/entrypoint', ['command-input-factory']),
+        location<TestRoleName>('/entrypoint', [
+          'command-input-factory',
+          'entrypoint-cli-input-parser',
+        ]),
       ),
     },
   },
@@ -66,6 +73,28 @@ export function createInput(): string {
     expect(result.exitCode).toBe(1)
     expect(result.stdout).toContain('forbids direct invocation of imported function')
     expect(result.stdout).toContain('execute')
+    expect(result.stdout).toContain('Classify the responsibility first')
+  })
+})
+
+it('rejects direct invocation of a statically imported function from a CLI input parser', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `import { execute } from 'external-client'
+
+/** @riviere-role entrypoint-cli-input-parser */
+export function parseInput(): string {
+  return execute()
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('forbids direct invocation of imported function')
+    expect(result.stdout).toContain('entrypoint-cli-input-parser')
   })
 })
 


### PR DESCRIPTION
## Problem

A function annotated as entrypoint-cli-input-parser could directly invoke imported functions. That left an escape route after command input factories and CLI entrypoints were constrained: Git and filesystem work could be moved into a parser and relabelled.

## Outcome

CLI input parsers now reject direct invocation of statically imported functions. Dependencies must be passed through a parameter, while private helper functions remain allowed. This preserves dependency inversion and stops parsers being used to host Git or filesystem work.

The diagnostic now tells the implementer to read the role definitions and classify the responsibility before changing annotations.

## Changes

- Enable forbiddenImportedFunctionCalls for entrypoint-cli-input-parser.
- Document that a parser translates CLI input and must not call Git, the filesystem, or imported services.
- Add direct plugin coverage for parser rejection and diagnostic guidance.
- Add Oxlint integration coverage for parser rejection.

## Acceptance criteria

- A CLI input parser cannot directly invoke a statically imported function.
- A parser can invoke a private helper or a dependency passed as a parameter.
- Violations instruct implementers to classify the responsibility before changing roles.

## Validation

- CI=true pnpm nx test riviere-role-enforcement-domain-model
- CI=true pnpm nx test riviere-role-enforcement-use-cases
- CI=true pnpm nx run @living-architecture/source:role-check
- CI=true pnpm verify