### PR TITLE
feat: enforce named CLI input parser collaborators

### DIFF
--- a/.riviere/configurations/app.ts
+++ b/.riviere/configurations/app.ts
@@ -14,6 +14,7 @@ const entrypointRoles: RoleName[] = [
 ]
 const entrypointPlatformCliRoles: RoleName[] = [
   'entrypoint-cli-input-parser',
+  'entrypoint-cli-input-parser-dependencies',
   'cli-output-formatter',
 ]
 const cliPresentationRoles: RoleName[] = [

--- a/.riviere/configurations/app.ts
+++ b/.riviere/configurations/app.ts
@@ -10,6 +10,7 @@ const entrypointRoles: RoleName[] = [
   'cli-output-formatter',
   'command-input-factory',
   'entrypoint-cli-input-parser',
+  'entrypoint-cli-input-parser-dependencies',
 ]
 const entrypointPlatformCliRoles: RoleName[] = [
   'entrypoint-cli-input-parser',

--- a/.riviere/role-definitions/entrypoint-cli-input-parser-dependencies.md
+++ b/.riviere/role-definitions/entrypoint-cli-input-parser-dependencies.md
@@ -1,0 +1,36 @@
+# entrypoint-cli-input-parser-dependencies
+
+## Purpose
+
+Defines the named collaborators supplied to a CLI input parser.
+
+## Behavioural Contract
+
+1. Belongs beside the CLI input parser that receives it.
+2. Is an interface whose members reference real collaborators.
+3. Does not declare inline function types. Reference a real function with `typeof` or a real class with its named type.
+
+## Canonical Example
+
+```typescript
+/** @riviere-role external-client-service */
+export function readWorkspaceFile(filePath: string): string {
+  // implementation
+}
+
+/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExtractCliInputParserDependencies {
+  readonly readWorkspaceFile: typeof readWorkspaceFile
+}
+```
+
+## Anti-Patterns
+
+```typescript
+/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExtractCliInputParserDependencies {
+  readonly readWorkspaceFile: (filePath: string) => string
+}
+```
+
+The inline type hides the collaborator's role and location. Define the collaborator first, give it its actual role, then reference it from this interface.

--- a/.riviere/role-definitions/entrypoint-cli-input-parser-dependencies.md
+++ b/.riviere/role-definitions/entrypoint-cli-input-parser-dependencies.md
@@ -24,6 +24,12 @@ export interface ExtractCliInputParserDependencies {
 }
 ```
 
+## Common Misclassifications
+
+A dependency interface is not CLI input data. Its members name the collaborators that a parser receives.
+
+Do not recreate a collaborator API in a local type alias or interface. Define the collaborator in its own location with its actual role, then reference that named function or class here.
+
 ## Anti-Patterns
 
 ```typescript

--- a/.riviere/roles.ts
+++ b/.riviere/roles.ts
@@ -111,6 +111,11 @@ export const allRoles = [
     targets: ['function'],
     forbiddenImportedFunctionCalls: true,
   }),
+  role('entrypoint-cli-input-parser-dependencies', {
+    forbiddenInlineCallableMembers: true,
+    targets: ['interface'],
+    nameMatches: '.*CliInputParserDependencies$',
+  }),
   role('cli-error', { targets: ['class'] }),
   role('main', {
     targets: ['function'],

--- a/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
+++ b/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
@@ -946,14 +946,17 @@ export default {
         }
 
         function validateInterfaceContract(node, role, name) {
-          if (role.mustBeDataStructure !== true) {
-            return
-          }
-          const hasCallableMember = hasCallableTypeMembers(node.body.body)
-          if (hasCallableMember) {
+          if (role.mustBeDataStructure === true && hasCallableTypeMembers(node.body.body)) {
             report(
               node,
               `Role '${role.name}' does not allow methods on '${name}'. ${referenceForKnownRole(options, role.name)}`,
+            )
+          }
+
+          if (role.forbiddenInlineCallableMembers === true && hasInlineCallableMembers(node.body.body)) {
+            report(
+              node,
+              `Role '${role.name}' forbids inline callable members on '${name}'. Define the collaborator with its actual role, then reference it by name. ${referenceForKnownRole(options, role.name)}`,
             )
           }
         }
@@ -1029,6 +1032,19 @@ export default {
               member.type === 'TSPropertySignature' &&
               isCallableTypeAnnotation(member.typeAnnotation)
             )
+          })
+        }
+
+        function hasInlineCallableMembers(members) {
+          return members.some((member) => {
+            if (
+              member.type === 'TSMethodSignature' ||
+              member.type === 'TSCallSignatureDeclaration' ||
+              member.type === 'TSConstructSignatureDeclaration'
+            ) {
+              return true
+            }
+            return member.type === 'TSPropertySignature' && isCallableTypeAnnotation(member.typeAnnotation)
           })
         }
 

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.ts
@@ -21,6 +21,7 @@ interface RoleConstraints<R extends string = string> {
   readonly allowedOutputs?: readonly R[]
   readonly approvedInstances?: readonly ApprovedInstance[]
   readonly forbiddenCallableDataMembers?: true
+  readonly forbiddenInlineCallableMembers?: true
   readonly forbiddenSupertypes?: readonly string[]
   readonly forbiddenDependencies?: readonly R[]
   readonly forbiddenImportedFunctionCalls?: true
@@ -112,6 +113,7 @@ export class BuiltRole<N extends string = string> {
   declare readonly allowedOutputs?: readonly string[]
   declare readonly approvedInstances?: readonly ApprovedInstance[]
   declare readonly forbiddenCallableDataMembers?: true
+  declare readonly forbiddenInlineCallableMembers?: true
   declare readonly forbiddenSupertypes?: readonly string[]
   declare readonly forbiddenDependencies?: readonly string[]
   declare readonly forbiddenImportedFunctionCalls?: true

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Linter } from 'eslint'
+import { parser } from 'typescript-eslint'
 import { expect, it } from 'vitest'
 import plugin from '@living-architecture/riviere-role-enforcement-domain-model/plugin'
 import { location, locationConfiguration, role, roleEnforcementConfiguration } from '../index'
@@ -14,6 +15,12 @@ const commandInputFactory = role('command-input-factory', {
 const cliInputParser = role('entrypoint-cli-input-parser', {
   forbiddenImportedFunctionCalls: true,
   targets: ['function'],
+})
+
+const cliInputParserDependencies = role('entrypoint-cli-input-parser-dependencies', {
+  forbiddenInlineCallableMembers: true,
+  nameMatches: '.*CliInputParserDependencies$',
+  targets: ['interface'],
 })
 
 const cliEntrypoint = role('cli-entrypoint', {
@@ -29,6 +36,7 @@ const config = roleEnforcementConfiguration({
         location('/entrypoint', [
           'command-input-factory',
           'entrypoint-cli-input-parser',
+          'entrypoint-cli-input-parser-dependencies',
           'cli-entrypoint',
         ]),
       ),
@@ -36,7 +44,7 @@ const config = roleEnforcementConfiguration({
   },
   ignorePatterns: [],
   roleDefinitionsDir: '.riviere/role-definitions',
-  roles: [commandInputFactory, cliInputParser, cliEntrypoint],
+  roles: [commandInputFactory, cliInputParser, cliInputParserDependencies, cliEntrypoint],
 })
 
 function enforce(source: string, options: { configDir?: string; filename?: string } = {}) {
@@ -47,10 +55,12 @@ function enforce(source: string, options: { configDir?: string; filename?: strin
     return []
   }
   linter.defineRule('enforce-roles', enforceRolesRule)
+  linter.defineParser('typescript', parser)
 
   return linter.verify(
     source,
     {
+      parser: 'typescript',
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: 'module',
@@ -97,6 +107,70 @@ export function parseInput() {
 
   expect(messages).toHaveLength(1)
   expect(messages[0]?.message).toContain("forbids direct invocation of imported function 'execute'")
+})
+
+it('rejects an inline callable property in CLI input parser dependencies', () => {
+  const messages = enforce(`/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  readonly readFile: (filePath: string) => string
+}
+`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]?.message).toContain(
+    "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+  )
+})
+
+it('rejects an inline callable method in CLI input parser dependencies', () => {
+  const messages = enforce(`/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  readFile(filePath: string): string
+}
+`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]?.message).toContain(
+    "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+  )
+})
+
+it('rejects an inline callable signature in CLI input parser dependencies', () => {
+  const messages = enforce(`/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  (filePath: string): string
+}
+`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]?.message).toContain(
+    "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+  )
+})
+
+it('rejects an inline construct signature in CLI input parser dependencies', () => {
+  const messages = enforce(`/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  new (filePath: string): object
+}
+`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]?.message).toContain(
+    "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+  )
+})
+
+it('allows CLI input parser dependencies to reference a named collaborator', () => {
+  const messages = enforce(`import { readFile } from 'external-client'
+
+/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  readonly readFile: typeof readFile
+}
+`)
+
+  expect(messages).toStrictEqual([])
 })
 
 it('rejects direct invocation of an imported function from a CLI entrypoint', () => {

--- a/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
+++ b/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
@@ -62,7 +62,19 @@ function withFixtureWorkspace(fn: (workspaceDir: string) => void) {
     {
       prefix: 'forbidden-imported-function-calls-',
       roles: testRoles,
-      files: {},
+      files: {
+        'node_modules/external-client/package.json': `{
+  "name": "external-client",
+  "exports": {
+    ".": { "@living-architecture/source": "./src/index.ts" }
+  }
+}
+`,
+        'node_modules/external-client/src/index.ts': `export function readFile(filePath: string): string {
+  return filePath
+}
+`,
+      },
     },
     fn,
   )
@@ -142,6 +154,46 @@ it('rejects inline method members in CLI input parser dependencies', () => {
       `/** @riviere-role entrypoint-cli-input-parser-dependencies */
 export interface ExampleCliInputParserDependencies {
   readFile(filePath: string): string
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain(
+      "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+    )
+  })
+})
+
+it('rejects inline call signatures in CLI input parser dependencies', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  (filePath: string): string
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain(
+      "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+    )
+  })
+})
+
+it('rejects inline construct signatures in CLI input parser dependencies', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  new (filePath: string): object
 }
 `,
     )

--- a/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
+++ b/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
@@ -20,6 +20,11 @@ const testRoles = [
     targets: ['function'],
     forbiddenImportedFunctionCalls: true,
   }),
+  role('entrypoint-cli-input-parser-dependencies', {
+    forbiddenInlineCallableMembers: true,
+    nameMatches: '.*CliInputParserDependencies$',
+    targets: ['interface'],
+  }),
   role('cli-entrypoint', {
     targets: ['function'],
     allowedInputs: ['cli-entrypoint-dependencies'],
@@ -40,6 +45,7 @@ const testConfig = roleEnforcementConfiguration({
         location<TestRoleName>('/entrypoint', [
           'command-input-factory',
           'entrypoint-cli-input-parser',
+          'entrypoint-cli-input-parser-dependencies',
           'cli-entrypoint',
           'cli-entrypoint-dependencies',
         ]),
@@ -106,6 +112,66 @@ export function parseInput(): string {
     expect(result.exitCode).toBe(1)
     expect(result.stdout).toContain('forbids direct invocation of imported function')
     expect(result.stdout).toContain('entrypoint-cli-input-parser')
+  })
+})
+
+it('rejects inline callable members in CLI input parser dependencies', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  readonly readFile: (filePath: string) => string
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain(
+      "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+    )
+  })
+})
+
+it('rejects inline method members in CLI input parser dependencies', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  readFile(filePath: string): string
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain(
+      "forbids inline callable members on 'ExampleCliInputParserDependencies'",
+    )
+  })
+})
+
+it('allows a CLI input parser dependency to reference a named collaborator', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `import { readFile } from 'external-client'
+
+/** @riviere-role entrypoint-cli-input-parser-dependencies */
+export interface ExampleCliInputParserDependencies {
+  readonly readFile: typeof readFile
+}
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe('')
   })
 })
 


### PR DESCRIPTION
## Problem

CLI input parsers can bypass the imported function call rule by declaring inline callable members in a dependency interface. That hides the collaborator role and location.

## Change

- Adds the entrypoint-cli-input-parser-dependencies role.
- Adds forbiddenInlineCallableMembers for role annotated interfaces.
- Rejects callable property, method, call signature, and constructor signature members.
- Allows named collaborators referenced with typeof.
- Documents the required pattern beside the role definition.

## Verification

- Focused role enforcement tests passed with 100 percent coverage.
- Repository role check passed.
- Markdown lint passed.
- Commit hook full verify gate passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for CLI input parser dependency interfaces.
  * Supports named collaborators referenced through `typeof`.
* **Bug Fixes**
  * Detects inline function properties, methods, call signatures, and constructor signatures in restricted dependency interfaces.
* **Documentation**
  * Added guidance describing the dependency interface contract, supported collaborator references, and discouraged patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->