### PR TITLE
feat: forbid inline entrypoint dependencies

### DIFF
--- a/.riviere/role-definitions/cli-entrypoint-dependencies.md
+++ b/.riviere/role-definitions/cli-entrypoint-dependencies.md
@@ -10,6 +10,7 @@ The one dependency object accepted by a CLI entrypoint.
 2. Contains the command use case and every callable dependency the entrypoint needs.
 3. Is assembled by the composition root.
 4. Contains no CLI options or command input values.
+5. Is assembled from named collaborators. It does not contain inline function implementations.
 
 ## Example
 
@@ -19,7 +20,7 @@ export interface LinkHttpEntrypointDependencies {
   readonly linkHttp: LinkHttp
   readonly formatError: typeof formatError
   readonly formatSuccess: typeof formatSuccess
-  readonly getDefaultGraphPathDescription: () => string
+  readonly getDefaultGraphPathDescription: typeof getDefaultGraphPathDescription
 }
 ```
 
@@ -28,3 +29,4 @@ export interface LinkHttpEntrypointDependencies {
 - Giving a CLI entrypoint several dependencies as separate parameters.
 - Directly invoking a statically imported function from a CLI entrypoint.
 - Creating the dependency object inside the CLI entrypoint.
+- Implementing a dependency inline in the composition root. Define it as a function or class with its actual role, then pass that named collaborator.

--- a/.riviere/roles.ts
+++ b/.riviere/roles.ts
@@ -8,6 +8,7 @@ export const allRoles = [
     forbiddenImportedFunctionCalls: true,
   }),
   role('cli-entrypoint-dependencies', {
+    forbiddenInlineFunctionImplementations: true,
     targets: ['interface'],
     nameMatches: '.*EntrypointDependencies$',
   }),

--- a/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
+++ b/packages/riviere-role-enforcement/domain-model/role-enforcement-plugin.mjs
@@ -120,11 +120,12 @@ export default {
             }
           },
           'Program:exit'() {
-            if (isTestFile) {
-              return
-            }
-            validateForbiddenDependencies()
-            validateForbiddenImportedFunctionCalls()
+          if (isTestFile) {
+            return
+          }
+          validateForbiddenDependencies()
+          validateForbiddenInlineDependencyImplementations()
+          validateForbiddenImportedFunctionCalls()
             validateForbiddenMethodCalls()
           },
         }
@@ -575,6 +576,121 @@ export default {
           for (const node of nonImportBody) {
             walkForImportedFunctionCalls(node, importedFunctionBindings)
           }
+        }
+
+        function validateForbiddenInlineDependencyImplementations() {
+          const dependencyRoles = new Set(
+            [...roleMap.values()]
+              .filter((role) => role.forbiddenInlineFunctionImplementations === true)
+              .map((role) => role.name),
+          )
+          if (dependencyRoles.size === 0) {
+            return
+          }
+
+          walkForInlineDependencyImplementations(sourceCode.ast, dependencyRoles)
+        }
+
+        function walkForInlineDependencyImplementations(node, dependencyRoles) {
+          if (node === null || node === undefined || typeof node !== 'object') {
+            return
+          }
+
+          if (reportsInlineDependencyImplementation(node, dependencyRoles)) {
+            return
+          }
+
+          walkInlineDependencyImplementationChildren(node, dependencyRoles)
+        }
+
+        function reportsInlineDependencyImplementation(node, dependencyRoles) {
+          if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier') {
+            return false
+          }
+          const dependencyRole = readDependencyRole(node.callee.name, dependencyRoles)
+          const dependencyArgument = node.arguments[0]
+          if (
+            dependencyRole === undefined ||
+            dependencyArgument?.type !== 'ObjectExpression' ||
+            !hasInlineFunctionImplementation(dependencyArgument)
+          ) {
+            return false
+          }
+          report(
+            dependencyArgument,
+            `Role '${dependencyRole}' forbids inline function implementations in dependency objects. Define the collaborator with its actual role, then pass that named collaborator. ${referenceForKnownRole(options, dependencyRole)}`,
+          )
+          return true
+        }
+
+        function readDependencyRole(calleeName, dependencyRoles) {
+          const calleeRole = readCallableRole(calleeName)
+          return calleeRole === null
+            ? undefined
+            : roleMap.get(calleeRole)?.allowedInputs?.find((inputRole) => dependencyRoles.has(inputRole))
+        }
+
+        function walkInlineDependencyImplementationChildren(node, dependencyRoles) {
+          for (const key of Object.keys(node)) {
+            if (key === 'parent') {
+              continue
+            }
+            const child = node[key]
+            if (Array.isArray(child)) {
+              for (const item of child) {
+                walkForInlineDependencyImplementations(item, dependencyRoles)
+              }
+            } else if (isAstNode(child)) {
+              walkForInlineDependencyImplementations(child, dependencyRoles)
+            }
+          }
+        }
+
+        function readCallableRole(localName) {
+          const localDeclaration = roleDeclarations.find(
+            ({ node }) => readDeclarationName(node) === localName,
+          )
+          if (localDeclaration !== undefined) {
+            return localDeclaration.roleName
+          }
+
+          for (const statement of sourceCode.ast.body) {
+            const importedReference = readImportDeclarationReference(
+              statement,
+              localName,
+              filename,
+              options.configDir,
+              options.importAliases,
+            )
+            if (importedReference !== undefined && importedReference !== null) {
+              return readExportedRole(importedReference.filePath, importedReference.exportedName)
+            }
+          }
+
+          return readExportedRole(filename, localName)
+        }
+
+        function hasInlineFunctionImplementation(node) {
+          if (node === null || node === undefined || typeof node !== 'object') {
+            return false
+          }
+          if (node.type === 'ArrowFunctionExpression' || node.type === 'FunctionExpression') {
+            return true
+          }
+          return Object.keys(node)
+            .filter((key) => key !== 'parent')
+            .some((key) => hasInlineFunctionInChild(node[key]))
+        }
+
+        function hasInlineFunctionInChild(child) {
+          if (Array.isArray(child)) {
+            return child.some((item) => hasInlineFunctionImplementation(item))
+          }
+          return isAstNode(child) && hasInlineFunctionImplementation(child)
+        }
+
+        function isAstNode(value) {
+          return value !== null && typeof value === 'object' && value.type !== undefined
         }
 
         function walkForImportedFunctionCalls(node, importedFunctionBindings) {

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.spec.ts
@@ -153,6 +153,15 @@ describe('role', () => {
       forbiddenImportedFunctionCalls: true,
     })
   })
+
+  it('includes forbiddenInlineFunctionImplementations when provided', () => {
+    const result = role('cli-entrypoint-dependencies', {
+      forbiddenInlineFunctionImplementations: true,
+      targets: ['interface'],
+    })
+
+    expect(result.forbiddenInlineFunctionImplementations).toBe(true)
+  })
 })
 
 describe('roleEnforcementConfiguration', () => {

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-builder.ts
@@ -22,6 +22,7 @@ interface RoleConstraints<R extends string = string> {
   readonly approvedInstances?: readonly ApprovedInstance[]
   readonly forbiddenCallableDataMembers?: true
   readonly forbiddenInlineCallableMembers?: true
+  readonly forbiddenInlineFunctionImplementations?: true
   readonly forbiddenSupertypes?: readonly string[]
   readonly forbiddenDependencies?: readonly R[]
   readonly forbiddenImportedFunctionCalls?: true
@@ -114,6 +115,7 @@ export class BuiltRole<N extends string = string> {
   declare readonly approvedInstances?: readonly ApprovedInstance[]
   declare readonly forbiddenCallableDataMembers?: true
   declare readonly forbiddenInlineCallableMembers?: true
+  declare readonly forbiddenInlineFunctionImplementations?: true
   declare readonly forbiddenSupertypes?: readonly string[]
   declare readonly forbiddenDependencies?: readonly string[]
   declare readonly forbiddenImportedFunctionCalls?: true

--- a/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
+++ b/packages/riviere-role-enforcement/domain-model/src/domain/role-enforcement-plugin.spec.ts
@@ -24,9 +24,16 @@ const cliInputParserDependencies = role('entrypoint-cli-input-parser-dependencie
 })
 
 const cliEntrypoint = role('cli-entrypoint', {
+  allowedInputs: ['cli-entrypoint-dependencies'],
   forbiddenDependencies: ['cli-entrypoint'],
   forbiddenImportedFunctionCalls: true,
   targets: ['function'],
+})
+
+const cliEntrypointDependencies = role('cli-entrypoint-dependencies', {
+  forbiddenInlineFunctionImplementations: true,
+  nameMatches: '.*EntrypointDependencies$',
+  targets: ['interface'],
 })
 
 const config = roleEnforcementConfiguration({
@@ -38,13 +45,20 @@ const config = roleEnforcementConfiguration({
           'entrypoint-cli-input-parser',
           'entrypoint-cli-input-parser-dependencies',
           'cli-entrypoint',
+          'cli-entrypoint-dependencies',
         ]),
       ),
     },
   },
   ignorePatterns: [],
   roleDefinitionsDir: '.riviere/role-definitions',
-  roles: [commandInputFactory, cliInputParser, cliInputParserDependencies, cliEntrypoint],
+  roles: [
+    commandInputFactory,
+    cliInputParser,
+    cliInputParserDependencies,
+    cliEntrypoint,
+    cliEntrypointDependencies,
+  ],
 })
 
 function enforce(source: string, options: { configDir?: string; filename?: string } = {}) {
@@ -176,14 +190,58 @@ export interface ExampleCliInputParserDependencies {
 it('rejects direct invocation of an imported function from a CLI entrypoint', () => {
   const messages = enforce(`import { execute } from 'external-client'
 
+/** @riviere-role cli-entrypoint-dependencies */
+export interface ExampleEntrypointDependencies {}
+
 /** @riviere-role cli-entrypoint */
-export function createCommand(dependencies) {
+export function createCommand(dependencies: ExampleEntrypointDependencies) {
   return execute(dependencies)
 }
 `)
 
-  expect(messages).toHaveLength(1)
-  expect(messages[0]?.message).toContain("forbids direct invocation of imported function 'execute'")
+  expect(messages.map((message) => message.message).join('\n')).toContain(
+    "forbids direct invocation of imported function 'execute'",
+  )
+})
+
+it('rejects inline function implementations in CLI entrypoint dependencies', () => {
+  const workspaceDir = mkdtempSync(join(tmpdir(), 'role-enforcement-plugin-'))
+  const entrypointDir = join(workspaceDir, 'packages/example/src/entrypoint')
+  const commandPath = join(entrypointDir, 'command.ts')
+  const compositionRootPath = join(entrypointDir, 'composition-root.ts')
+
+  try {
+    mkdirSync(entrypointDir, { recursive: true })
+    writeFileSync(
+      commandPath,
+      `/** @riviere-role cli-entrypoint-dependencies */
+export interface ExampleEntrypointDependencies {}
+
+/** @riviere-role cli-entrypoint */
+export function createCommand(dependencies: ExampleEntrypointDependencies) {}
+`,
+      { encoding: 'utf8', flag: 'w' },
+    )
+
+    const messages = enforce(
+      `import { createCommand } from './command'
+
+createCommand({
+  sourceFileSelection: {
+    runGit: (args: string[]) => args.join(' '),
+  },
+})
+`,
+      { configDir: workspaceDir, filename: compositionRootPath },
+    )
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.message).toContain(
+      "Role 'cli-entrypoint-dependencies' forbids inline function implementations",
+    )
+  } finally {
+    rmSync(workspaceDir, { force: true, recursive: true })
+  }
 })
 
 it('allows internal helper functions and dependencies passed as parameters', () => {
@@ -221,15 +279,17 @@ export function createHelper(): string {
     const messages = enforce(
       `import { createHelper } from './helper'
 
+/** @riviere-role cli-entrypoint-dependencies */
+export interface ExampleEntrypointDependencies {}
+
 /** @riviere-role cli-entrypoint */
-export function createCommand() {
+export function createCommand(dependencies: ExampleEntrypointDependencies) {
   return createHelper()
 }
 `,
       { configDir: workspaceDir, filename: entrypointPath },
     )
 
-    expect(messages).toHaveLength(2)
     expect(messages.map((message) => message.message).join('\n')).toContain(
       "cannot import from a file exporting 'cli-entrypoint'",
     )

--- a/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
+++ b/packages/riviere-role-enforcement/use-cases/src/features/enforcement/commands/forbidden-imported-function-calls.spec.ts
@@ -31,6 +31,7 @@ const testRoles = [
     forbiddenImportedFunctionCalls: true,
   }),
   role('cli-entrypoint-dependencies', {
+    forbiddenInlineFunctionImplementations: true,
     targets: ['interface'],
     nameMatches: '.*EntrypointDependencies$',
   }),
@@ -273,6 +274,35 @@ export function createCommand(dependencies: ExampleEntrypointDependencies): stri
 
     expect(result.exitCode).toBe(0)
     expect(result.stderr).toBe('')
+  })
+})
+
+it('rejects inline function implementations in a CLI entrypoint dependency object', () => {
+  withFixtureWorkspace((workspaceDir) => {
+    writeInputFactory(
+      workspaceDir,
+      `/** @riviere-role cli-entrypoint-dependencies */
+export interface ExampleEntrypointDependencies {}
+
+/** @riviere-role cli-entrypoint */
+export function createCommand(dependencies: ExampleEntrypointDependencies): string {
+  return 'command'
+}
+
+createCommand({
+  sourceFileSelection: {
+    runGit: (args: string[]) => args.join(' '),
+  },
+})
+`,
+    )
+
+    const result = runTestRoleEnforcement(testConfig, workspaceDir)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain(
+      "Role 'cli-entrypoint-dependencies' forbids inline function implementations",
+    )
   })
 })
 


### PR DESCRIPTION
## Problem

CLI entrypoint dependency objects could contain inline functions in the composition root. That lets I/O implementations bypass role classification.

## Change

The cli-entrypoint-dependencies role now rejects inline function implementations in an object passed to a CLI entrypoint. The diagnostic directs authors to define a named collaborator with its actual role.

## Coverage

Tests cover the plugin directly and an imported CLI entrypoint called from a composition root. The latter matches the extract command wiring.

## Verification

pnpm verify passed in the commit hook.