### PR TITLE
fix(workflow): share parent session with Codex reviewers

### DIFF
--- a/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.spec.ts
+++ b/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.spec.ts
@@ -1,0 +1,117 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CodexSessionMetadataError, readCodexParentThreadId } from './codex-session'
+
+const directories: string[] = []
+
+function withCodexHome(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'codex-workflow-session-'))
+  directories.push(directory)
+  return directory
+}
+
+function writeSessionMetadata(codexHome: string, threadId: string, payload: unknown): void {
+  const sessionsDirectory = join(codexHome, 'sessions', '2026', '08', '21')
+  mkdirSync(sessionsDirectory, { recursive: true })
+  writeFileSync(
+    join(sessionsDirectory, `rollout-2026-08-21T08-00-00-${threadId}.jsonl`),
+    `${JSON.stringify({ type: 'session_meta', payload })}\n`,
+  )
+}
+
+afterEach(() => {
+  for (const directory of directories) rmSync(directory, { recursive: true, force: true })
+  directories.length = 0
+})
+
+describe('readCodexParentThreadId', () => {
+  it('returns undefined when the current session is not a subagent', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'parent-session', { thread_source: 'cli' })
+
+    expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
+  })
+
+  it('returns undefined when no local transcript exists', () => {
+    const codexHome = withCodexHome()
+
+    expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
+  })
+
+  it('returns undefined when no transcript matches the current session', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'other-session', { thread_source: 'cli' })
+
+    expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
+  })
+
+  it('returns undefined when a transcript does not start with session metadata', () => {
+    const codexHome = withCodexHome()
+    const sessionsDirectory = join(codexHome, 'sessions', '2026', '08', '21')
+    mkdirSync(sessionsDirectory, { recursive: true })
+    writeFileSync(
+      join(sessionsDirectory, 'rollout-2026-08-21T08-00-00-parent-session.jsonl'),
+      `${JSON.stringify({ type: 'response_item' })}\n`,
+    )
+
+    expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
+  })
+
+  it('returns undefined when a transcript is empty', () => {
+    const codexHome = withCodexHome()
+    const sessionsDirectory = join(codexHome, 'sessions', '2026', '08', '21')
+    mkdirSync(sessionsDirectory, { recursive: true })
+    writeFileSync(join(sessionsDirectory, 'rollout-2026-08-21T08-00-00-parent-session.jsonl'), '')
+
+    expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
+  })
+
+  it('returns undefined when session metadata has no subagent source', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'parent-session', { source: {} })
+
+    expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
+  })
+
+  it('uses parent_thread_id from a spawned subagent session', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'child-session', {
+      thread_source: 'subagent',
+      source: { subagent: { thread_spawn: { parent_thread_id: 'parent-session' } } },
+    })
+
+    expect(readCodexParentThreadId('child-session', codexHome)).toStrictEqual('parent-session')
+  })
+
+  it('uses forked_from_id when parent_thread_id is unavailable', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'child-session', {
+      thread_source: 'subagent',
+      forked_from_id: 'parent-session',
+    })
+
+    expect(readCodexParentThreadId('child-session', codexHome)).toStrictEqual('parent-session')
+  })
+
+  it('fails when a subagent transcript has no parent identifier', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'child-session', { thread_source: 'subagent' })
+
+    expect(() => readCodexParentThreadId('child-session', codexHome)).toThrow(
+      new CodexSessionMetadataError('child-session'),
+    )
+  })
+
+  it('recognises a spawned subagent when thread_source is absent', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'child-session', {
+      source: { subagent: { thread_spawn: {} } },
+    })
+
+    expect(() => readCodexParentThreadId('child-session', codexHome)).toThrow(
+      new CodexSessionMetadataError('child-session'),
+    )
+  })
+})

--- a/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.spec.ts
+++ b/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.spec.ts
@@ -75,6 +75,13 @@ describe('readCodexParentThreadId', () => {
     expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
   })
 
+  it('returns undefined when subagent metadata has no thread spawn', () => {
+    const codexHome = withCodexHome()
+    writeSessionMetadata(codexHome, 'parent-session', { source: { subagent: {} } })
+
+    expect(readCodexParentThreadId('parent-session', codexHome)).toBeUndefined()
+  })
+
   it('uses parent_thread_id from a spawned subagent session', () => {
     const codexHome = withCodexHome()
     writeSessionMetadata(codexHome, 'child-session', {
@@ -89,6 +96,7 @@ describe('readCodexParentThreadId', () => {
     const codexHome = withCodexHome()
     writeSessionMetadata(codexHome, 'child-session', {
       thread_source: 'subagent',
+      source: { subagent: { thread_spawn: {} } },
       forked_from_id: 'parent-session',
     })
 

--- a/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.ts
+++ b/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.ts
@@ -1,0 +1,90 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readString(record: JsonRecord, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+function readParentThreadId(payload: JsonRecord): string | undefined {
+  const source = payload['source']
+  if (isRecord(source)) {
+    const subagent = source['subagent']
+    if (isRecord(subagent)) {
+      const threadSpawn = subagent['thread_spawn']
+      if (isRecord(threadSpawn)) return readString(threadSpawn, 'parent_thread_id')
+    }
+  }
+
+  return readString(payload, 'parent_thread_id') ?? readString(payload, 'forked_from_id')
+}
+
+function isSubagentSession(payload: JsonRecord): boolean {
+  if (payload['thread_source'] === 'subagent') return true
+
+  const source = payload['source']
+  if (!isRecord(source)) return false
+  const subagent = source['subagent']
+  if (!isRecord(subagent)) return false
+
+  return isRecord(subagent['thread_spawn'])
+}
+
+function findTranscriptPath(directory: string, threadId: string): string | undefined {
+  if (!existsSync(directory)) return undefined
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      const transcriptPath = findTranscriptPath(path, threadId)
+      if (transcriptPath !== undefined) return transcriptPath
+      continue
+    }
+
+    if (entry.isFile() && entry.name.endsWith(`-${threadId}.jsonl`)) return path
+  }
+
+  return undefined
+}
+
+function readSessionMetadata(transcriptPath: string): JsonRecord | undefined {
+  const firstLine = readFileSync(transcriptPath, 'utf8').split('\n')[0]
+  if (firstLine === undefined || firstLine === '') return undefined
+
+  const entry: unknown = JSON.parse(firstLine)
+  if (!isRecord(entry) || entry['type'] !== 'session_meta' || !isRecord(entry['payload'])) {
+    return undefined
+  }
+
+  return entry['payload']
+}
+
+/** @riviere-role external-client-error */
+export class CodexSessionMetadataError extends Error {
+  constructor(threadId: string) {
+    super(`Codex subagent session ${threadId} is missing parent_thread_id metadata`)
+    this.name = 'CodexSessionMetadataError'
+  }
+}
+
+/** @riviere-role external-client-service */
+export function readCodexParentThreadId(threadId: string, codexHome: string): string | undefined {
+  const transcriptsDirectory = join(codexHome, 'sessions')
+  const transcriptPath = findTranscriptPath(transcriptsDirectory, threadId)
+  if (transcriptPath === undefined) return undefined
+
+  const metadata = readSessionMetadata(transcriptPath)
+  if (metadata === undefined) return undefined
+
+  const parentThreadId = readParentThreadId(metadata)
+  if (parentThreadId !== undefined) return parentThreadId
+  if (isSubagentSession(metadata)) throw new CodexSessionMetadataError(threadId)
+
+  return undefined
+}

--- a/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.ts
+++ b/packages/dev-workflow-v2/use-cases/src/infra/external-clients/codex/codex-session.ts
@@ -12,15 +12,21 @@ function readString(record: JsonRecord, key: string): string | undefined {
   return typeof value === 'string' && value !== '' ? value : undefined
 }
 
+function readSpawnParentThreadId(source: unknown): string | undefined {
+  if (!isRecord(source)) return undefined
+
+  const subagent = source['subagent']
+  if (!isRecord(subagent)) return undefined
+
+  const threadSpawn = subagent['thread_spawn']
+  if (!isRecord(threadSpawn)) return undefined
+
+  return readString(threadSpawn, 'parent_thread_id')
+}
+
 function readParentThreadId(payload: JsonRecord): string | undefined {
-  const source = payload['source']
-  if (isRecord(source)) {
-    const subagent = source['subagent']
-    if (isRecord(subagent)) {
-      const threadSpawn = subagent['thread_spawn']
-      if (isRecord(threadSpawn)) return readString(threadSpawn, 'parent_thread_id')
-    }
-  }
+  const spawnParentThreadId = readSpawnParentThreadId(payload['source'])
+  if (spawnParentThreadId !== undefined) return spawnParentThreadId
 
   return readString(payload, 'parent_thread_id') ?? readString(payload, 'forked_from_id')
 }

--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/.codex-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "description": "Event-sourced workflow state machine for a structured task lifecycle.",
   "author": {
     "name": "NTCoding",

--- a/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
+import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { readCodexParentThreadId } from '@living-architecture/dev-workflow-v2-use-cases/external-clients/codex/codex-session'
 
 class InvalidWorkflowCommandError extends Error {
   constructor() {
@@ -28,19 +30,28 @@ if (sessionId === undefined || sessionId === '') {
   throw new MissingCodexThreadIdError()
 }
 
-const args = operationArgs[0] === sessionId ? operationArgs.slice(1) : operationArgs
+const codexHome = process.env.CODEX_HOME ?? join(homedir(), '.codex')
+const workflowSessionId = readCodexParentThreadId(sessionId, codexHome) ?? sessionId
+const args =
+  operationArgs[0] === sessionId || operationArgs[0] === workflowSessionId
+    ? operationArgs.slice(1)
+    : operationArgs
 const cliPath = join(dirname(fileURLToPath(import.meta.url)), 'codex-cli.ts')
 const require = createRequire(import.meta.url)
 const tsxCliPath = require.resolve('tsx/cli')
 const sourceCondition = '--conditions=@living-architecture/source'
 const nodeOptions = [process.env.NODE_OPTIONS, sourceCondition].filter(Boolean).join(' ')
-const result = spawnSync(process.execPath, [tsxCliPath, cliPath, operation, sessionId, ...args], {
-  stdio: 'inherit',
-  env: {
-    ...process.env,
-    NODE_OPTIONS: nodeOptions,
+const result = spawnSync(
+  process.execPath,
+  [tsxCliPath, cliPath, operation, workflowSessionId, ...args],
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: nodeOptions,
+    },
   },
-})
+)
 
 if (result.error !== undefined) {
   throw result.error


### PR DESCRIPTION
## Problem

Codex child agents have their own thread IDs, but workflow events belong to the active parent task session. A reviewer calling `get-state` with its child ID cannot find that session, so it cannot record the review result.

## Proposed outcome

Any workflow command run by a Codex child agent resolves to the parent task session before it reaches the deterministic workflow CLI. Parent sessions continue to use their own IDs.

## Changes

- Read Codex session metadata from the local transcript store in a use cases external client.
- Resolve nested `parent_thread_id`, then top level `parent_thread_id`, then `forked_from_id`.
- Pass the resolved ID to every workflow CLI operation.
- Add regression coverage for missing, malformed, parent, and child metadata shapes.

## Acceptance criteria

- [x] A child transcript with a parent ID reads and writes the parent workflow session.
- [x] A child transcript with an empty nested spawn record falls back to `forked_from_id`.
- [x] A parent transcript continues to use its own session ID.
- [x] The full workspace role check passes.

## Validation

- `pnpm verify` passed before the initial PR commit.
- `pnpm nx test @living-architecture/dev-workflow-v2-use-cases` passes with 100% coverage after the review fix.
- `pnpm nx role-check @living-architecture/source` passes.
- A live `get-state` invocation using the failed reviewer child ID returned issue #407 parent session state.

## Design decisions and constraints

Codex transcript reading is external client work, so it lives in the use cases infrastructure boundary. The shell remains a minimal adapter that resolves the session ID and invokes the workflow CLI. The resolver is read only and does not change workflow state.

## Out of scope

This PR does not change workflow transitions, review permissions, or the #407 implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow commands now detect and use the associated parent Codex session automatically.
  * Session discovery supports spawned and forked subagent workflows.

* **Bug Fixes**
  * Improved handling of missing, invalid, or incomplete session metadata.
  * Prevented duplicate session identifiers from being passed to the workflow command.

* **Chores**
  * Updated the workflow plugin version to 0.0.148.

* **Tests**
  * Added coverage for session discovery and metadata edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->