### PR TITLE
fix(workflow): align Codex plugin version

### DIFF
--- a/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository-validation.spec.ts
+++ b/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository-validation.spec.ts
@@ -22,18 +22,22 @@ const VALID_CONFIG = `modules:
 
 const GIT_EXECUTABLE = process.env['GIT_EXECUTABLE'] ?? '/usr/bin/git'
 
+function runGit(args: string[], cwd: string): void {
+  execFileSync(GIT_EXECUTABLE, args, {
+    cwd,
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_')),
+    ),
+    stdio: 'ignore',
+  })
+}
+
 function withWorkspace(run: (directory: string) => void): void {
   const directory = mkdtempSync(join(tmpdir(), 'extract-validation-test-'))
   writeFileSync(join(directory, 'package.json'), JSON.stringify({ name: 'workspace' }))
   writeFileSync(join(directory, 'component.ts'), 'export class Order {}')
-  execFileSync(GIT_EXECUTABLE, ['init', '--initial-branch=main'], {
-    cwd: directory,
-    stdio: 'ignore',
-  })
-  execFileSync(GIT_EXECUTABLE, ['remote', 'add', 'origin', 'https://github.com/test/repo.git'], {
-    cwd: directory,
-    stdio: 'ignore',
-  })
+  runGit(['init', '--initial-branch=main'], directory)
+  runGit(['remote', 'add', 'origin', 'https://github.com/test/repo.git'], directory)
   try {
     run(directory)
   } finally {
@@ -65,7 +69,10 @@ function writeExtendsConfig(directory: string, extendsRef: string): void {
   writeFileSync(join(directory, 'component.ts'), 'export class Order {}')
   writeFileSync(
     join(directory, 'extract.yml'),
-    VALID_CONFIG.replace('api: { notUsed: true }', `extends: ${extendsRef}\n    api: { notUsed: true }`),
+    VALID_CONFIG.replace(
+      'api: { notUsed: true }',
+      `extends: ${extendsRef}\n    api: { notUsed: true }`,
+    ),
   )
 }
 

--- a/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository.spec.ts
+++ b/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository.spec.ts
@@ -22,14 +22,21 @@ const VALID_CONFIG = `modules:
 
 const GIT_EXECUTABLE = process.env['GIT_EXECUTABLE'] ?? '/usr/bin/git'
 
+function runGit(args: string[], cwd: string): void {
+  execFileSync(GIT_EXECUTABLE, args, {
+    cwd,
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_')),
+    ),
+    stdio: 'ignore',
+  })
+}
+
 function withWorkspace(fn: (dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), 'extract-project-test-'))
   writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'workspace' }), 'utf-8')
-  execFileSync(GIT_EXECUTABLE, ['init', '--initial-branch=main'], { cwd: dir, stdio: 'ignore' })
-  execFileSync(GIT_EXECUTABLE, ['remote', 'add', 'origin', 'https://github.com/test/repo.git'], {
-    cwd: dir,
-    stdio: 'ignore',
-  })
+  runGit(['init', '--initial-branch=main'], dir)
+  runGit(['remote', 'add', 'origin', 'https://github.com/test/repo.git'], dir)
   try {
     fn(dir)
   } finally {
@@ -122,11 +129,16 @@ describe('RiviereProjectRepository', () => {
 
   it('translates a missing Git remote into a data access error', () => {
     withWorkspace((dir) => {
-      execFileSync(GIT_EXECUTABLE, ['remote', 'remove', 'origin'], { cwd: dir, stdio: 'ignore' })
+      runGit(['remote', 'remove', 'origin'], dir)
       writeFileSync(join(dir, 'component.ts'), 'export class Order {}')
       writeFileSync(join(dir, 'extract.config.yml'), VALID_CONFIG)
 
-      const load = () => loadProject({ configPath: join(dir, 'extract.config.yml'), projectRoot: dir, useTsConfig: false })
+      const load = () =>
+        loadProject({
+          configPath: join(dir, 'extract.config.yml'),
+          projectRoot: dir,
+          useTsConfig: false,
+        })
       expect(load).toThrow(ExtractionDataAccessError)
       expect(load).toThrow(expect.objectContaining({ code: 'NO_REMOTE' }))
     })

--- a/packages/riviere-extract-ts/use-cases/src/infra/external-clients/git/git-changed-files.spec.ts
+++ b/packages/riviere-extract-ts/use-cases/src/infra/external-clients/git/git-changed-files.spec.ts
@@ -59,19 +59,28 @@ function attachedHeadResponses(
 const WORK_DIR = '/fake/project'
 const GIT_EXECUTABLE = process.env['GIT_EXECUTABLE'] ?? '/usr/bin/git'
 
+function runGit(args: string[], cwd: string): void {
+  execFileSync(GIT_EXECUTABLE, args, {
+    cwd,
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_')),
+    ),
+  })
+}
+
 describe('detectChangedTypeScriptFiles', () => {
   it('uses the default Git executor with a controlled repository', () => {
     const directory = mkdtempSync(join(tmpdir(), 'changed-files-test-'))
     try {
-      execFileSync(GIT_EXECUTABLE, ['init', '--initial-branch=main'], { cwd: directory })
-      execFileSync(GIT_EXECUTABLE, ['config', 'user.email', 'test@example.com'], { cwd: directory })
-      execFileSync(GIT_EXECUTABLE, ['config', 'user.name', 'Test'], { cwd: directory })
+      runGit(['init', '--initial-branch=main'], directory)
+      runGit(['config', 'user.email', 'test@example.com'], directory)
+      runGit(['config', 'user.name', 'Test'], directory)
       writeFileSync(join(directory, 'changed.ts'), 'export const changed = true')
-      execFileSync(GIT_EXECUTABLE, ['add', 'changed.ts'], { cwd: directory })
-      execFileSync(GIT_EXECUTABLE, ['commit', '-m', 'initial'], { cwd: directory })
+      runGit(['add', 'changed.ts'], directory)
+      runGit(['commit', '-m', 'initial'], directory)
       writeFileSync(join(directory, 'changed.ts'), 'export const changed = false')
-      execFileSync(GIT_EXECUTABLE, ['add', 'changed.ts'], { cwd: directory })
-      execFileSync(GIT_EXECUTABLE, ['commit', '-m', 'changed'], { cwd: directory })
+      runGit(['add', 'changed.ts'], directory)
+      runGit(['commit', '-m', 'changed'], directory)
 
       expect(detectChangedTypeScriptFiles(directory, { base: 'HEAD~1' }).files).toStrictEqual([
         join(directory, 'changed.ts'),

--- a/tools/dev-workflow-v2/plugin.json
+++ b/tools/dev-workflow-v2/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "dev-workflow-v2",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "description": "Event-sourced workflow state machine for a structured task lifecycle.",
   "author": {
     "name": "NTCoding"


### PR DESCRIPTION
## Problem

The marketplace root manifest still advertised dev-workflow-v2 0.0.147 after the 0.0.148 release. Codex therefore installed the old plugin.

The pre-commit gate also failed because Git hook variables leaked into temporary Git repositories created by extraction tests.

## Change

- advertise dev-workflow-v2 0.0.148 from the marketplace root manifest
- strip inherited GIT_* variables from each temporary test repository command

## Verification

- pnpm nx test @living-architecture/riviere-extract-ts-use-cases with GIT_INDEX_FILE set
- pnpm verify
- commit hook pnpm verify