### PR TITLE
fix(workflow): reject invalid stage plans

### DIFF
--- a/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.spec.ts
+++ b/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.spec.ts
@@ -87,11 +87,26 @@ describe('parseWorkflowDefinition', () => {
   it.each([
     ['unsupported version', { ...validWorkflow, version: 2 }],
     ['missing graph metadata', { ...validWorkflow, graph: { outputPath: 'graph.json' } }],
+    [
+      'missing graph sources',
+      { ...validWorkflow, graph: { ...validWorkflow.graph, sources: undefined } },
+    ],
+    [
+      'missing graph domains',
+      { ...validWorkflow, graph: { ...validWorkflow.graph, domains: undefined } },
+    ],
+    [
+      'missing graph output path',
+      { ...validWorkflow, graph: { ...validWorkflow.graph, outputPath: undefined } },
+    ],
+    ['missing run log directory', { ...validWorkflow, runLog: {} }],
     ['unknown stage type', { ...validWorkflow, stages: [{ command: { run: 'echo forbidden' } }] }],
     [
       'more than one type in a stage',
       { ...validWorkflow, stages: [{ extract: {}, validate: {} }] },
     ],
+    ['missing extract config', { ...validWorkflow, stages: [{ extract: { name: 'orders' } }] }],
+    ['missing link config', { ...validWorkflow, stages: [{ link: {} }] }],
     ['empty strings', { ...validWorkflow, graph: { ...validWorkflow.graph, outputPath: '' } }],
     [
       'unsupported system type',

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow-definition-failure.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow-definition-failure.ts
@@ -1,6 +1,11 @@
 type WorkflowDefinitionFailureCode =
   | 'INVALID_WORKFLOW_NAME'
+  | 'MISSING_EXTRACT_STAGE'
   | 'DUPLICATE_STAGE_NAME'
+  | 'MISSING_LINK_STAGE'
+  | 'MULTIPLE_LINK_STAGES'
+  | 'MISSING_VALIDATE_STAGE'
+  | 'MULTIPLE_VALIDATE_STAGES'
   | 'INVALID_STAGE_ORDER'
 
 /** @riviere-role value-object */

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow-definition-validation.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow-definition-validation.spec.ts
@@ -1,0 +1,101 @@
+import { ValidatedConfiguration } from '@living-architecture/riviere-extract-config-published-language'
+import { Project } from 'ts-morph'
+import { assert, describe, expect, it } from 'vitest'
+import { ExtractionConfiguration } from './extraction-configuration'
+import { Workflow } from './workflow'
+import { WorkflowStage } from './workflow-stage'
+
+function configuration(): ExtractionConfiguration {
+  const parsed = ValidatedConfiguration.parse({
+    modules: [
+      {
+        api: { notUsed: true },
+        domain: 'orders',
+        domainOp: { notUsed: true },
+        event: { notUsed: true },
+        eventHandler: { notUsed: true },
+        glob: '**/*.ts',
+        name: 'orders',
+        path: '.',
+        ui: { notUsed: true },
+        useCase: { notUsed: true },
+      },
+    ],
+  })
+  assert(parsed.success)
+  const module = parsed.data.modules[0]
+  assert(module)
+  return ExtractionConfiguration.parse({
+    name: 'orders',
+    configPath: 'orders.yml',
+    useTsConfig: false,
+    repositoryName: 'shop',
+    resolvedConfig: parsed.data,
+    moduleContexts: [{ module, project: new Project(), files: [] }],
+  })
+}
+
+describe('Workflow stage plan validation', () => {
+  it.each([
+    [
+      'missing extract stages',
+      [WorkflowStage.fromLink('link', configuration()), WorkflowStage.fromValidation('validate')],
+      'MISSING_EXTRACT_STAGE',
+    ],
+    [
+      'missing the link stage',
+      [
+        WorkflowStage.fromExtraction('extract', configuration()),
+        WorkflowStage.fromValidation('validate'),
+      ],
+      'MISSING_LINK_STAGE',
+    ],
+    [
+      'multiple link stages',
+      [
+        WorkflowStage.fromExtraction('extract', configuration()),
+        WorkflowStage.fromLink('first-link', configuration()),
+        WorkflowStage.fromLink('second-link', configuration()),
+        WorkflowStage.fromValidation('validate'),
+      ],
+      'MULTIPLE_LINK_STAGES',
+    ],
+    [
+      'missing the validate stage',
+      [
+        WorkflowStage.fromExtraction('extract', configuration()),
+        WorkflowStage.fromLink('link', configuration()),
+      ],
+      'MISSING_VALIDATE_STAGE',
+    ],
+    [
+      'multiple validate stages',
+      [
+        WorkflowStage.fromExtraction('extract', configuration()),
+        WorkflowStage.fromLink('link', configuration()),
+        WorkflowStage.fromValidation('first-validate'),
+        WorkflowStage.fromValidation('second-validate'),
+      ],
+      'MULTIPLE_VALIDATE_STAGES',
+    ],
+    [
+      'misplaced stages',
+      [
+        WorkflowStage.fromLink('link', configuration()),
+        WorkflowStage.fromExtraction('extract', configuration()),
+        WorkflowStage.fromValidation('validate'),
+      ],
+      'INVALID_STAGE_ORDER',
+    ],
+  ])('rejects %s with a specific failure', (_case, stages, code) => {
+    const result = Workflow.start({
+      name: 'build-graph',
+      outputPath: 'graph.json',
+      runLogDirectory: 'logs',
+      stages,
+    })
+
+    assert(!result.success)
+    expect(result.error.code).toBe(code)
+  })
+})

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow-definition-validation.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow-definition-validation.spec.ts
@@ -79,11 +79,20 @@ describe('Workflow stage plan validation', () => {
       'MULTIPLE_VALIDATE_STAGES',
     ],
     [
-      'misplaced stages',
+      'link before extract',
       [
         WorkflowStage.fromLink('link', configuration()),
         WorkflowStage.fromExtraction('extract', configuration()),
         WorkflowStage.fromValidation('validate'),
+      ],
+      'INVALID_STAGE_ORDER',
+    ],
+    [
+      'validate before link',
+      [
+        WorkflowStage.fromExtraction('extract', configuration()),
+        WorkflowStage.fromValidation('validate'),
+        WorkflowStage.fromLink('link', configuration()),
       ],
       'INVALID_STAGE_ORDER',
     ],

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
@@ -137,7 +137,11 @@ describe('Workflow definition', () => {
       name: 'build-graph',
       outputPath: 'graph.json',
       runLogDirectory: 'logs',
-      stages: [WorkflowStage.fromExtraction('extract', config)],
+      stages: [
+        WorkflowStage.fromLink('link', config),
+        WorkflowStage.fromExtraction('extract', config),
+        WorkflowStage.fromValidation('validate'),
+      ],
     })
 
     assert(!invalidName.success)
@@ -149,33 +153,6 @@ describe('Workflow definition', () => {
       message: "Duplicate workflow stage name 'same'",
     })
     expect(invalidOrder.error.code).toBe('INVALID_STAGE_ORDER')
-  })
-
-  it('rejects misplaced link and validate stages', () => {
-    const config = configuration()
-    const misplacedLink = Workflow.start({
-      name: 'build-graph',
-      outputPath: 'graph.json',
-      runLogDirectory: 'logs',
-      stages: [
-        WorkflowStage.fromLink('link', config),
-        WorkflowStage.fromExtraction('extract', config),
-        WorkflowStage.fromValidation('validate'),
-      ],
-    })
-    const misplacedValidate = Workflow.start({
-      name: 'build-graph',
-      outputPath: 'graph.json',
-      runLogDirectory: 'logs',
-      stages: [
-        WorkflowStage.fromExtraction('extract', config),
-        WorkflowStage.fromValidation('validate'),
-        WorkflowStage.fromLink('link', config),
-      ],
-    })
-
-    expect(misplacedLink.success).toBe(false)
-    expect(misplacedValidate.success).toBe(false)
   })
 })
 

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
@@ -154,6 +154,23 @@ describe('Workflow definition', () => {
     })
     expect(invalidOrder.error.code).toBe('INVALID_STAGE_ORDER')
   })
+
+  it('rejects validate before link', () => {
+    const config = configuration()
+    const invalidOrder = Workflow.start({
+      name: 'build-graph',
+      outputPath: 'graph.json',
+      runLogDirectory: 'logs',
+      stages: [
+        WorkflowStage.fromExtraction('extract', config),
+        WorkflowStage.fromValidation('validate'),
+        WorkflowStage.fromLink('link', config),
+      ],
+    })
+
+    assert(!invalidOrder.success)
+    expect(invalidOrder.error.code).toBe('INVALID_STAGE_ORDER')
+  })
 })
 
 describe('Workflow.run', () => {

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
@@ -223,13 +223,7 @@ function validateWorkflow(
       `Duplicate workflow stage name '${duplicateName}'`,
     )
   }
-  if (!hasValidStageOrder(stages)) {
-    return WorkflowDefinitionFailure.parse(
-      'INVALID_STAGE_ORDER',
-      'Workflow stages must contain one or more extract stages, followed by one link stage and one validate stage',
-    )
-  }
-  return undefined
+  return validateStageSequence(stages)
 }
 
 function findDuplicateStageName(stages: readonly WorkflowStage[]): string | undefined {
@@ -241,12 +235,73 @@ function findDuplicateStageName(stages: readonly WorkflowStage[]): string | unde
   return undefined
 }
 
-function hasValidStageOrder(stages: readonly WorkflowStage[]): boolean {
-  if (stages.length < 3) return false
+function validateStageSequence(
+  stages: readonly WorkflowStage[],
+): WorkflowDefinitionFailure | undefined {
+  const counts = countStageKinds(stages)
+  if (counts.extract === 0) {
+    return WorkflowDefinitionFailure.parse(
+      'MISSING_EXTRACT_STAGE',
+      'Workflow stages must contain one or more extract stages',
+    )
+  }
+  if (counts.link === 0) {
+    return WorkflowDefinitionFailure.parse(
+      'MISSING_LINK_STAGE',
+      'Workflow stages must contain exactly one link stage',
+    )
+  }
+  if (counts.link > 1) {
+    return WorkflowDefinitionFailure.parse(
+      'MULTIPLE_LINK_STAGES',
+      'Workflow stages must contain exactly one link stage',
+    )
+  }
+  if (counts.validate === 0) {
+    return WorkflowDefinitionFailure.parse(
+      'MISSING_VALIDATE_STAGE',
+      'Workflow stages must contain exactly one validate stage',
+    )
+  }
+  if (counts.validate > 1) {
+    return WorkflowDefinitionFailure.parse(
+      'MULTIPLE_VALIDATE_STAGES',
+      'Workflow stages must contain exactly one validate stage',
+    )
+  }
   const linkStage = stages.at(-2)
   const validateStage = stages.at(-1)
-  if (linkStage?.value.kind !== 'link' || validateStage?.value.kind !== 'validate') return false
-  return stages.slice(0, -2).every((stage) => stage.value.kind === 'extract')
+  if (linkStage?.value.kind === 'link' && validateStage?.value.kind === 'validate') {
+    return undefined
+  }
+  return WorkflowDefinitionFailure.parse(
+    'INVALID_STAGE_ORDER',
+    'Workflow stages must contain all extract stages, followed by one link stage and one validate stage',
+  )
+}
+
+function countStageKinds(
+  stages: readonly WorkflowStage[],
+): Record<WorkflowStageValue['kind'], number> {
+  const counts: Record<WorkflowStageValue['kind'], number> = {
+    extract: 0,
+    link: 0,
+    validate: 0,
+  }
+  for (const stage of stages) {
+    switch (stage.value.kind) {
+      case 'extract':
+        counts.extract += 1
+        break
+      case 'link':
+        counts.link += 1
+        break
+      case 'validate':
+        counts.validate += 1
+        break
+    }
+  }
+  return counts
 }
 
 function validateGraph(builder: RiviereBuilder): WorkflowStageExecutionResult {

--- a/packages/riviere-extract-ts/use-cases/src/features/extract/commands/run-workflow.spec.ts
+++ b/packages/riviere-extract-ts/use-cases/src/features/extract/commands/run-workflow.spec.ts
@@ -53,6 +53,7 @@ describe('RunWorkflow', () => {
         warnings: [],
       },
     })
+    expect(mocks.rebuildGraph).not.toHaveBeenCalled()
   })
 
   it('does not hide unexpected failures', () => {

--- a/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository-workflow.spec.ts
+++ b/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository-workflow.spec.ts
@@ -53,6 +53,10 @@ function writeWorkflow(
   secondConfig = 'shipping.yaml',
   secondStageName = 'shipping',
   graphMetadata = '',
+  stages = `  - extract: { name: orders, config: orders.yaml, useTsConfig: false }
+  - extract: { name: ${secondStageName}, config: ${secondConfig}, useTsConfig: false }
+  - link: { config: orders.yaml, useTsConfig: false }
+  - validate: {}`,
 ): void {
   writeFileSync(
     join(directory, '.riviere', 'workflows', 'combined.yaml'),
@@ -64,10 +68,7 @@ ${graphMetadata}
   outputPath: .riviere/graph.json
 runLog: { directory: .riviere/logs }
 stages:
-  - extract: { name: orders, config: orders.yaml, useTsConfig: false }
-  - extract: { name: ${secondStageName}, config: ${secondConfig}, useTsConfig: false }
-  - link: { config: orders.yaml, useTsConfig: false }
-  - validate: {}
+${stages}
 `,
   )
 }
@@ -184,6 +185,54 @@ describe('RiviereProjectRepository workflow loading', () => {
         workflowName: 'combined',
       }),
     ).toThrow("Duplicate workflow stage name 'orders'")
+  })
+
+  it.each([
+    [
+      'missing extract stages',
+      `  - link: { config: orders.yaml, useTsConfig: false }
+  - validate: {}`,
+      'one or more extract stages',
+    ],
+    [
+      'missing the link stage',
+      `  - extract: { name: orders, config: orders.yaml, useTsConfig: false }
+  - validate: {}`,
+      'exactly one link stage',
+    ],
+    [
+      'multiple link stages',
+      `  - extract: { name: orders, config: orders.yaml, useTsConfig: false }
+  - link: { config: orders.yaml, useTsConfig: false }
+  - link: { config: orders.yaml, useTsConfig: false }
+  - validate: {}`,
+      "Duplicate workflow stage name 'link'",
+    ],
+    [
+      'missing the validate stage',
+      `  - extract: { name: orders, config: orders.yaml, useTsConfig: false }
+  - link: { config: orders.yaml, useTsConfig: false }`,
+      'exactly one validate stage',
+    ],
+    [
+      'multiple validate stages',
+      `  - extract: { name: orders, config: orders.yaml, useTsConfig: false }
+  - link: { config: orders.yaml, useTsConfig: false }
+  - validate: {}
+  - validate: {}`,
+      "Duplicate workflow stage name 'validate'",
+    ],
+  ])('rejects workflows with %s before stages run', (_case, stages, reason) => {
+    const directory = workspace()
+    writeFileSync(join(directory, 'orders.yaml'), CONFIG)
+    writeWorkflow(directory, 'shipping.yaml', 'shipping', '', stages)
+
+    expect(() =>
+      new RiviereProjectRepository().loadWorkflow({
+        projectRoot: directory,
+        workflowName: 'combined',
+      }),
+    ).toThrow(reason)
   })
 
   it('translates unexpected workflow document failures', () => {


### PR DESCRIPTION
## Problem
Workflow loading accepted some structurally valid YAML that did not describe a runnable workflow. The domain model returned a generic order failure for several distinct invalid stage plans, and repository loading needed explicit proof that invalid definitions stop before execution.

## Changes
* Validate that a workflow has one or more extract stages, exactly one link stage, and exactly one validate stage.
* Return specific domain failure codes for missing and repeated stage kinds while retaining the order failure for misplaced stages.
* Cover missing workflow fields and stage configuration in the published language parser tests.
* Cover repository rejection of invalid stage plans and prove the run command does not rebuild or execute the graph after a load failure.

## Validation
* env -u NO_COLOR -u FORCE_COLOR CI=true pnpm verify
* Commit hook repository verification bundle

Closes #408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation for missing, duplicate, and incorrectly ordered stages.
  * Workflows now report specific errors when extract, link, or validate stages are invalid.
  * Invalid workflows are rejected before execution begins.
  * Prevented graph rebuilding when workflow configuration or data loading fails.

* **Tests**
  * Expanded coverage for invalid workflow definitions, stage sequences, and configuration values.
  * Added verification that invalid workflows are rejected before execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->