### PR TITLE
fix(workflow): run Codex commands through compiled CLI

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://knip.dev/reference/knip-json",
-  "ignoreDependencies": ["tailwindcss", "oxlint"],
+  "ignoreDependencies": ["tailwindcss", "oxlint", "tsx"],
   "workspaces": {
     ".": {
       "entry": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,8 +467,8 @@ importers:
         specifier: 0.4.1
         version: 0.4.1
       '@nt-ai-lab/deterministic-agent-workflow-codex':
-        specifier: 0.4.2
-        version: 0.4.2
+        specifier: 0.4.3
+        version: 0.4.3
       '@nt-ai-lab/deterministic-agent-workflow-engine':
         specifier: 0.4.1
         version: 0.4.1
@@ -478,6 +478,9 @@ importers:
       '@nt-ai-lab/deterministic-agent-workflow-opencode':
         specifier: 0.4.1
         version: 0.4.1
+      esbuild:
+        specifier: 0.27.2
+        version: 0.27.2
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -2102,8 +2105,8 @@ packages:
   '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.1':
     resolution: {integrity: sha512-dpm2vb3z0cCweaZDyJEvUzo7LaoU3SBg4Ff+xTmJxCGo/2nBwFQuzJXXBhUyhqDm4VkWzVmswGL8pf6oigdrNw==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.2':
-    resolution: {integrity: sha512-XUTjc95wlje5GCtO2seeWY5TcQNhHOt/l2uBSmeTl2sZIayfi9SHAFkRbWe4UbbW/HrOBgiLWyxcxP6CY+zOuw==}
+  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.3':
+    resolution: {integrity: sha512-Ri08mUk8mJ5NALvpGUd7pMsF/6fOOgC7+DgSQEvpvfbhPgV8IsYXfHUircMwpH4hLdBOlZ4u2dVtFgFG1KWN1g==}
 
   '@nt-ai-lab/deterministic-agent-workflow-dsl@0.3.6':
     resolution: {integrity: sha512-HluSmsDvoIgYIepnNn8GcGMZs65AtJ3ydoZW0b9H4BlU38Qr6BHz08aEj9+OetDcy4pkFqQj4JfAlxaacl+wnQ==}
@@ -10336,7 +10339,7 @@ snapshots:
       '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.1
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.2':
+  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.3':
     dependencies:
       '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.1
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.1

--- a/tools/dev-workflow-v2/esbuild.config.mjs
+++ b/tools/dev-workflow-v2/esbuild.config.mjs
@@ -1,0 +1,29 @@
+import * as esbuild from 'esbuild'
+
+const executableBanner = '#!/usr/bin/env node'
+
+await esbuild.build({
+  entryPoints: ['src/shell/codex-workflow-command.ts'],
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  format: 'esm',
+  outfile: 'dist/codex-workflow-command.js',
+  banner: { js: executableBanner },
+  external: ['@nt-ai-lab/deterministic-agent-workflow-codex'],
+})
+
+await esbuild.build({
+  entryPoints: ['src/shell/codex-cli.ts'],
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  format: 'esm',
+  outfile: 'dist/codex-cli.js',
+  banner: { js: executableBanner },
+  external: [
+    '@nt-ai-lab/deterministic-agent-workflow-cli',
+    '@nt-ai-lab/deterministic-agent-workflow-codex',
+    '@nt-ai-lab/deterministic-agent-workflow-engine',
+  ],
+})

--- a/tools/dev-workflow-v2/package.json
+++ b/tools/dev-workflow-v2/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build": "node esbuild.config.mjs",
+    "precodex-workflow": "pnpm --dir ../.. exec nx build dev-workflow-v2",
+    "codex-workflow": "node dist/codex-workflow-command.js",
     "test": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
   },
@@ -11,10 +14,11 @@
     "@living-architecture/dev-workflow-v2-use-cases": "workspace:*",
     "@nt-ai-lab/deterministic-agent-workflow-claude-code": "0.4.1",
     "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.1",
-    "@nt-ai-lab/deterministic-agent-workflow-codex": "0.4.2",
+    "@nt-ai-lab/deterministic-agent-workflow-codex": "0.4.3",
     "@nt-ai-lab/deterministic-agent-workflow-engine": "0.4.1",
     "@nt-ai-lab/deterministic-agent-workflow-event-store": "0.4.1",
     "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.4.1",
+    "esbuild": "0.27.2",
     "tsx": "4.21.0"
   },
   "devDependencies": {

--- a/tools/dev-workflow-v2/project.json
+++ b/tools/dev-workflow-v2/project.json
@@ -1,0 +1,17 @@
+{
+  "name": "dev-workflow-v2",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/dist"],
+      "options": {
+        "command": "pnpm run build",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "test": {
+      "dependsOn": ["lint", "^build", "build"]
+    }
+  }
+}

--- a/tools/dev-workflow-v2/skills/code-review/SKILL.md
+++ b/tools/dev-workflow-v2/skills/code-review/SKILL.md
@@ -6,7 +6,7 @@ description: Run and record the dev-workflow-v2 review bundle. Use only when the
 # Code Review
 
 1. Detect the current harness before doing any review work:
-   - If `CODEX_THREAD_ID` is present, use Codex `spawn_agent` for subagents. Run workflow operations from the repository root with `pnpm exec tsx tools/dev-workflow-v2/src/shell/codex-workflow-command.ts <operation> [args]`.
+   - If `CODEX_THREAD_ID` is present, use Codex `spawn_agent` for subagents. Run workflow operations with `pnpm --dir tools/dev-workflow-v2 run codex-workflow <operation> [args]`.
    - Otherwise, if `OPENCODE=1` is present, use OpenCode `Task` for subagents. Run workflow operations with `/dev-workflow-v2:workflow <operation> [args]`.
    - Otherwise, use Claude Code `Agent` for subagents. Run workflow operations with `/dev-workflow-v2:workflow <operation> [args]`.
 1. Run the selected harness's `get-state` workflow operation. Extract `currentStateMachineState`, `taskCheckPassed`, and `githubIssue`. Stop unless `currentStateMachineState` is `REVIEWING`.

--- a/tools/dev-workflow-v2/skills/create-pr/SKILL.md
+++ b/tools/dev-workflow-v2/skills/create-pr/SKILL.md
@@ -6,7 +6,7 @@ description: Push the current workflow branch and create its pull request. Use o
 # Create Pull Request
 
 1. Detect the current harness before doing any pull-request work:
-   - If `CODEX_THREAD_ID` is present, run workflow operations from the repository root with `pnpm exec tsx tools/dev-workflow-v2/src/shell/codex-workflow-command.ts <operation> [args]`.
+   - If `CODEX_THREAD_ID` is present, run workflow operations with `pnpm --dir tools/dev-workflow-v2 run codex-workflow <operation> [args]`.
    - Otherwise, run workflow operations with `/dev-workflow-v2:workflow <operation> [args]`.
 1. Run the selected harness's `get-state` workflow operation. Extract `currentStateMachineState`, `githubIssue`, `featureBranch`, and `prNumber`. Stop unless `currentStateMachineState` is `SUBMITTING_PR`.
 1. Stop if `githubIssue` or `featureBranch` is missing. Do not infer either value from the branch name.

--- a/tools/dev-workflow-v2/skills/dev-workflow-start-implementation/SKILL.md
+++ b/tools/dev-workflow-v2/skills/dev-workflow-start-implementation/SKILL.md
@@ -8,8 +8,8 @@ description: Start implementation for a GitHub issue. Use only when the user exp
 Use the supplied issue number. Follow the canonical procedure in the plugin's `commands/start-implementation.md` exactly, with this Codex-specific replacement for its two Claude workflow commands:
 
 ```bash
-pnpm --dir "$(git rev-parse --show-toplevel)" exec tsx "$(git rev-parse --show-toplevel)/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts" init
-pnpm --dir "$(git rev-parse --show-toplevel)" exec tsx "$(git rev-parse --show-toplevel)/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts" record-issue <issue-number>
+pnpm --dir "$(git rev-parse --show-toplevel)/tools/dev-workflow-v2" run codex-workflow init
+pnpm --dir "$(git rev-parse --show-toplevel)/tools/dev-workflow-v2" run codex-workflow record-issue <issue-number>
 ```
 
 The shared command reads Codex's `CODEX_THREAD_ID`. Do not read a session ID from hook output or substitute any other value.

--- a/tools/dev-workflow-v2/skills/list-review-threads/SKILL.md
+++ b/tools/dev-workflow-v2/skills/list-review-threads/SKILL.md
@@ -6,7 +6,7 @@ description: List unresolved review threads for the pull request recorded in wor
 # List Review Threads
 
 1. Detect the current harness before reading review threads:
-   - If `CODEX_THREAD_ID` is present, run workflow operations from the repository root with `pnpm exec tsx tools/dev-workflow-v2/src/shell/codex-workflow-command.ts <operation> [args]`.
+   - If `CODEX_THREAD_ID` is present, run workflow operations with `pnpm --dir tools/dev-workflow-v2 run codex-workflow <operation> [args]`.
    - Otherwise, run workflow operations with `/dev-workflow-v2:workflow <operation> [args]`.
 1. Run the selected harness's `get-state` workflow operation and extract `prNumber`.
 1. Stop if `prNumber` is missing. Do not infer a PR from the current branch.

--- a/tools/dev-workflow-v2/skills/workflow/SKILL.md
+++ b/tools/dev-workflow-v2/skills/workflow/SKILL.md
@@ -10,7 +10,7 @@ Use the arguments supplied after `$dev-workflow-v2:workflow` as `<operation> [ar
 From the repository root, run:
 
 ```bash
-pnpm exec tsx tools/dev-workflow-v2/src/shell/codex-workflow-command.ts <operation> [args]
+pnpm --dir tools/dev-workflow-v2 run codex-workflow <operation> [args]
 ```
 
 The command reads the active Codex task identifier from `CODEX_THREAD_ID`. Never supply, infer, or copy a session identifier.

--- a/tools/dev-workflow-v2/src/shell/codex-cli.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-cli.ts
@@ -38,9 +38,8 @@ const bashForbidden = {
   flags: ['--no-verify', '--force', '--hard'],
 }
 
-const workflowRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const workflowCommand =
-  'pnpm --dir "$PLUGIN_ROOT" exec tsx "$PLUGIN_ROOT/src/shell/codex-workflow-command.ts"'
+const workflowRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const workflowCommand = 'pnpm --dir "$PLUGIN_ROOT" run codex-workflow'
 const defaultProcessDeps = createDefaultProcessDeps()
 const processDeps = {
   ...defaultProcessDeps,

--- a/tools/dev-workflow-v2/src/shell/codex-workflow-command.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-workflow-command.spec.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const shellDirectory = dirname(fileURLToPath(import.meta.url))
+const workflowCommandPath = join(shellDirectory, '../../dist/codex-workflow-command.js')
+
+describe('Codex workflow command', () => {
+  it('loads the compiled workflow command without source resolution', () => {
+    const result = spawnSync(process.execPath, [workflowCommandPath], {
+      encoding: 'utf8',
+      env: { ...process.env, NODE_OPTIONS: '' },
+    })
+
+    expect(result.stderr).toContain('Codex workflow command requires <operation> [args]')
+    expect(result.stderr).not.toContain('ERR_MODULE_NOT_FOUND')
+  })
+})

--- a/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
@@ -1,5 +1,4 @@
 import { spawnSync } from 'node:child_process'
-import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -36,22 +35,10 @@ const args =
   operationArgs[0] === sessionId || operationArgs[0] === workflowSessionId
     ? operationArgs.slice(1)
     : operationArgs
-const cliPath = join(dirname(fileURLToPath(import.meta.url)), 'codex-cli.ts')
-const require = createRequire(import.meta.url)
-const tsxCliPath = require.resolve('tsx/cli')
-const sourceCondition = '--conditions=@living-architecture/source'
-const nodeOptions = [process.env.NODE_OPTIONS, sourceCondition].filter(Boolean).join(' ')
-const result = spawnSync(
-  process.execPath,
-  [tsxCliPath, cliPath, operation, workflowSessionId, ...args],
-  {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      NODE_OPTIONS: nodeOptions,
-    },
-  },
-)
+const cliPath = join(dirname(fileURLToPath(import.meta.url)), 'codex-cli.js')
+const result = spawnSync(process.execPath, [cliPath, operation, workflowSessionId, ...args], {
+  stdio: 'inherit',
+})
 
 if (result.error !== undefined) {
   throw result.error

--- a/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
@@ -107,7 +107,9 @@ describe('plugin Agent Skills', () => {
 
       expect({
         detectsCodex: skill.includes('If `CODEX_THREAD_ID` is present'),
-        usesCodexRunner: skill.includes('codex-workflow-command.ts <operation> [args]'),
+        usesCodexRunner: skill.includes(
+          'pnpm --dir tools/dev-workflow-v2 run codex-workflow <operation> [args]',
+        ),
         usesSlashCommand: skill.includes('/dev-workflow-v2:workflow <operation> [args]'),
       }).toStrictEqual({
         detectsCodex: true,


### PR DESCRIPTION
## Summary

- build the Codex workflow launcher and CLI before running workflow operations
- route Codex workflow skill instructions through one pnpm command
- update the Codex workflow engine to 0.4.3
- ignore `tsx` in Knip because the Codex hook JSON invokes it

Closes #480

## Verification

- `CI=true pnpm nx test dev-workflow-v2 --skip-nx-cache`
- `CI=true pnpm nx typecheck dev-workflow-v2`
- `CI=true pnpm nx lint dev-workflow-v2`
- `CI=true pnpm verify`