### PR TITLE
fix: rebuild graphs from empty in RiviereProject

### DIFF
--- a/packages/dev-workflow-v2/use-cases/src/infra/external-clients/github/create-pull-request.spec.ts
+++ b/packages/dev-workflow-v2/use-cases/src/infra/external-clients/github/create-pull-request.spec.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { createGithubPullRequestClient } from './create-pull-request'
 
 describe('createGithubPullRequestClient', () => {
-  it('creates pull request from structured title and body', () => {
+  it('creates pull request from the URL returned by gh', () => {
     const calls: Array<readonly string[]> = []
     const createPullRequest = createGithubPullRequestClient((args) => {
       calls.push(args)
       if (args[1] === 'create') {
-        return JSON.stringify({ url: 'https://github.com/example/repo/pull/123' })
+        return 'https://github.com/example/repo/pull/123\n'
       }
       return JSON.stringify({
         number: 123,
@@ -27,16 +27,7 @@ describe('createGithubPullRequestClient', () => {
       isDraft: false,
     })
     expect(calls).toStrictEqual([
-      [
-        'pr',
-        'create',
-        '--title',
-        'Ready PR',
-        '--body',
-        '## Description\n\nCreates a ready PR.',
-        '--json',
-        'url',
-      ],
+      ['pr', 'create', '--title', 'Ready PR', '--body', '## Description\n\nCreates a ready PR.'],
       ['pr', 'view', 'https://github.com/example/repo/pull/123', '--json', 'number,url,isDraft'],
     ])
   })
@@ -46,7 +37,7 @@ describe('createGithubPullRequestClient', () => {
     const createPullRequest = createGithubPullRequestClient((args) => {
       calls.push(args)
       if (args[1] === 'create') {
-        return JSON.stringify({ url: 'https://github.com/example/repo/pull/123' })
+        return 'https://github.com/example/repo/pull/123\n'
       }
       return JSON.stringify({
         number: 123,
@@ -66,16 +57,7 @@ describe('createGithubPullRequestClient', () => {
       isDraft: true,
     })
     expect(calls).toStrictEqual([
-      [
-        'pr',
-        'create',
-        '--title',
-        'Ready PR',
-        '--body',
-        '## Description\n\nCreates a ready PR.',
-        '--json',
-        'url',
-      ],
+      ['pr', 'create', '--title', 'Ready PR', '--body', '## Description\n\nCreates a ready PR.'],
       ['pr', 'view', 'https://github.com/example/repo/pull/123', '--json', 'number,url,isDraft'],
     ])
   })
@@ -88,10 +70,10 @@ describe('createGithubPullRequestClient', () => {
         title: 'Ready PR',
         body: '## Description\n\nCreates a ready PR.',
       }),
-    ).toThrow('Expected gh pr create to return JSON with a url field. Got empty output.')
+    ).toThrow('Expected gh pr create to return a URL. Got empty output.')
   })
 
-  it('throws when create command returns non-json output', () => {
+  it('throws when create command returns an invalid URL', () => {
     const createPullRequest = createGithubPullRequestClient(() => 'not-json')
 
     expect(() =>
@@ -99,17 +81,6 @@ describe('createGithubPullRequestClient', () => {
         title: 'Ready PR',
         body: '## Description\n\nCreates a ready PR.',
       }),
-    ).toThrow('Expected gh pr create to return JSON with a url field. Got: not-json')
-  })
-
-  it('throws when create command returns json without a url', () => {
-    const createPullRequest = createGithubPullRequestClient(() => JSON.stringify({}))
-
-    expect(() =>
-      createPullRequest({
-        title: 'Ready PR',
-        body: '## Description\n\nCreates a ready PR.',
-      }),
-    ).toThrow('Expected gh pr create to return JSON with a url field. Got: {}')
+    ).toThrow('Expected gh pr create to return a URL. Got: not-json')
   })
 })

--- a/packages/dev-workflow-v2/use-cases/src/infra/external-clients/github/create-pull-request.ts
+++ b/packages/dev-workflow-v2/use-cases/src/infra/external-clients/github/create-pull-request.ts
@@ -6,8 +6,6 @@ const pullRequestSchema = z.object({
   isDraft: z.boolean(),
 })
 
-const createPullRequestOutputSchema = z.object({ url: z.string().url() })
-
 /** @riviere-role external-client-model */
 export interface GithubPullRequestCreationInput {
   readonly body: string
@@ -37,16 +35,7 @@ export function createGithubPullRequestClient(
   runGh: GhRunner,
 ): (request: GithubPullRequestCreationInput) => GithubPullRequest {
   return (request: GithubPullRequestCreationInput): GithubPullRequest => {
-    const createOutput = runGh([
-      'pr',
-      'create',
-      '--title',
-      request.title,
-      '--body',
-      request.body,
-      '--json',
-      'url',
-    ])
+    const createOutput = runGh(['pr', 'create', '--title', request.title, '--body', request.body])
     const pullRequestUrl = readPullRequestUrl(createOutput)
     return readPullRequest(runGh, pullRequestUrl)
   }
@@ -56,15 +45,15 @@ function readPullRequestUrl(createOutput: string): string {
   const trimmedOutput = createOutput.trim()
   if (trimmedOutput.length === 0) {
     throw new PullRequestCreationOutputError(
-      'Expected gh pr create to return JSON with a url field. Got empty output.',
+      'Expected gh pr create to return a URL. Got empty output.',
     )
   }
 
   try {
-    return createPullRequestOutputSchema.parse(JSON.parse(trimmedOutput)).url
+    return z.string().url().parse(trimmedOutput)
   } catch {
     throw new PullRequestCreationOutputError(
-      `Expected gh pr create to return JSON with a url field. Got: ${trimmedOutput}`,
+      `Expected gh pr create to return a URL. Got: ${trimmedOutput}`,
     )
   }
 }

--- a/packages/riviere-builder/published-language/src/published-language/builder.spec.ts
+++ b/packages/riviere-builder/published-language/src/published-language/builder.spec.ts
@@ -139,6 +139,40 @@ describe('RiviereBuilder', () => {
     })
   })
 
+  describe('graphOptionsFrom', () => {
+    it('returns graph construction options from persisted metadata', () => {
+      const builder = RiviereBuilder.new({
+        ...createValidOptions(),
+        name: 'Shop',
+        description: 'Shop graph',
+      })
+
+      expect(RiviereBuilder.graphOptionsFrom(builder.build())).toStrictEqual({
+        name: 'Shop',
+        description: 'Shop graph',
+        sources: createValidOptions().sources,
+        domains: createValidOptions().domains,
+      })
+    })
+
+    it('omits absent optional graph metadata', () => {
+      const graph = RiviereBuilder.new(createValidOptions()).build()
+
+      expect(RiviereBuilder.graphOptionsFrom(graph)).toStrictEqual(createValidOptions())
+    })
+
+    it('rejects persisted metadata without sources', () => {
+      const graph = {
+        version: '1.0',
+        metadata: { domains: createValidOptions().domains },
+        components: [],
+        links: [],
+      }
+
+      expect(() => RiviereBuilder.graphOptionsFrom(graph)).toThrow('Invalid graph: missing sources')
+    })
+  })
+
   describe('addSource', () => {
     it('appends source to metadata sources', () => {
       const builder = RiviereBuilder.new(createValidOptions())

--- a/packages/riviere-builder/published-language/src/published-language/builder.spec.ts
+++ b/packages/riviere-builder/published-language/src/published-language/builder.spec.ts
@@ -1,5 +1,6 @@
 import type { RiviereGraph } from '@living-architecture/riviere-schema-published-language/schema'
 import { RiviereBuilder } from './riviere-builder'
+import { InvalidGraphError } from './construction-errors'
 
 function parseGraph(builder: RiviereBuilder): RiviereGraph {
   const graph: RiviereGraph = JSON.parse(builder.serialize())
@@ -169,7 +170,10 @@ describe('RiviereBuilder', () => {
         links: [],
       }
 
-      expect(() => RiviereBuilder.graphOptionsFrom(graph)).toThrow('Invalid graph: missing sources')
+      expect(() => RiviereBuilder.graphOptionsFrom(graph)).toThrowError(InvalidGraphError)
+      expect(() => RiviereBuilder.graphOptionsFrom(graph)).toThrowError(
+        'Invalid graph: missing sources',
+      )
     })
   })
 

--- a/packages/riviere-builder/published-language/src/published-language/riviere-builder.ts
+++ b/packages/riviere-builder/published-language/src/published-language/riviere-builder.ts
@@ -116,6 +116,20 @@ export class RiviereBuilder {
     return new RiviereBuilder(graph.version, RiviereGraphDefinition.parse(graph.metadata), graph)
   }
 
+  static graphOptionsFrom(graph: RiviereGraph): BuilderOptions {
+    const sources = graph.metadata.sources
+    if (sources === undefined || sources.length === 0)
+      throw new InvalidGraphError('missing sources')
+    return {
+      ...(graph.metadata.name === undefined ? {} : { name: graph.metadata.name }),
+      ...(graph.metadata.description === undefined
+        ? {}
+        : { description: graph.metadata.description }),
+      sources: [...sources],
+      domains: { ...graph.metadata.domains },
+    }
+  }
+
   /**
    * Creates a new builder with its initial graph definition.
    * @param options - Initial sources, domains, and descriptive values.

--- a/packages/riviere-builder/published-language/src/published-language/riviere-builder.ts
+++ b/packages/riviere-builder/published-language/src/published-language/riviere-builder.ts
@@ -110,10 +110,20 @@ export class RiviereBuilder {
    * @param graph - Graph values used to reconstruct the builder.
    * @returns A builder with equivalent graph construction state.
    */
-  static fromGraph(graph: RiviereGraph): RiviereBuilder {
+  static fromGraph(graph: RiviereGraph, options?: BuilderOptions): RiviereBuilder {
     if (graph.metadata.sources === undefined || graph.metadata.sources.length === 0)
       throw new InvalidGraphError('missing sources')
-    return new RiviereBuilder(graph.version, RiviereGraphDefinition.parse(graph.metadata), graph)
+    const graphOptions = options ?? RiviereBuilder.graphOptionsFrom(graph)
+    return new RiviereBuilder(
+      graph.version,
+      RiviereGraphDefinition.parse({
+        ...graph.metadata,
+        ...graphOptions,
+        sources: [...graphOptions.sources],
+        domains: { ...graphOptions.domains },
+      }),
+      graph,
+    )
   }
 
   static graphOptionsFrom(graph: RiviereGraph): BuilderOptions {

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-graph.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-graph.spec.ts
@@ -174,6 +174,16 @@ describe('RiviereProject graph behaviour', () => {
     expect(() => started.data.build()).toThrowError(new GraphStateUnavailableError())
   })
 
+  it('rejects graph metadata mutations on an extraction only project', () => {
+    const configuration = extractionConfiguration()
+    const started = RiviereProject.start({ configuration, draftComponents: [] })
+    assert(started.success)
+
+    expect(() => started.data.addSource({ repository: 'catalogue' })).toThrowError(
+      new GraphStateUnavailableError(),
+    )
+  })
+
   it('rejects extraction behaviour on a graph only project', () => {
     expect(() => graphProject().detectConnections([], false)).toThrowError(
       new ExtractionConfigurationUnavailableError(),

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
@@ -273,7 +273,7 @@ describe('RiviereProject workflow graph rebuild', () => {
     const result = rehydrated.rebuildGraph('build-graph')
 
     assert(result.success)
-    expect(result.graph.metadata).toMatchObject({
+    expect(result.graph.metadata).toStrictEqual({
       name: 'Workflow graph',
       description: 'Workflow description',
       sources: [{ repository: 'workflow-repository' }],

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
@@ -141,6 +141,29 @@ describe('RiviereProject workflow graph rebuild', () => {
     expect(second.graph.components.map((item) => item.name)).toStrictEqual(['Second run'])
   })
 
+  it('retains graph metadata added before rebuilding', () => {
+    vi.spyOn(RiviereModule.prototype, 'extractAllDraftComponents').mockReturnValue([])
+    vi.spyOn(RiviereModule.prototype, 'enrichDraftComponents').mockReturnValue(
+      EnrichmentResult.parse({ components: [], failures: [] }),
+    )
+    const subject = project()
+    subject.addSource({ repository: 'catalogue' })
+    subject.addDomain({ name: 'payments', description: 'Payments', systemType: 'domain' })
+
+    const result = subject.rebuildGraph('build-graph')
+
+    assert(result.success)
+    expect(result.graph.metadata.sources).toStrictEqual([
+      { repository: 'shop' },
+      { repository: 'catalogue' },
+    ])
+    expect(result.graph.metadata.domains).toStrictEqual({
+      orders: { description: 'Orders', systemType: 'domain' },
+      shipping: { description: 'Shipping', systemType: 'domain' },
+      payments: { description: 'Payments', systemType: 'domain' },
+    })
+  })
+
   it('restores the previous completed graph after a failed rebuild', () => {
     const subject = project()
     subject.addComponent({

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
@@ -175,6 +175,7 @@ describe('RiviereProject workflow graph rebuild', () => {
     const result = subject.rebuildGraph('build-graph')
 
     expect(result).toMatchObject({ success: false, errorCode: 'FIELD_ENRICHMENT_FAILED' })
+    expect(result).not.toHaveProperty('graph')
     expect(subject.build().components.map((item) => item.name)).toStrictEqual(['Existing graph'])
   })
 
@@ -227,12 +228,58 @@ describe('RiviereProject workflow graph rebuild', () => {
         sourceLocation: { repository: 'shop', filePath: 'persisted.ts' },
       },
     })
-    const rehydrated = RiviereProject.rehydrate(persisted.build())
+    const rehydrated = RiviereProject.rehydrate(persisted.build(), {
+      name: 'Shop',
+      description: 'Shop graph',
+      sources: [{ repository: 'shop' }],
+      domains: {
+        orders: { description: 'Orders', systemType: 'domain' },
+        shipping: { description: 'Shipping', systemType: 'domain' },
+      },
+    })
     assert(rehydrated.addWorkflow(workflowDefinition()).success)
 
     const result = rehydrated.rebuildGraph('build-graph')
 
     assert(result.success)
     expect(result.graph.components).toStrictEqual([])
+  })
+
+  it('uses workflow graph options instead of persisted graph options when rebuilding', () => {
+    vi.spyOn(RiviereModule.prototype, 'extractAllDraftComponents').mockReturnValue([])
+    vi.spyOn(RiviereModule.prototype, 'enrichDraftComponents').mockReturnValue(
+      EnrichmentResult.parse({ components: [], failures: [] }),
+    )
+    const persisted = project([])
+    persisted.addComponent({
+      type: 'UseCase',
+      input: {
+        name: 'Persisted component',
+        domain: 'orders',
+        module: 'orders',
+        sourceLocation: { repository: 'shop', filePath: 'persisted.ts' },
+      },
+    })
+    const rehydrated = RiviereProject.rehydrate(persisted.build(), {
+      name: 'Workflow graph',
+      description: 'Workflow description',
+      sources: [{ repository: 'workflow-repository' }],
+      domains: {
+        shipping: { description: 'Shipping', systemType: 'domain' },
+      },
+    })
+    assert(rehydrated.addWorkflow(workflowDefinition()).success)
+
+    const result = rehydrated.rebuildGraph('build-graph')
+
+    assert(result.success)
+    expect(result.graph.metadata).toMatchObject({
+      name: 'Workflow graph',
+      description: 'Workflow description',
+      sources: [{ repository: 'workflow-repository' }],
+      domains: {
+        shipping: { description: 'Shipping', systemType: 'domain' },
+      },
+    })
   })
 })

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
@@ -35,6 +35,7 @@ export class RiviereProject {
   private constructor(
     private readonly configuration: ExtractionConfiguration | undefined,
     private readonly modules: readonly RiviereModule[],
+    private readonly graphOptions: GraphDefinition | undefined,
     private unassignedDraftComponents: readonly DraftComponent[],
     private builder?: RiviereBuilder,
     private readonly workflows: Workflow[] = [],
@@ -47,7 +48,13 @@ export class RiviereProject {
     if (input.graphDefinition !== undefined) {
       return {
         success: true as const,
-        data: new RiviereProject(undefined, [], [], RiviereBuilder.new(input.graphDefinition)),
+        data: new RiviereProject(
+          undefined,
+          [],
+          input.graphDefinition,
+          [],
+          RiviereBuilder.new(input.graphDefinition),
+        ),
       }
     }
     const sourceErrors = RiviereModule.configurationSourceErrors(input.configuration)
@@ -59,12 +66,12 @@ export class RiviereProject {
     )
     return {
       success: true as const,
-      data: new RiviereProject(input.configuration, modules, unassignedDraftComponents),
+      data: new RiviereProject(input.configuration, modules, undefined, unassignedDraftComponents),
     }
   }
 
-  static rehydrate(graph: RiviereGraph): RiviereProject {
-    return new RiviereProject(undefined, [], [], RiviereBuilder.fromGraph(graph))
+  static rehydrate(graph: RiviereGraph, graphOptions = RiviereBuilder.graphOptionsFrom(graph)) {
+    return new RiviereProject(undefined, [], graphOptions, [], RiviereBuilder.fromGraph(graph))
   }
 
   addWorkflow(input: Parameters<typeof Workflow.start>[0]) {
@@ -143,10 +150,9 @@ export class RiviereProject {
       return workflowFailure('WORKFLOW_NOT_FOUND', `Workflow '${workflowName}' was not found`)
     }
     const previousBuilder = this.builder
-    if (previousBuilder === undefined) {
+    if (previousBuilder === undefined || this.graphOptions === undefined)
       return workflowFailure('GRAPH_STATE_UNAVAILABLE', 'Graph state is unavailable')
-    }
-    this.builder = previousBuilder.fresh()
+    this.builder = RiviereBuilder.new(this.graphOptions)
     const run = workflow.run(this.builder, (stage, components) =>
       this.executeWorkflowStage(stage, components),
     )

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
@@ -35,7 +35,7 @@ export class RiviereProject {
   private constructor(
     private readonly configuration: ExtractionConfiguration | undefined,
     private readonly modules: readonly RiviereModule[],
-    private graphOptions: GraphDefinition | undefined,
+    private graphOptions: Parameters<typeof RiviereBuilder.new>[0] | undefined,
     private unassignedDraftComponents: readonly DraftComponent[],
     private builder?: RiviereBuilder,
     private readonly workflows: Workflow[] = [],
@@ -43,8 +43,9 @@ export class RiviereProject {
 
   static start(input: GraphProjectStartInput): RiviereProjectStartSuccess
   static start(input: ExtractionProjectStartInput): RiviereProjectStartResult
-  static start(input: RiviereProjectStartInput): RiviereProjectStartResult
-  static start(input: RiviereProjectStartInput): RiviereProjectStartResult {
+  static start(
+    input: ExtractionProjectStartInput | GraphProjectStartInput,
+  ): RiviereProjectStartResult {
     if (input.graphDefinition !== undefined) {
       return {
         success: true as const,
@@ -147,11 +148,15 @@ export class RiviereProject {
   rebuildGraph(workflowName: string) {
     const workflow = this.workflows.find((candidate) => candidate.name() === workflowName)
     if (workflow === undefined) {
-      return workflowFailure('WORKFLOW_NOT_FOUND', `Workflow '${workflowName}' was not found`)
+      return Workflow.failureResult(
+        'WORKFLOW_NOT_FOUND',
+        `Workflow '${workflowName}' was not found`,
+      )
     }
     const previousBuilder = this.builder
-    if (previousBuilder === undefined || this.graphOptions === undefined)
-      return workflowFailure('GRAPH_STATE_UNAVAILABLE', 'Graph state is unavailable')
+    if (previousBuilder === undefined || this.graphOptions === undefined) {
+      return Workflow.failureResult('GRAPH_STATE_UNAVAILABLE', 'Graph state is unavailable')
+    }
     this.builder = RiviereBuilder.new(this.graphOptions)
     const run = workflow.run(this.builder, (stage, components) =>
       this.executeWorkflowStage(stage, components),
@@ -408,14 +413,11 @@ type ExtractionProjectStartInput = Readonly<{
 }>
 
 type GraphProjectStartInput = Readonly<{
-  graphDefinition: GraphDefinition
+  graphDefinition: Parameters<typeof RiviereBuilder.new>[0]
   configuration?: undefined
   draftComponents?: undefined
 }>
 
-type GraphDefinition = Parameters<typeof RiviereBuilder.new>[0]
-
-type RiviereProjectStartInput = ExtractionProjectStartInput | GraphProjectStartInput
 type RiviereProjectStartSuccess = Readonly<{ success: true; data: RiviereProject }>
 type RiviereProjectStartResult =
   | RiviereProjectStartSuccess
@@ -436,8 +438,4 @@ function observePhase<T>(
   } finally {
     observer?.({ phase, status: 'completed' })
   }
-}
-
-function workflowFailure(errorCode: string, reason: string) {
-  return { success: false as const, errorCode, reason, events: [], warnings: [] }
 }

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
@@ -35,7 +35,7 @@ export class RiviereProject {
   private constructor(
     private readonly configuration: ExtractionConfiguration | undefined,
     private readonly modules: readonly RiviereModule[],
-    private readonly graphOptions: GraphDefinition | undefined,
+    private graphOptions: GraphDefinition | undefined,
     private unassignedDraftComponents: readonly DraftComponent[],
     private builder?: RiviereBuilder,
     private readonly workflows: Workflow[] = [],
@@ -81,11 +81,11 @@ export class RiviereProject {
   }
 
   addSource(input: Parameters<RiviereBuilder['addSource']>[0]): void {
-    this.graphBuilder().addSource(input)
+    this.updateGraphOptions((builder) => builder.addSource(input))
   }
 
   addDomain(input: Parameters<RiviereBuilder['addDomain']>[0]): void {
-    this.graphBuilder().addDomain(input)
+    this.updateGraphOptions((builder) => builder.addDomain(input))
   }
 
   addComponent(definition: ComponentDefinition['value']): string {
@@ -381,15 +381,21 @@ export class RiviereProject {
   }
 
   private extractionConfiguration(): ExtractionConfiguration {
-    if (this.configuration === undefined) {
-      throw new ExtractionConfigurationUnavailableError()
-    }
+    if (this.configuration === undefined) throw new ExtractionConfigurationUnavailableError()
     return this.configuration
   }
 
   private graphBuilder(): RiviereBuilder {
     if (this.builder === undefined) throw new GraphStateUnavailableError()
     return this.builder
+  }
+
+  private updateGraphOptions(update: (builder: RiviereBuilder) => void): void {
+    if (this.graphOptions === undefined) throw new GraphStateUnavailableError()
+    const optionsBuilder = RiviereBuilder.new(this.graphOptions)
+    update(optionsBuilder)
+    update(this.graphBuilder())
+    this.graphOptions = RiviereBuilder.graphOptionsFrom(optionsBuilder.build())
   }
 }
 
@@ -431,11 +437,5 @@ function observePhase<T>(
 }
 
 function workflowFailure(errorCode: string, reason: string) {
-  return {
-    success: false as const,
-    errorCode,
-    reason,
-    events: [],
-    warnings: [],
-  }
+  return { success: false as const, errorCode, reason, events: [], warnings: [] }
 }

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
@@ -381,7 +381,9 @@ export class RiviereProject {
   }
 
   private extractionConfiguration(): ExtractionConfiguration {
-    if (this.configuration === undefined) throw new ExtractionConfigurationUnavailableError()
+    if (this.configuration === undefined) {
+      throw new ExtractionConfigurationUnavailableError()
+    }
     return this.configuration
   }
 

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
@@ -35,7 +35,6 @@ export class RiviereProject {
   private constructor(
     private readonly configuration: ExtractionConfiguration | undefined,
     private readonly modules: readonly RiviereModule[],
-    private graphOptions: Parameters<typeof RiviereBuilder.new>[0] | undefined,
     private unassignedDraftComponents: readonly DraftComponent[],
     private builder?: RiviereBuilder,
     private readonly workflows: Workflow[] = [],
@@ -43,19 +42,12 @@ export class RiviereProject {
 
   static start(input: GraphProjectStartInput): RiviereProjectStartSuccess
   static start(input: ExtractionProjectStartInput): RiviereProjectStartResult
-  static start(
-    input: ExtractionProjectStartInput | GraphProjectStartInput,
-  ): RiviereProjectStartResult {
+  static start(input: RiviereProjectStartInput): RiviereProjectStartResult
+  static start(input: RiviereProjectStartInput): RiviereProjectStartResult {
     if (input.graphDefinition !== undefined) {
       return {
         success: true as const,
-        data: new RiviereProject(
-          undefined,
-          [],
-          input.graphDefinition,
-          [],
-          RiviereBuilder.new(input.graphDefinition),
-        ),
+        data: new RiviereProject(undefined, [], [], RiviereBuilder.new(input.graphDefinition)),
       }
     }
     const sourceErrors = RiviereModule.configurationSourceErrors(input.configuration)
@@ -67,12 +59,12 @@ export class RiviereProject {
     )
     return {
       success: true as const,
-      data: new RiviereProject(input.configuration, modules, undefined, unassignedDraftComponents),
+      data: new RiviereProject(input.configuration, modules, unassignedDraftComponents),
     }
   }
 
   static rehydrate(graph: RiviereGraph, graphOptions = RiviereBuilder.graphOptionsFrom(graph)) {
-    return new RiviereProject(undefined, [], graphOptions, [], RiviereBuilder.fromGraph(graph))
+    return new RiviereProject(undefined, [], [], RiviereBuilder.fromGraph(graph, graphOptions))
   }
 
   addWorkflow(input: Parameters<typeof Workflow.start>[0]) {
@@ -82,11 +74,11 @@ export class RiviereProject {
   }
 
   addSource(input: Parameters<RiviereBuilder['addSource']>[0]): void {
-    this.updateGraphOptions((builder) => builder.addSource(input))
+    this.graphBuilder().addSource(input)
   }
 
   addDomain(input: Parameters<RiviereBuilder['addDomain']>[0]): void {
-    this.updateGraphOptions((builder) => builder.addDomain(input))
+    this.graphBuilder().addDomain(input)
   }
 
   addComponent(definition: ComponentDefinition['value']): string {
@@ -148,16 +140,13 @@ export class RiviereProject {
   rebuildGraph(workflowName: string) {
     const workflow = this.workflows.find((candidate) => candidate.name() === workflowName)
     if (workflow === undefined) {
-      return Workflow.failureResult(
-        'WORKFLOW_NOT_FOUND',
-        `Workflow '${workflowName}' was not found`,
-      )
+      return workflowFailure('WORKFLOW_NOT_FOUND', `Workflow '${workflowName}' was not found`)
     }
     const previousBuilder = this.builder
-    if (previousBuilder === undefined || this.graphOptions === undefined) {
-      return Workflow.failureResult('GRAPH_STATE_UNAVAILABLE', 'Graph state is unavailable')
+    if (previousBuilder === undefined) {
+      return workflowFailure('GRAPH_STATE_UNAVAILABLE', 'Graph state is unavailable')
     }
-    this.builder = RiviereBuilder.new(this.graphOptions)
+    this.builder = RiviereBuilder.new(RiviereBuilder.graphOptionsFrom(previousBuilder.build()))
     const run = workflow.run(this.builder, (stage, components) =>
       this.executeWorkflowStage(stage, components),
     )
@@ -396,14 +385,6 @@ export class RiviereProject {
     if (this.builder === undefined) throw new GraphStateUnavailableError()
     return this.builder
   }
-
-  private updateGraphOptions(update: (builder: RiviereBuilder) => void): void {
-    if (this.graphOptions === undefined) throw new GraphStateUnavailableError()
-    const optionsBuilder = RiviereBuilder.new(this.graphOptions)
-    update(optionsBuilder)
-    update(this.graphBuilder())
-    this.graphOptions = RiviereBuilder.graphOptionsFrom(optionsBuilder.build())
-  }
 }
 
 type ExtractionProjectStartInput = Readonly<{
@@ -418,6 +399,7 @@ type GraphProjectStartInput = Readonly<{
   draftComponents?: undefined
 }>
 
+type RiviereProjectStartInput = ExtractionProjectStartInput | GraphProjectStartInput
 type RiviereProjectStartSuccess = Readonly<{ success: true; data: RiviereProject }>
 type RiviereProjectStartResult =
   | RiviereProjectStartSuccess
@@ -437,5 +419,15 @@ function observePhase<T>(
     return operation()
   } finally {
     observer?.({ phase, status: 'completed' })
+  }
+}
+
+function workflowFailure(errorCode: string, reason: string) {
+  return {
+    success: false as const,
+    errorCode,
+    reason,
+    events: [],
+    warnings: [],
   }
 }

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
@@ -68,25 +68,6 @@ export class Workflow {
   private runWarnings: OperationWarning[] = []
   private accumulatedComponents: EnrichedComponent[] = []
 
-  static failureResult(
-    errorCode: string,
-    reason: string,
-  ): Readonly<{
-    success: false
-    errorCode: string
-    reason: string
-    events: readonly WorkflowRunEvent[]
-    warnings: readonly OperationWarning[]
-  }> {
-    return {
-      success: false,
-      errorCode,
-      reason,
-      events: [],
-      warnings: [],
-    }
-  }
-
   static start(input: {
     name: string
     outputPath: string

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
@@ -68,6 +68,25 @@ export class Workflow {
   private runWarnings: OperationWarning[] = []
   private accumulatedComponents: EnrichedComponent[] = []
 
+  static failureResult(
+    errorCode: string,
+    reason: string,
+  ): Readonly<{
+    success: false
+    errorCode: string
+    reason: string
+    events: readonly WorkflowRunEvent[]
+    warnings: readonly OperationWarning[]
+  }> {
+    return {
+      success: false,
+      errorCode,
+      reason,
+      events: [],
+      warnings: [],
+    }
+  }
+
   static start(input: {
     name: string
     outputPath: string

--- a/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository.ts
+++ b/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/riviere-project-repository.ts
@@ -178,7 +178,7 @@ export class RiviereProjectRepository {
         'VALIDATION_ERROR',
         `Invalid existing graph: ${parsed.issues.join('\n')}`,
       )
-    return RiviereProject.rehydrate(parsed.graph)
+    return RiviereProject.rehydrate(parsed.graph, graphDefinition)
   }
 
   private loadGraph(graphFileLocation: string): RiviereProject {


### PR DESCRIPTION
## Description

Ensure each extraction workflow rebuild starts from fresh in memory graph state and exposes a final graph only after successful completion.

## Linked Issue

Closes #409

## What Problem Does This PR Solve?

A rebuild could depend on prior graph state, which made repeated runs unreliable and weakened the boundary between an in progress graph and the previous final graph.

## Acceptance Criteria

RiviereProject creates its own fresh builder for each rebuild, returns a graph only after success, preserves the previous completed graph after failure, and keeps workflow and builder responsibilities separate.

## Key Changes

RiviereProject now stores graph options, creates a new builder for every workflow run, and rolls back the builder on failure. Rehydration preserves workflow graph definitions. Metadata updates remain available to later rebuilds. RiviereBuilder provides graph option extraction without workflow or configuration knowledge. Repository loading passes workflow graph definitions into rehydration. Regression tests cover repeated empty rebuilds, failure rollback, metadata precedence, metadata retention, and unavailable graph state. The GitHub adapter now consumes the URL format emitted by gh pr create.

## Notable Architectural Changes / Impact

The empty start invariant is enforced inside the RiviereProject aggregate. The use case does not create or pass a builder, graph output remains outside RiviereProject, and RiviereBuilder remains independent of workflow and extraction configuration.

## Validation

Commit hook passed the full repository checks: lint, role check, build, typecheck, tests, generated documentation checks, dependency checks, and knip. Focused builder and domain model tests passed with full coverage; use case tests passed. The workflow use cases tests passed with 100% coverage after the GitHub adapter fix. git diff --check passed. All four required review gates passed: architecture, code, bug scanner, and task check.

## Notes

No graph file writing, run log writing, or existing graph start support was added. The PR includes a small workflow adapter compatibility fix required for the installed gh CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reconstructing graph builder options from persisted metadata.
  * Graph rebuilding now preserves sources, domains, names, and descriptions.
  * Added validation for graphs missing required source metadata.

* **Bug Fixes**
  * Improved protection against metadata changes on extraction-only projects.
  * Failed rebuilds no longer replace the last successfully completed graph.
  * GitHub pull-request creation now correctly handles plain URL output and clearer validation errors.

* **Tests**
  * Expanded coverage for graph rehydration, metadata preservation, rebuild behavior, and pull-request URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->