### PR TITLE
Execute extract, link, and validate against an accumulated in memory graph

### DIFF
--- a/packages/riviere-extract-ts/domain-model/src/domain/connection-detection/connection-detection-result.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/connection-detection/connection-detection-result.spec.ts
@@ -43,4 +43,20 @@ describe('ConnectionDetectionResult', () => {
       externalLinks,
     )
   })
+
+  it('combines results from several extraction contexts', () => {
+    const first = ConnectionDetectionResult.parse({
+      links: [ExtractedLink.parse({ source: 'orders:api:orders', target: 'orders:usecase:list' })],
+      externalLinks: [],
+    })
+    const second = ConnectionDetectionResult.parse({
+      links: [],
+      externalLinks: [{ source: 'orders:api:orders', target: { name: 'payments' } }],
+    })
+
+    expect(ConnectionDetectionResult.combine([first, second])).toMatchObject({
+      links: first.links,
+      externalLinks: second.externalLinks,
+    })
+  })
 })

--- a/packages/riviere-extract-ts/domain-model/src/domain/connection-detection/connection-detection-result.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/connection-detection/connection-detection-result.ts
@@ -14,6 +14,13 @@ export class ConnectionDetectionResult {
     return new ConnectionDetectionResult(params)
   }
 
+  static combine(results: readonly ConnectionDetectionResult[]): ConnectionDetectionResult {
+    return ConnectionDetectionResult.parse({
+      links: results.flatMap((result) => result.links),
+      externalLinks: results.flatMap((result) => result.externalLinks),
+    })
+  }
+
   private constructor(params: {
     links: readonly ExtractedLink[]
     externalLinks: readonly ExternalLink[]

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
@@ -57,6 +57,7 @@ function component(domain: string, name: string): EnrichedComponent {
 function workflowDefinition(
   orderConfig = configuration('orders'),
   shippingConfig = configuration('shipping'),
+  linkConfig = orderConfig,
 ) {
   return {
     name: 'build-graph',
@@ -65,7 +66,7 @@ function workflowDefinition(
     stages: [
       WorkflowStage.fromExtraction('extract-orders', orderConfig),
       WorkflowStage.fromExtraction('extract-shipping', shippingConfig),
-      WorkflowStage.fromLink('link', orderConfig),
+      WorkflowStage.fromLink('link', linkConfig),
       WorkflowStage.fromValidation('validate'),
     ],
   }
@@ -116,6 +117,26 @@ describe('RiviereProject workflow graph rebuild', () => {
       runLogDirectory: '/project/.riviere/logs/workflows',
       warnings: [],
     })
+    expect(subject.build()).toStrictEqual(result.graph)
+  })
+
+  it('detects links through the configurations that completed extraction', () => {
+    const orders = configuration('orders')
+    const shipping = configuration('shipping')
+    const link = configuration('link-rules')
+    const fromConfiguration = vi.spyOn(RiviereModule, 'fromConfiguration')
+    vi.spyOn(RiviereModule.prototype, 'extractAllDraftComponents').mockReturnValue([])
+    vi.spyOn(RiviereModule.prototype, 'enrichDraftComponents').mockReturnValue(
+      EnrichmentResult.parse({ components: [], failures: [] }),
+    )
+    const subject = project([workflowDefinition(orders, shipping, link)])
+
+    const result = subject.rebuildGraph('build-graph')
+
+    assert(result.success)
+    expect(fromConfiguration.mock.calls.map(([configuration]) => configuration.name)).toStrictEqual(
+      ['orders', 'shipping', 'orders', 'shipping'],
+    )
   })
 
   it('starts repeated runs with fresh graph construction state', () => {
@@ -164,7 +185,7 @@ describe('RiviereProject workflow graph rebuild', () => {
     })
   })
 
-  it('restores the previous completed graph after a failed rebuild', () => {
+  it('leaves the previous completed graph unchanged after a failed rebuild', () => {
     const subject = project()
     subject.addComponent({
       type: 'UseCase',

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts
@@ -142,21 +142,18 @@ export class RiviereProject {
     if (workflow === undefined) {
       return workflowFailure('WORKFLOW_NOT_FOUND', `Workflow '${workflowName}' was not found`)
     }
-    const previousBuilder = this.builder
-    if (previousBuilder === undefined) {
+    const currentBuilder = this.builder
+    if (currentBuilder === undefined) {
       return workflowFailure('GRAPH_STATE_UNAVAILABLE', 'Graph state is unavailable')
     }
-    this.builder = RiviereBuilder.new(RiviereBuilder.graphOptionsFrom(previousBuilder.build()))
-    const run = workflow.run(this.builder, (stage, components) =>
-      this.executeWorkflowStage(stage, components),
+    const run = workflow.run(currentBuilder, (stage, components, executedExtractions) =>
+      this.executeWorkflowStage(stage, components, executedExtractions),
     )
-    if (!run.success) {
-      this.builder = previousBuilder
-      return run
-    }
+    if (!run.success) return run
+    this.builder = run.builder
     return {
       success: true as const,
-      graph: this.graphBuilder().build(),
+      graph: run.builder.build(),
       outputPath: workflow.outputPath(),
       runLogDirectory: workflow.runLogDirectory(),
       events: run.events,
@@ -167,12 +164,17 @@ export class RiviereProject {
   private executeWorkflowStage(
     stage: Exclude<WorkflowStageValue, { kind: 'validate' }>,
     accumulatedComponents: readonly EnrichedComponent[],
+    executedExtractions: readonly ExtractionConfiguration[],
   ) {
     switch (stage.kind) {
       case 'extract':
         return this.executeExtractionStage(stage.configuration)
       case 'link':
-        return this.executeLinkStage(stage.configuration, accumulatedComponents)
+        return this.executeLinkStage(
+          stage.configuration,
+          executedExtractions,
+          accumulatedComponents,
+        )
     }
   }
 
@@ -198,11 +200,15 @@ export class RiviereProject {
   }
 
   private executeLinkStage(
-    configuration: ExtractionConfiguration,
+    linkConfiguration: ExtractionConfiguration,
+    executedExtractions: readonly ExtractionConfiguration[],
     components: readonly EnrichedComponent[],
   ) {
-    const modules = RiviereModule.fromConfiguration(configuration, [])
-    const connections = this.detectConnectionsUsing(configuration, modules, components, false)
+    const detectedConnections = executedExtractions.map((extraction) => {
+      const modules = RiviereModule.fromConfiguration(extraction, [])
+      return this.detectConnectionsUsing(linkConfiguration, modules, components, false)
+    })
+    const connections = ConnectionDetectionResult.combine(detectedConnections)
     return { success: true as const, kind: 'connections' as const, connections }
   }
 

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow-state.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow-state.spec.ts
@@ -1,0 +1,42 @@
+import { RiviereBuilder } from '@living-architecture/riviere-builder-published-language'
+import { describe, expect, it } from 'vitest'
+import { WorkflowState } from './workflow-state'
+
+function builder(): RiviereBuilder {
+  return RiviereBuilder.new({
+    name: 'Shop',
+    description: 'Shop graph',
+    sources: [{ repository: 'shop' }],
+    domains: { orders: { description: 'Orders', systemType: 'domain' } },
+  })
+}
+
+describe('WorkflowState', () => {
+  it('creates a candidate builder without changing the supplied graph', () => {
+    const currentBuilder = builder()
+    currentBuilder.addUseCase({
+      name: 'Existing graph',
+      domain: 'orders',
+      module: 'orders',
+      sourceLocation: { repository: 'shop', filePath: 'existing.ts' },
+    })
+
+    const state = WorkflowState.fromBuilder(currentBuilder)
+    state.builder().addUseCase({
+      name: 'Workflow graph',
+      domain: 'orders',
+      module: 'orders',
+      sourceLocation: { repository: 'shop', filePath: 'workflow.ts' },
+    })
+
+    expect(currentBuilder.build().components.map((item) => item.name)).toStrictEqual([
+      'Existing graph',
+    ])
+    expect(
+      state
+        .builder()
+        .build()
+        .components.map((item) => item.name),
+    ).toStrictEqual(['Workflow graph'])
+  })
+})

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow-state.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow-state.ts
@@ -1,0 +1,128 @@
+import {
+  type OperationWarning,
+  RiviereBuilder,
+} from '@living-architecture/riviere-builder-published-language'
+import type { ExtractionConfiguration } from './extraction-configuration'
+import type { EnrichedComponent } from './value-extraction/enriched-component'
+import { WorkflowRunEvent } from './workflow-run-event'
+import type { WorkflowStageValue } from './workflow-stage'
+
+type WorkflowStatus = 'ready' | 'running' | 'completed' | 'failed'
+
+type WorkflowStageEventValues = Readonly<{
+  name: string
+  kind: WorkflowStageValue['kind']
+  index: number
+}>
+
+/**
+ * @riviere-role value-object
+ * @riviere-role-justification The state has no identity outside its owning Workflow. It contains the transient graph value for one run and is replaced on each workflow transition.
+ */
+export class WorkflowState {
+  declare private readonly brand: 'WorkflowState'
+
+  static fromBuilder(builder: RiviereBuilder): WorkflowState {
+    return new WorkflowState('running', builder.fresh(), [
+      WorkflowRunEvent.fromWorkflow('WorkflowStarted'),
+    ])
+  }
+
+  private constructor(
+    private readonly currentStatus: WorkflowStatus,
+    private readonly intermediateBuilder: RiviereBuilder,
+    private readonly runEvents: readonly WorkflowRunEvent[],
+    private readonly runWarnings: readonly OperationWarning[] = [],
+    private readonly components: readonly EnrichedComponent[] = [],
+    private readonly extractions: readonly ExtractionConfiguration[] = [],
+  ) {}
+
+  status(): WorkflowStatus {
+    return this.currentStatus
+  }
+
+  builder(): RiviereBuilder {
+    return this.intermediateBuilder
+  }
+
+  accumulatedComponents(): readonly EnrichedComponent[] {
+    return this.components
+  }
+
+  executedExtractions(): readonly ExtractionConfiguration[] {
+    return this.extractions
+  }
+
+  events(): readonly WorkflowRunEvent[] {
+    return this.runEvents
+  }
+
+  warnings(): readonly OperationWarning[] {
+    return this.runWarnings
+  }
+
+  startStage(values: WorkflowStageEventValues): WorkflowState {
+    return this.withEvents(WorkflowRunEvent.fromStage('StageStarted', values))
+  }
+
+  completeStage(
+    stage: WorkflowStageValue,
+    values: WorkflowStageEventValues,
+    extractedComponents: readonly EnrichedComponent[] | undefined,
+    warnings: readonly OperationWarning[],
+  ): WorkflowState {
+    const completedExtractions =
+      stage.kind === 'extract' && extractedComponents !== undefined
+        ? [...this.extractions, stage.configuration]
+        : this.extractions
+    const accumulatedComponents =
+      stage.kind === 'extract' && extractedComponents !== undefined
+        ? [...this.components, ...extractedComponents]
+        : this.components
+    return new WorkflowState(
+      this.currentStatus,
+      this.intermediateBuilder,
+      [...this.runEvents, WorkflowRunEvent.fromStage('StageCompleted', values)],
+      [...this.runWarnings, ...warnings],
+      accumulatedComponents,
+      completedExtractions,
+    )
+  }
+
+  fail(values: WorkflowStageEventValues, reason: string, errorCode: string): WorkflowState {
+    return new WorkflowState(
+      'failed',
+      this.intermediateBuilder,
+      [
+        ...this.runEvents,
+        WorkflowRunEvent.fromStageFailure(values, reason, errorCode),
+        WorkflowRunEvent.fromWorkflowFailure(reason, errorCode),
+      ],
+      this.runWarnings,
+      this.components,
+      this.extractions,
+    )
+  }
+
+  complete(): WorkflowState {
+    return new WorkflowState(
+      'completed',
+      this.intermediateBuilder,
+      [...this.runEvents, WorkflowRunEvent.fromWorkflow('WorkflowCompleted')],
+      this.runWarnings,
+      this.components,
+      this.extractions,
+    )
+  }
+
+  private withEvents(event: WorkflowRunEvent): WorkflowState {
+    return new WorkflowState(
+      this.currentStatus,
+      this.intermediateBuilder,
+      [...this.runEvents, event],
+      this.runWarnings,
+      this.components,
+      this.extractions,
+    )
+  }
+}

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
@@ -1,4 +1,7 @@
-import { RiviereBuilder } from '@living-architecture/riviere-builder-published-language'
+import {
+  ComponentId,
+  RiviereBuilder,
+} from '@living-architecture/riviere-builder-published-language'
 import { ValidatedConfiguration } from '@living-architecture/riviere-extract-config-published-language'
 import { ValidationResult } from '@living-architecture/riviere-schema-published-language/graph-validation'
 import { Project } from 'ts-morph'
@@ -193,39 +196,46 @@ describe('Workflow.run', () => {
         return { success: true, kind: 'components', components, repository: 'shop' }
       }
       expect(accumulated).toStrictEqual(components)
-      const graph = graphBuilder.build()
-      const source = graph.components[0]
-      const target = graph.components[1]
-      assert(source)
-      assert(target)
+      const source = ComponentId.parseFromParts({
+        domain: 'orders',
+        module: 'orders',
+        type: 'ui',
+        name: 'Orders page',
+      }).toString()
+      const target = ComponentId.parseFromParts({
+        domain: 'orders',
+        module: 'orders',
+        type: 'api',
+        name: 'Orders API',
+      }).toString()
       return {
         success: true,
         kind: 'connections',
         connections: ConnectionDetectionResult.parse({
           links: [
             ExtractedLink.parse({
-              source: source.id,
-              target: target.id,
+              source,
+              target,
               type: 'sync',
               sourceLocation: { repository: 'shop', filePath: 'orders.ts', lineNumber: 4 },
             }),
-            ExtractedLink.parse({ source: target.id, target: source.id }),
+            ExtractedLink.parse({ source: target, target: source }),
           ],
           externalLinks: [
             {
-              source: source.id,
+              source,
               target: { name: 'Payments API', repository: 'payments' },
               type: 'sync',
               description: 'Charges the order',
               sourceLocation: { repository: 'shop', filePath: 'orders.ts', lineNumber: 5 },
             },
             {
-              source: source.id,
+              source,
               target: { name: 'Payments API', repository: 'payments' },
               type: 'sync',
             },
             {
-              source: target.id,
+              source: target,
               target: { name: 'Search API' },
             },
           ],
@@ -234,7 +244,7 @@ describe('Workflow.run', () => {
     })
 
     assert(result.success)
-    expect(graphBuilder.build()).toMatchObject({
+    expect(result.builder.build()).toMatchObject({
       components: expect.arrayContaining([
         expect.objectContaining({ type: 'UI' }),
         expect.objectContaining({ type: 'API' }),
@@ -374,7 +384,9 @@ describe('Workflow.run', () => {
       ...graphBuilder.build(),
       links: [{ source: 'missing', target: 'also-missing', type: 'sync' as const }],
     }
-    vi.spyOn(graphBuilder, 'validate').mockReturnValue(ValidationResult.parse(invalidGraph))
+    vi.spyOn(RiviereBuilder.prototype, 'validate').mockReturnValue(
+      ValidationResult.parse(invalidGraph),
+    )
 
     const result = workflow().run(graphBuilder, (stage) =>
       stage.kind === 'extract'

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts
@@ -9,8 +9,7 @@ import type { EnrichedComponent } from './value-extraction/enriched-component'
 import { WorkflowDefinitionFailure } from './workflow-definition-failure'
 import { WorkflowRunEvent } from './workflow-run-event'
 import type { WorkflowStage, WorkflowStageValue } from './workflow-stage'
-
-type WorkflowState = 'ready' | 'running' | 'completed' | 'failed'
+import { WorkflowState } from './workflow-state'
 
 type WorkflowStageExecutionResult =
   | Readonly<{
@@ -41,6 +40,7 @@ type WorkflowStagePreparationResult =
 type WorkflowRunResult =
   | Readonly<{
       success: true
+      builder: RiviereBuilder
       events: readonly WorkflowRunEvent[]
       warnings: readonly OperationWarning[]
     }>
@@ -59,14 +59,12 @@ type WorkflowStartResult =
 type ExecuteWorkflowStage = (
   stage: Exclude<WorkflowStageValue, { kind: 'validate' }>,
   accumulatedComponents: readonly EnrichedComponent[],
+  executedExtractions: readonly ExtractionConfiguration[],
 ) => WorkflowStagePreparationResult
 
 /** @riviere-role aggregate-entity */
 export class Workflow {
-  private state: WorkflowState = 'ready'
-  private runEvents: WorkflowRunEvent[] = []
-  private runWarnings: OperationWarning[] = []
-  private accumulatedComponents: EnrichedComponent[] = []
+  private state: WorkflowState | undefined
 
   static start(input: {
     name: string
@@ -101,8 +99,8 @@ export class Workflow {
     return this.logDirectory
   }
 
-  status(): WorkflowState {
-    return this.state
+  status(): ReturnType<WorkflowState['status']> {
+    return this.state?.status() ?? 'ready'
   }
 
   configurations(): readonly ExtractionConfiguration[] {
@@ -112,39 +110,50 @@ export class Workflow {
   }
 
   run(builder: RiviereBuilder, execute: ExecuteWorkflowStage): WorkflowRunResult {
-    this.startRun()
-    this.defineCustomTypes(builder)
-    for (const [index, stage] of this.stages.entries()) {
-      const values = stageEventValues(stage.value, index)
-      this.runEvents.push(WorkflowRunEvent.fromStage('StageStarted', values))
-      const result = this.executeStage(builder, execute, stage.value)
-      if (!result.success) return this.failRun(values, result)
-      this.recordStageSuccess(stage.value, values, result)
-    }
-    this.state = 'completed'
-    this.runEvents.push(WorkflowRunEvent.fromWorkflow('WorkflowCompleted'))
-    return { success: true, events: [...this.runEvents], warnings: [...this.runWarnings] }
+    const state = WorkflowState.fromBuilder(builder)
+    this.state = state
+    this.defineCustomTypes(state.builder())
+    return this.runStages(state, execute, 0)
   }
 
-  private startRun(): void {
-    this.state = 'running'
-    this.runEvents = [WorkflowRunEvent.fromWorkflow('WorkflowStarted')]
-    this.runWarnings = []
-    this.accumulatedComponents = []
+  private runStages(
+    state: WorkflowState,
+    execute: ExecuteWorkflowStage,
+    index: number,
+  ): WorkflowRunResult {
+    const stage = this.stages[index]
+    if (stage === undefined) {
+      const completedState = state.complete()
+      this.state = completedState
+      return {
+        success: true,
+        builder: completedState.builder(),
+        events: completedState.events(),
+        warnings: completedState.warnings(),
+      }
+    }
+    const values = stageEventValues(stage.value, index)
+    const startedState = state.startStage(values)
+    this.state = startedState
+    const result = this.executeStage(startedState, execute, stage.value)
+    if (!result.success) return this.failRun(startedState, values, result)
+    const completedState = this.recordStageSuccess(startedState, stage.value, values, result)
+    this.state = completedState
+    return this.runStages(completedState, execute, index + 1)
   }
 
   private executeStage(
-    builder: RiviereBuilder,
+    state: WorkflowState,
     execute: ExecuteWorkflowStage,
     stage: WorkflowStageValue,
   ): WorkflowStageExecutionResult {
     try {
-      if (stage.kind === 'validate') return validateGraph(builder)
-      const prepared = execute(stage, this.accumulatedComponents)
+      if (stage.kind === 'validate') return validateGraph(state.builder())
+      const prepared = execute(stage, state.accumulatedComponents(), state.executedExtractions())
       if (!prepared.success) return prepared
       return prepared.kind === 'components'
-        ? applyComponents(builder, prepared.components, prepared.repository)
-        : applyConnections(builder, prepared.connections)
+        ? applyComponents(state.builder(), prepared.components, prepared.repository)
+        : applyConnections(state.builder(), prepared.connections)
     } catch (error) {
       return {
         success: false,
@@ -166,32 +175,27 @@ export class Workflow {
   }
 
   private recordStageSuccess(
+    state: WorkflowState,
     stage: WorkflowStageValue,
     values: WorkflowStageEventValues,
     result: Extract<WorkflowStageExecutionResult, { success: true }>,
-  ): void {
-    if (stage.kind === 'extract' && result.extractedComponents !== undefined) {
-      this.accumulatedComponents.push(...result.extractedComponents)
-    }
-    this.runWarnings.push(...result.warnings)
-    this.runEvents.push(WorkflowRunEvent.fromStage('StageCompleted', values))
+  ): WorkflowState {
+    return state.completeStage(stage, values, result.extractedComponents, result.warnings)
   }
 
   private failRun(
+    state: WorkflowState,
     values: WorkflowStageEventValues,
     failure: Extract<WorkflowStageExecutionResult, { success: false }>,
   ): WorkflowRunResult {
-    this.state = 'failed'
-    this.runEvents.push(
-      WorkflowRunEvent.fromStageFailure(values, failure.reason, failure.errorCode),
-      WorkflowRunEvent.fromWorkflowFailure(failure.reason, failure.errorCode),
-    )
+    const failedState = state.fail(values, failure.reason, failure.errorCode)
+    this.state = failedState
     return {
       success: false,
       errorCode: failure.errorCode,
       reason: failure.reason,
-      events: [...this.runEvents],
-      warnings: [...this.runWarnings],
+      events: failedState.events(),
+      warnings: failedState.warnings(),
     }
   }
 }


### PR DESCRIPTION
## Problem

This is the V1 in memory stage execution slice from #410. A workflow must run extract → link → validate against one accumulated candidate graph. Writing the completed graph remains at the CLI boundary.

The current project graph must stay unchanged while the workflow runs. If any stage fails, the completed graph remains available.

## Design

Workflow owns one WorkflowState for a run. The state owns a fresh candidate builder, accumulated components, completed extraction configurations, events, and warnings. RiviereProject adopts that candidate only after extract, link, and validate complete successfully.

The Builder contains the graph construction logic. WorkflowState only holds the in memory result while the workflow is incomplete.

## Changes

- Add immutable WorkflowState for the accumulated candidate graph and stage results.
- Run extraction, linking, and validation against the candidate builder.
- Use only extraction configurations completed in the current run as link source contexts.
- Keep the existing project graph unchanged on failure.
- Adopt the candidate graph only after a successful final validation stage.
- Move connection result combination into ConnectionDetectionResult.

## Acceptance criteria

- Each extraction stage adds to the same candidate graph.
- Link detection uses the extraction contexts completed in that workflow run.
- Validation evaluates the accumulated candidate graph.
- A failed workflow does not overwrite the existing completed graph.
- A successful workflow replaces the project graph with the accumulated candidate graph.
- This change does not write the final graph. That remains at the CLI boundary.

## Validation

- CI=true pnpm nx test riviere-extract-ts-domain-model --skip-nx-cache --output-style=static: 47 files, 388 tests, 100 percent coverage.
- CI=true pnpm nx test riviere-cli --skip-nx-cache --output-style=static.
- env -u NO_COLOR -u FORCE_COLOR CI=true pnpm verify.

Closes #410