### PR TITLE
fix(workflow): update OpenCode workflow dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,20 +464,20 @@ importers:
         specifier: 0.4.1
         version: 0.4.1
       '@nt-ai-lab/deterministic-agent-workflow-cli':
-        specifier: 0.4.1
-        version: 0.4.1
+        specifier: 0.4.2
+        version: 0.4.2
       '@nt-ai-lab/deterministic-agent-workflow-codex':
         specifier: 0.4.3
         version: 0.4.3
       '@nt-ai-lab/deterministic-agent-workflow-engine':
-        specifier: 0.4.1
-        version: 0.4.1
+        specifier: 0.4.2
+        version: 0.4.2
       '@nt-ai-lab/deterministic-agent-workflow-event-store':
-        specifier: 0.4.1
-        version: 0.4.1
+        specifier: 0.4.2
+        version: 0.4.2
       '@nt-ai-lab/deterministic-agent-workflow-opencode':
-        specifier: 0.4.1
-        version: 0.4.1
+        specifier: 0.4.2
+        version: 0.4.2
       esbuild:
         specifier: 0.27.2
         version: 0.27.2
@@ -2105,6 +2105,9 @@ packages:
   '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.1':
     resolution: {integrity: sha512-dpm2vb3z0cCweaZDyJEvUzo7LaoU3SBg4Ff+xTmJxCGo/2nBwFQuzJXXBhUyhqDm4VkWzVmswGL8pf6oigdrNw==}
 
+  '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.2':
+    resolution: {integrity: sha512-+ZQmTDoV/QiYHOMiZlzU4T18Ujz0V9uY8EUXFfIacj7p3/7g71j5Vuk9ZLALanemL8hjgcVjZukxMofnPnr3sA==}
+
   '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.3':
     resolution: {integrity: sha512-Ri08mUk8mJ5NALvpGUd7pMsF/6fOOgC7+DgSQEvpvfbhPgV8IsYXfHUircMwpH4hLdBOlZ4u2dVtFgFG1KWN1g==}
 
@@ -2114,17 +2117,26 @@ packages:
   '@nt-ai-lab/deterministic-agent-workflow-dsl@0.4.1':
     resolution: {integrity: sha512-q4zgiRSfxf4j+5uq8Huon2Gu9cncjko8/ELYnf2bto+P2tReHvKMhuo85GF/YNgxLZNZ+/uYXDrsr5Xbpmkvuw==}
 
+  '@nt-ai-lab/deterministic-agent-workflow-dsl@0.4.2':
+    resolution: {integrity: sha512-ZMjCmYl6oP1eSuC+iS9UAdc6dVkmoTCsmAzT0582i4W2StXrHybdQO4xm3KOsAHh+HY+/MovE8KQ63xQHSgB7w==}
+
   '@nt-ai-lab/deterministic-agent-workflow-engine@0.3.6':
     resolution: {integrity: sha512-06hbQQ1p5NkHKPMTBK6CQj/t6LQ1SwApak3vNqkkO4bVMlamcsIIDcw0DLyBvbQ69osesIWa6y/nVuH3phNuwQ==}
 
   '@nt-ai-lab/deterministic-agent-workflow-engine@0.4.1':
     resolution: {integrity: sha512-VUZXT4vdFxr1ki1rzAqe2qE+8shyyrktWF4ROw6MeFwqrB9hch+rUhoYWXDJTv0fudIHghLCDAmVFrQImkg10Q==}
 
+  '@nt-ai-lab/deterministic-agent-workflow-engine@0.4.2':
+    resolution: {integrity: sha512-sAWFcZHQHFzsQuugp+PQhUExC8nxydyg1mP/8bO0z+QImb31c3RVdnGqAN5fgKCbjqbHOqPSuzU4Biaz0IR0Qw==}
+
   '@nt-ai-lab/deterministic-agent-workflow-event-store@0.4.1':
     resolution: {integrity: sha512-wM1UfmNg1GUAD4kFIQPkjFxOPj1YYNGVJvo7z+06Nf32sxyKkNKHPJufIJqiBBmceBnU+4aqypvU6dHM9D/7dA==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.1':
-    resolution: {integrity: sha512-5izz/BjPBERNN0/47B+0TEowCGY6TwSHyaKu3WvIhcwEyGZna0ed+/hY+LgFoAjbNifx1IPFDOWVGt628S0GTg==}
+  '@nt-ai-lab/deterministic-agent-workflow-event-store@0.4.2':
+    resolution: {integrity: sha512-kIjdN3KMbjyT6PisIHXxTRJHZ/zX+Y74eIOoqAFGkpmu2gxEVj1I/nIHW2ojplSeVIEECNUJXcRC3BKRm6o9Yw==}
+
+  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.2':
+    resolution: {integrity: sha512-9j0wn5vFIQLqgbZecfsHud1Up6v0pLXYQh4z6yiyPdlAseldHrr+DFR0NwQHiQq0DRlgPvN/E010Gi7vUKBJEA==}
 
   '@nx/devkit@23.1.1':
     resolution: {integrity: sha512-FmBfS1xUkWYvDYH/ysO7gAqGlaRzugLac8SIC+X/p76WBmhM6tJhfRW/BQ8mxOFZoVLmwhIiR8X0dRPKdasFxw==}
@@ -10339,6 +10351,13 @@ snapshots:
       '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.1
       zod: 3.25.76
 
+  '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.2':
+    dependencies:
+      '@nt-ai-lab/deterministic-agent-workflow-dsl': 0.4.2
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.2
+      '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.2
+      zod: 3.25.76
+
   '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.3':
     dependencies:
       '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.1
@@ -10354,6 +10373,10 @@ snapshots:
     dependencies:
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.1
 
+  '@nt-ai-lab/deterministic-agent-workflow-dsl@0.4.2':
+    dependencies:
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.2
+
   '@nt-ai-lab/deterministic-agent-workflow-engine@0.3.6':
     dependencies:
       zod: 3.25.76
@@ -10362,16 +10385,25 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@nt-ai-lab/deterministic-agent-workflow-engine@0.4.2':
+    dependencies:
+      zod: 3.25.76
+
   '@nt-ai-lab/deterministic-agent-workflow-event-store@0.4.1':
     dependencies:
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.1
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.1':
+  '@nt-ai-lab/deterministic-agent-workflow-event-store@0.4.2':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.1
-      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.1
-      '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.1
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.2
+      zod: 3.25.76
+
+  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.2':
+    dependencies:
+      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.2
+      '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.2
+      '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.2
       '@opencode-ai/plugin': 1.4.3
       zod: 3.25.76
     transitivePeerDependencies:

--- a/tools/dev-workflow-v2/package.json
+++ b/tools/dev-workflow-v2/package.json
@@ -13,11 +13,11 @@
   "dependencies": {
     "@living-architecture/dev-workflow-v2-use-cases": "workspace:*",
     "@nt-ai-lab/deterministic-agent-workflow-claude-code": "0.4.1",
-    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.1",
+    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.2",
     "@nt-ai-lab/deterministic-agent-workflow-codex": "0.4.3",
-    "@nt-ai-lab/deterministic-agent-workflow-engine": "0.4.1",
-    "@nt-ai-lab/deterministic-agent-workflow-event-store": "0.4.1",
-    "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.4.1",
+    "@nt-ai-lab/deterministic-agent-workflow-engine": "0.4.2",
+    "@nt-ai-lab/deterministic-agent-workflow-event-store": "0.4.2",
+    "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.4.2",
     "esbuild": "0.27.2",
     "tsx": "4.21.0"
   },

--- a/tools/dev-workflow-v2/src/features/workflow/entrypoint/workflow/workflow-cli-hooks.spec.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/entrypoint/workflow/workflow-cli-hooks.spec.ts
@@ -133,7 +133,24 @@ describe('workflow-cli hooks', () => {
     expect(result.exitCode).toStrictEqual(0)
   })
 
-  it('rejects Write with missing file_path', () => {
+  it('allows workflow tools without a file path', () => {
+    const ctx = setup()
+    runCommand(ctx, ['init'])
+
+    const stdinJson = JSON.stringify({
+      session_id: ctx.sessionId,
+      transcript_path: '/transcript',
+      cwd: '/dir',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'workflow',
+      tool_input: { operation: 'record-issue', args: ['410'] },
+      tool_use_id: 'tu-workflow',
+    })
+    const result = runHook(ctx, stdinJson)
+    expect(result.exitCode).toStrictEqual(0)
+  })
+
+  it('blocks Write with missing file_path', () => {
     const ctx = setup()
     runCommand(ctx, ['init'])
 
@@ -146,7 +163,9 @@ describe('workflow-cli hooks', () => {
       tool_input: {},
       tool_use_id: 'tu-write-no-path',
     })
-    expect(() => runHook(ctx, stdinJson)).toThrow('String must contain at least 1 character')
+    const result = runHook(ctx, stdinJson)
+    expect(result.exitCode).toStrictEqual(2)
+    expect(result.output).toContain('Cannot determine every file edited by Write.')
   })
 
   it('throws when Write file_path is non-string type', () => {


### PR DESCRIPTION
## Problem

OpenCode workflow operations were routed through write enforcement despite having no file path. The resulting empty file path caused event validation to fail before operations such as record-issue or transition to BLOCKED could execute.

## Outcome

The workflow now uses the released 0.4.2 OpenCode, CLI, engine, and event-store packages. The upstream fix applies write checks only to actual write tools, allowing pathless workflow operations to proceed.

## Changes

- Upgrade the OpenCode workflow runtime dependency set to 0.4.2.
- Cover a pathless workflow pre-tool invocation.
- Assert the released explicit rejection for write tools without a path.

## Acceptance Criteria

- Pathless workflow operations are allowed by the pre-tool hook.
- Real write tools without a determinable path are blocked cleanly.
- Existing workflow tests and the full verification gate pass.

## Validation

- pnpm nx test dev-workflow-v2
- pnpm verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow tools can now run without specifying a file path.
  - Improved handling of write operations with a missing file path: the workflow exits cleanly with status 2 and explains that edited files could not be determined.

- **Chores**
  - Updated workflow components to the latest maintenance release for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->