### PR TITLE
test(workflow): cover in-memory stage execution

### DIFF
--- a/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.spec.ts
+++ b/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.spec.ts
@@ -107,6 +107,17 @@ describe('parseWorkflowDefinition', () => {
     ],
     ['missing extract config', { ...validWorkflow, stages: [{ extract: { name: 'orders' } }] }],
     ['missing link config', { ...validWorkflow, stages: [{ link: {} }] }],
+    [
+      'extract allowIncomplete option',
+      {
+        ...validWorkflow,
+        stages: [{ extract: { name: 'orders', config: 'orders.yaml', allowIncomplete: true } }],
+      },
+    ],
+    [
+      'link allowIncomplete option',
+      { ...validWorkflow, stages: [{ link: { config: 'combined.yaml', allowIncomplete: true } }] },
+    ],
     ['empty strings', { ...validWorkflow, graph: { ...validWorkflow.graph, outputPath: '' } }],
     [
       'unsupported system type',

--- a/packages/riviere-extract-ts/domain-model/src/domain/__fixtures__/workflow-fixtures.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/__fixtures__/workflow-fixtures.ts
@@ -1,0 +1,92 @@
+import { RiviereBuilder } from '@living-architecture/riviere-builder-published-language'
+import { ValidatedConfiguration } from '@living-architecture/riviere-extract-config-published-language'
+import { Project } from 'ts-morph'
+import { assert } from 'vitest'
+import { ExtractionConfiguration } from '../extraction-configuration'
+import { type MetadataValue, EnrichedComponent } from '../value-extraction/enriched-component'
+import { Workflow } from '../workflow'
+import { WorkflowStage } from '../workflow-stage'
+
+export function configuration(customType?: string): ExtractionConfiguration {
+  const parsed = ValidatedConfiguration.parse({
+    modules: [
+      {
+        api: { notUsed: true },
+        domain: 'orders',
+        domainOp: { notUsed: true },
+        event: { notUsed: true },
+        eventHandler: { notUsed: true },
+        glob: '**/*.ts',
+        name: 'orders',
+        path: '.',
+        ui: { notUsed: true },
+        useCase: { notUsed: true },
+        ...(customType === undefined
+          ? {}
+          : {
+              customTypes: {
+                [customType]: {
+                  find: 'classes' as const,
+                  where: { hasJSDoc: { tag: 'scheduledJob' } },
+                },
+              },
+            }),
+      },
+    ],
+  })
+  assert(parsed.success)
+  const module = parsed.data.modules[0]
+  assert(module)
+  return ExtractionConfiguration.parse({
+    name: 'orders',
+    configPath: 'orders.yml',
+    useTsConfig: false,
+    repositoryName: 'shop',
+    resolvedConfig: parsed.data,
+    moduleContexts: [{ module, project: new Project(), files: [] }],
+  })
+}
+
+export function builder(): RiviereBuilder {
+  return RiviereBuilder.new({
+    name: 'Shop',
+    description: 'Shop graph',
+    sources: [{ repository: 'shop' }],
+    domains: { orders: { description: 'Orders', systemType: 'domain' } },
+  })
+}
+
+export function component(
+  type: string,
+  name: string,
+  metadata: Record<string, MetadataValue> = {},
+): EnrichedComponent {
+  return EnrichedComponent.parse({
+    type,
+    name,
+    domain: 'orders',
+    module: 'orders',
+    location: { file: 'orders.ts', line: 1 },
+    metadata,
+    _missing: undefined,
+  })
+}
+
+export function workflow(stages = stagesFor(configuration())): Workflow {
+  const result = Workflow.start({
+    name: 'build-graph',
+    outputPath: '.riviere/graph.json',
+    runLogDirectory: '.riviere/logs/workflows',
+    stages,
+  })
+  assert(result.success)
+  return result.data
+}
+
+export function stagesFor(config: ExtractionConfiguration) {
+  return [
+    WorkflowStage.fromExtraction('extract', config),
+    WorkflowStage.fromLink('link', config),
+    WorkflowStage.fromValidation('validate'),
+  ]
+}

--- a/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-workflow.spec.ts
@@ -1,4 +1,6 @@
 import { ValidatedConfiguration } from '@living-architecture/riviere-extract-config-published-language'
+import { RiviereBuilder } from '@living-architecture/riviere-builder-published-language'
+import { ValidationResult } from '@living-architecture/riviere-schema-published-language/graph-validation'
 import { Project } from 'ts-morph'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ExtractionConfiguration } from './extraction-configuration'
@@ -200,6 +202,32 @@ describe('RiviereProject workflow graph rebuild', () => {
     expect(result).toMatchObject({ success: false, errorCode: 'FIELD_ENRICHMENT_FAILED' })
     expect(result).not.toHaveProperty('graph')
     expect(subject.build().components.map((item) => item.name)).toStrictEqual(['Existing graph'])
+  })
+
+  it('returns no graph artefact when workflow validation fails', () => {
+    vi.spyOn(RiviereModule.prototype, 'extractAllDraftComponents').mockReturnValue([])
+    vi.spyOn(RiviereModule.prototype, 'enrichDraftComponents').mockReturnValue(
+      EnrichmentResult.parse({ components: [], failures: [] }),
+    )
+    const subject = project()
+    const graph = subject.build()
+    const invalidGraph = {
+      version: graph.version,
+      metadata: graph.metadata,
+      components: graph.components,
+      links: [{ source: 'missing', target: 'also-missing', type: 'sync' as const }],
+    }
+    vi.spyOn(RiviereBuilder.prototype, 'validate').mockReturnValue(
+      ValidationResult.parse(invalidGraph),
+    )
+
+    const result = subject.rebuildGraph('build-graph')
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: 'GRAPH_VALIDATION_FAILED',
+    })
+    expect(result).not.toHaveProperty('graph')
   })
 
   it('returns typed failures for an unknown workflow and unavailable graph state', () => {

--- a/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
+++ b/packages/riviere-extract-ts/domain-model/src/domain/workflow.spec.ts
@@ -1,99 +1,17 @@
-import { RiviereBuilder } from '@living-architecture/riviere-builder-published-language'
-import { ValidatedConfiguration } from '@living-architecture/riviere-extract-config-published-language'
 import { ValidationResult } from '@living-architecture/riviere-schema-published-language/graph-validation'
-import { Project } from 'ts-morph'
 import { assert, describe, expect, it, vi } from 'vitest'
 import { ConnectionDetectionResult } from './connection-detection/connection-detection-result'
 import { ExtractedLink } from './connection-detection/extracted-link'
-import { ExtractionConfiguration } from './extraction-configuration'
-import { EnrichedComponent, type MetadataValue } from './value-extraction/enriched-component'
 import { TestFixtureError } from './value-extraction/literal-detection'
 import { Workflow } from './workflow'
+import {
+  builder,
+  component,
+  configuration,
+  stagesFor,
+  workflow,
+} from './__fixtures__/workflow-fixtures'
 import { WorkflowStage } from './workflow-stage'
-
-function configuration(customType?: string): ExtractionConfiguration {
-  const parsed = ValidatedConfiguration.parse({
-    modules: [
-      {
-        api: { notUsed: true },
-        domain: 'orders',
-        domainOp: { notUsed: true },
-        event: { notUsed: true },
-        eventHandler: { notUsed: true },
-        glob: '**/*.ts',
-        name: 'orders',
-        path: '.',
-        ui: { notUsed: true },
-        useCase: { notUsed: true },
-        ...(customType === undefined
-          ? {}
-          : {
-              customTypes: {
-                [customType]: {
-                  find: 'classes' as const,
-                  where: { hasJSDoc: { tag: 'scheduledJob' } },
-                },
-              },
-            }),
-      },
-    ],
-  })
-  assert(parsed.success)
-  const module = parsed.data.modules[0]
-  assert(module)
-  return ExtractionConfiguration.parse({
-    name: 'orders',
-    configPath: 'orders.yml',
-    useTsConfig: false,
-    repositoryName: 'shop',
-    resolvedConfig: parsed.data,
-    moduleContexts: [{ module, project: new Project(), files: [] }],
-  })
-}
-
-function builder(): RiviereBuilder {
-  return RiviereBuilder.new({
-    name: 'Shop',
-    description: 'Shop graph',
-    sources: [{ repository: 'shop' }],
-    domains: { orders: { description: 'Orders', systemType: 'domain' } },
-  })
-}
-
-function component(
-  type: string,
-  name: string,
-  metadata: Record<string, MetadataValue> = {},
-): EnrichedComponent {
-  return EnrichedComponent.parse({
-    type,
-    name,
-    domain: 'orders',
-    module: 'orders',
-    location: { file: 'orders.ts', line: 1 },
-    metadata,
-    _missing: undefined,
-  })
-}
-
-function workflow(stages = stagesFor(configuration())): Workflow {
-  const result = Workflow.start({
-    name: 'build-graph',
-    outputPath: '.riviere/graph.json',
-    runLogDirectory: '.riviere/logs/workflows',
-    stages,
-  })
-  assert(result.success)
-  return result.data
-}
-
-function stagesFor(config: ExtractionConfiguration) {
-  return [
-    WorkflowStage.fromExtraction('extract', config),
-    WorkflowStage.fromLink('link', config),
-    WorkflowStage.fromValidation('validate'),
-  ]
-}
 
 describe('Workflow definition', () => {
   it('owns its identity, paths, ready state and configurations', () => {
@@ -308,6 +226,49 @@ describe('Workflow.run', () => {
     expect(second.events).toHaveLength(10)
   })
 
+  it('passes components from every extraction stage to the link stage', () => {
+    const config = configuration()
+    const subject = workflow([
+      WorkflowStage.fromExtraction('extract-orders', config),
+      WorkflowStage.fromExtraction('extract-shipping', config),
+      WorkflowStage.fromLink('link', config),
+      WorkflowStage.fromValidation('validate'),
+    ])
+    const orderComponents = [component('useCase', 'Place order')]
+    const shippingComponents = [component('useCase', 'Ship order')]
+    const linkInputs = new Map<string, readonly ReturnType<typeof component>[]>()
+
+    const result = subject.run(builder(), (stage, accumulatedComponents) => {
+      if (stage.kind === 'extract' && stage.name === 'extract-orders') {
+        return {
+          success: true,
+          kind: 'components',
+          components: orderComponents,
+          repository: 'shop',
+        }
+      }
+      if (stage.kind === 'extract') {
+        return {
+          success: true,
+          kind: 'components',
+          components: shippingComponents,
+          repository: 'shop',
+        }
+      }
+      linkInputs.set(stage.name, accumulatedComponents)
+      return {
+        success: true,
+        kind: 'connections',
+        connections: ConnectionDetectionResult.parse({ links: [], externalLinks: [] }),
+      }
+    })
+
+    assert(result.success)
+    const componentsProvidedToLink = linkInputs.get('link')
+    assert(componentsProvidedToLink)
+    expect(componentsProvidedToLink).toStrictEqual([...orderComponents, ...shippingComponents])
+  })
+
   it('stops after a typed stage failure', () => {
     const subject = workflow()
     const execute = vi.fn().mockReturnValue({
@@ -331,6 +292,43 @@ describe('Workflow.run', () => {
       result: { errorCode: 'EXTRACTION_FAILED', reason: 'Extraction failed' },
       eventTypes: ['WorkflowStarted', 'StageStarted', 'StageFailed', 'WorkflowFailed'],
       failure: { reason: 'Extraction failed', errorCode: 'EXTRACTION_FAILED' },
+    })
+  })
+
+  it('does not validate after the link stage fails', () => {
+    const graphBuilder = builder()
+    const validate = vi.spyOn(graphBuilder, 'validate')
+
+    const result = workflow().run(graphBuilder, (stage) => {
+      if (stage.kind === 'extract') {
+        return { success: true, kind: 'components', components: [], repository: 'shop' }
+      }
+      return {
+        success: false,
+        errorCode: 'CONNECTION_DETECTION_FAILED',
+        reason: 'Connection detection failed',
+      }
+    })
+
+    expect({
+      result,
+      validationCalls: validate.mock.calls.length,
+      eventTypes: result.events.map((event) => event.type),
+    }).toMatchObject({
+      result: {
+        success: false,
+        errorCode: 'CONNECTION_DETECTION_FAILED',
+        reason: 'Connection detection failed',
+      },
+      validationCalls: 0,
+      eventTypes: [
+        'WorkflowStarted',
+        'StageStarted',
+        'StageCompleted',
+        'StageStarted',
+        'StageFailed',
+        'WorkflowFailed',
+      ],
     })
   })
 


### PR DESCRIPTION
## Problem
Workflow stage execution needed direct evidence that strict workflows accumulate graph-ready components before linking, validate before graph build, and abort later stages after a failure.

## Outcome
Adds focused workflow and project tests for the in-memory extract -> link -> validate lifecycle.

## Changes
- Rejects allowIncomplete in extract and link workflow-file stages.
- Verifies link receives components from every completed extract stage.
- Verifies a failed link stage does not run validation.
- Verifies graph-validation failure produces no graph artefact.
- Consolidates workflow test fixtures.

## Acceptance Criteria
- Ordered extract, link, and validate stage execution is covered.
- Components accumulated across multiple extraction stages are passed to link detection.
- Fail-fast behavior prevents validation after a link failure.
- Validation failures do not return a built graph.

## Validation
- pnpm verify

Closes #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow error handling so failed graph validation no longer produces an invalid graph artifact.
  * Prevented graph validation from running when the link stage fails.
  * Ensured components from all extraction stages are included before linking.
  * Rejected workflow definitions that allow incomplete extract or link stages.

* **Tests**
  * Added coverage for workflow stage processing, validation failures, and invalid definitions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->