### PR TITLE
fix(workflow): require concrete issue problems

### DIFF
--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/.codex-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "description": "Event-sourced workflow state machine for a structured task lifecycle.",
   "author": {
     "name": "NTCoding",

--- a/tools/dev-workflow-v2/planning-stages/task-creation.md
+++ b/tools/dev-workflow-v2/planning-stages/task-creation.md
@@ -118,15 +118,36 @@ Populate from:
 
 This section must:
 
-- quote the relevant PRD/problem-statement text verbatim
+- ground every claim in the relevant approved PRD or problem-definition text
 - explain the specific problem slice this ticket covers
 - explain the current workflow or failure mode using concrete details from the PRD or problem definition
 - explain the impact using numbers, examples, affected users, or named consequences from the PRD or problem definition
-- explain why this slice matters in the wider delivery sequence
+- explain how this specific problem fits into the wider problem described by the approved problem definition and PRD
+- describe the source-backed cost to affected users or the missed opportunity if the problem remains unresolved
 
-Do not use vague claims like "slow", "inconsistent", "unreliable", or "hard to repeat" unless the approved PRD/problem definition explains what that means. If the approved artefacts do not contain enough concrete problem detail to write this section, block task creation rather than padding with generic wording.
+Describe what users are trying to do, what makes that difficult or unreliable today, and the resulting consequence. Focus on the problem, not the proposed solution, project plan, delivery sequence, dependencies, or later tickets.
 
-Do not describe the implementation solution here.
+Do not define the problem as the absence of the proposed solution, deliverable, artefact, component, or implementation. For example, "users have no complete, executable reference" describes a missing solution rather than the underlying user problem.
+
+Use concrete, plain-language nouns and actions. Do not use umbrella terms or project jargon when the approved sources provide more specific language. For example, replace "architecture facts" with the actual information and sources involved: components, operations, events, and relationships obtained from source code, EventCatalog, AsyncAPI, and AI-assisted discovery.
+
+The problem must be understandable without ticket IDs, deliverable IDs, milestone names, or knowledge of the delivery plan. Never justify the problem by saying that another ticket depends on this ticket, that the ticket appears in an approved delivery sequence, or that delaying it would affect later implementation. Dependency information belongs only in `## Dependencies`.
+
+Bad:
+
+```text
+Product-level tests alone do not prove that a real multi-domain customer can author the complete Workflow or that exact accumulated state remains correct after each stage. This slice matters because D0.3 is an explicit dependency in the approved delivery sequence and an incomplete boundary would push design decisions into later implementation tickets.
+```
+
+This is project verification and delivery-sequence rationale, not the difficulty or consequence experienced by users.
+
+Good:
+
+```text
+Users trying to create one accurate architecture graph from multiple codebases, EventCatalog, AsyncAPI, and AI-assisted findings must determine for themselves how to combine those inputs, in what order, and whether each step produced the correct result. This makes Rivière difficult to learn, adapt, and trust. Users who cannot confidently apply it to their own systems are less likely to adopt it.
+```
+
+Do not use vague claims like "slow", "inconsistent", "unreliable", or "hard to repeat" unless the approved PRD/problem definition explains what that means. If the approved artefacts do not contain enough concrete problem detail and user or product consequence to write this section, block task creation rather than padding with generic wording or inventing an impact.
 
 ### Solution
 
@@ -471,6 +492,12 @@ Block task creation if any of these are true:
 24. a dogfooding ticket replaces the dogfooding artefact's workflow/config/README/CI/script/generated-output block with prose
 25. a dogfooding ticket omits the linked dogfooding deliverable's customer action, customer-visible result, existing dogfooding fit, final content, or acceptance criteria
 26. a dogfooding ticket weakens any acceptance criterion, dependency, exclusion, customer action, customer-visible result, or final artefact from `dogfoodingPath`
+27. `## Problem` justifies the ticket through dependencies, delivery sequencing, or effects on later tickets
+28. `## Problem` defines the problem as the absence of the proposed solution, deliverable, artefact, component, or implementation
+29. `## Problem` uses vague umbrella terms or project jargon where concrete source-backed language is available
+30. `## Problem` does not state a source-backed user or product consequence
+31. `## Problem` does not explain the concrete user task, difficulty, or failure mode covered by this ticket
+32. `## Problem` does not explain how the ticket's problem fits into the wider approved problem context
 
 If blocked, the current planning command must produce:
 

--- a/tools/dev-workflow-v2/plugin.json
+++ b/tools/dev-workflow-v2/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "dev-workflow-v2",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "description": "Event-sourced workflow state machine for a structured task lifecycle.",
   "author": {
     "name": "NTCoding"

--- a/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
@@ -149,3 +149,57 @@ describe('reviewer workflow preflight', () => {
     },
   )
 })
+
+describe('task creation planning guidance', () => {
+  it('keeps problem statements focused on concrete user problems and consequences', () => {
+    const taskCreation = readPluginFile('planning-stages/task-creation.md')
+    const badExample =
+      'Product-level tests alone do not prove that a real multi-domain customer can author the complete Workflow or that exact accumulated state remains correct after each stage. This slice matters because D0.3 is an explicit dependency in the approved delivery sequence and an incomplete boundary would push design decisions into later implementation tickets.'
+    const goodExample =
+      'Users trying to create one accurate architecture graph from multiple codebases, EventCatalog, AsyncAPI, and AI-assisted findings must determine for themselves how to combine those inputs, in what order, and whether each step produced the correct result. This makes Rivière difficult to learn, adapt, and trust. Users who cannot confidently apply it to their own systems are less likely to adopt it.'
+    const badLabelPosition = taskCreation.indexOf('Bad:')
+    const badExamplePosition = taskCreation.indexOf(badExample)
+    const goodLabelPosition = taskCreation.indexOf('Good:')
+    const goodExamplePosition = taskCreation.indexOf(goodExample)
+
+    expect({
+      connectsWiderProblem: taskCreation.includes(
+        'how this specific problem fits into the wider problem described',
+      ),
+      rejectsDeliveryRationale: taskCreation.includes(
+        '`## Problem` justifies the ticket through dependencies, delivery sequencing, or effects on later tickets',
+      ),
+      rejectsMissingSolution: taskCreation.includes(
+        '`## Problem` defines the problem as the absence of the proposed solution',
+      ),
+      requiresConcreteLanguage: taskCreation.includes(
+        '`## Problem` uses vague umbrella terms or project jargon where concrete source-backed language is available',
+      ),
+      requiresSourceBackedConsequence: taskCreation.includes(
+        'does not state a source-backed user or product consequence',
+      ),
+      requiresConcreteUserProblem: taskCreation.includes(
+        'does not explain the concrete user task, difficulty, or failure mode',
+      ),
+      requiresWiderProblemContext: taskCreation.includes(
+        "does not explain how the ticket's problem fits into the wider approved problem context",
+      ),
+      showsJargonReplacement: taskCreation.includes('replace "architecture facts"'),
+      showsCompleteOrderedExamples:
+        badLabelPosition > -1 &&
+        badLabelPosition < badExamplePosition &&
+        badExamplePosition < goodLabelPosition &&
+        goodLabelPosition < goodExamplePosition,
+    }).toStrictEqual({
+      connectsWiderProblem: true,
+      rejectsDeliveryRationale: true,
+      rejectsMissingSolution: true,
+      requiresConcreteLanguage: true,
+      requiresSourceBackedConsequence: true,
+      requiresConcreteUserProblem: true,
+      requiresWiderProblemContext: true,
+      showsJargonReplacement: true,
+      showsCompleteOrderedExamples: true,
+    })
+  })
+})


### PR DESCRIPTION
## Problem

Task creation instructed issue problem statements to explain why a slice matters in the delivery sequence. That produced dependency rationale instead of the concrete user problem, its wider context, and its cost. It also allowed solution-shaped framing and vague project jargon.

## Outcome

Issue problem statements describe what users are trying to do, what makes it difficult, how that fits the wider approved problem, and the source-backed consequence of leaving it unresolved.

## Changes

- Replace delivery-sequence rationale with wider problem context and user or product impact.
- Reject dependency-based justification and missing-solution framing.
- Require concrete language, with architecture facts as the jargon example.
- Add bad and good examples plus hard-fail conditions.
- Add regression coverage and bump plugin manifests to 0.0.149.

## Acceptance Criteria

- Problem sections do not justify tickets through dependencies, sequencing, or later work.
- Problem sections do not define problems as missing proposed solutions.
- Problem sections use concrete source-backed language and consequences.
- Task creation blocks when these requirements cannot be met.

## Validation

- pnpm nx test dev-workflow-v2
- pnpm lint:md
- pnpm verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Guidance**
  - Improved task-creation instructions to produce concrete, source-grounded problem statements focused on user impact and product consequences.
  - Added examples and clearer rules to avoid solution-based framing, jargon, delivery sequencing, and unsupported references.

- **Quality Improvements**
  - Added automated checks to help ensure task-creation guidance remains consistent and enforceable.

- **Maintenance**
  - Updated the plugin version to 0.0.149 across supported plugin manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->