### PR TITLE
docs(workflow): correct event store location

### DIFF
--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.149",
+  "version": "0.0.150",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/README.md
+++ b/tools/dev-workflow-v2/README.md
@@ -218,6 +218,6 @@ Most of the workflow is automated. You interact at these points:
 
 | Problem                       | Where to look                                          |
 | ----------------------------- | ------------------------------------------------------ |
-| Workflow state seems wrong    | Event store: `~/.claude/workflow-events.db`            |
+| Workflow state seems wrong    | Event store: `$WORKFLOW_EVENTS_DB`, or `~/ai-workflow-database/.workflow-events.db` when it is unset |
 | Hook errors / silent failures | Error log: `~/.claude/dev-workflow-v2-hook-errors.log` |
 | Stale NX cache                | Run `pnpm nx reset`                                    |


### PR DESCRIPTION
## Problem

The dev-workflow-v2 troubleshooting guide points to the obsolete `~/.claude/workflow-events.db` location, so users inspecting workflow state can open the wrong database and see no sessions.

## Proposed outcome

The guide identifies the active event-store location: `WORKFLOW_EVENTS_DB` when configured, otherwise `~/ai-workflow-database/.workflow-events.db`.

## Changes

- Correct the event-store troubleshooting entry.
- Bump the plugin patch version as required by the plugin guidance.

## Acceptance criteria

- The README documents the current event-store environment override and fallback path.
- The plugin manifest patch version is incremented.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guidance with the current workflow event store location, including the default path when no environment variable is set.

* **Chores**
  * Incremented the development workflow plugin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->