### PR TITLE
docs(workflow): require user-focused demo issues

### DIFF
--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.152",
+  "version": "0.0.153",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.150",
+  "version": "0.0.151",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.151",
+  "version": "0.0.152",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/planning-stages/dogfooding.md
+++ b/tools/dev-workflow-v2/planning-stages/dogfooding.md
@@ -80,6 +80,8 @@ For every proposed dogfooding deliverable, first state:
 2. the supported capability and customer journey it exercises; and
 3. why that journey matters to a user or customer.
 
+High-level purpose does not mean abstract wording. Name the product capability, the action the user takes, and the result the user sees. Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, or “everything”. At the point of reference, name the file, stages, sources, commands, outputs, or decision involved, or link to the exact source that defines it. An agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.
+
 Only then specify the files, configurations, fixtures, scripts, and README changes that make the journey executable and repeatable. Do not present an artefact list as the dogfooding solution or as user value.
 
 Another crucial objective for this step is to ensure the requirements for engineers are sufficiently detailed so there are no mistakes or misassumptions when planning or implementing the dogfooding solution. So detail is crucial, it's better to over-specify the solution than unders-specify. Lots of code / configuration samples are encouraged showing exactly how this solution will look in the target repository and it must be implementable.

--- a/tools/dev-workflow-v2/planning-stages/dogfooding.md
+++ b/tools/dev-workflow-v2/planning-stages/dogfooding.md
@@ -14,6 +14,10 @@ We need a high level of confidence that our product functionality meets the need
 
 In this step of the planning process, your objective is to look at the new PRD.md and ARCH.md and identify what new functionality is being added and how can we dogfood it to verify it works as expected and to ensure it provides the optimal experience for our users. It's a crucial step that must be done with care and high levels of rigour to leave no stone unturned.
 
+`ecommerce-demo-app` is a user and customer demo, not merely a fixture repository. Its purpose is to demonstrate supported Living Architecture capabilities through a realistic, runnable customer journey. A dogfooding deliverable must exercise the capability it names through the product. Source files, mappings, generated fixtures, and tooling are evidence for that journey; they are not the customer outcome on their own.
+
+If a capability is not supported yet, source preparation may be planned separately, but it must be described as preparation and must not claim to demonstrate that capability. The executable demo and customer validation must wait until the product can run the relevant journey.
+
 You will produce the document `docs/project/PRD/<planning-id>/dogfooding.md` with this exact top level structure:
 
 1. New functionality added in this PRD to verify
@@ -69,6 +73,14 @@ In the output document, write section 2 `What dogfooding exists today`. This sho
 ## Step 3: Designing new dogfooding solutions
 
 This step is crucial. It is important to design a detailed solution that fully exercises the capability. Mistakes here will result in customers having a bad or broken product and we don't realise because it falls through our net.
+
+For every proposed dogfooding deliverable, first state:
+
+1. the high-level purpose of the demo update;
+2. the supported capability and customer journey it exercises; and
+3. why that journey matters to a user or customer.
+
+Only then specify the files, configurations, fixtures, scripts, and README changes that make the journey executable and repeatable. Do not present an artefact list as the dogfooding solution or as user value.
 
 Another crucial objective for this step is to ensure the requirements for engineers are sufficiently detailed so there are no mistakes or misassumptions when planning or implementing the dogfooding solution. So detail is crucial, it's better to over-specify the solution than unders-specify. Lots of code / configuration samples are encouraged showing exactly how this solution will look in the target repository and it must be implementable.
 

--- a/tools/dev-workflow-v2/planning-stages/dogfooding.md
+++ b/tools/dev-workflow-v2/planning-stages/dogfooding.md
@@ -80,7 +80,7 @@ For every proposed dogfooding deliverable, first state:
 2. the supported capability and customer journey it exercises; and
 3. why that journey matters to a user or customer.
 
-High-level purpose does not mean abstract wording. Name the product capability, the action the user takes, and the result the user sees. Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, or “everything”. At the point of reference, name the file, stages, sources, commands, outputs, or decision involved, or link to the exact source that defines it. An agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.
+High-level purpose does not mean abstract wording. Name the product capability, the action the user takes, and the result the user sees. Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, or “everything”. At the point of reference, name the file, stages, sources, commands, outputs, or decision involved, or link to the exact source that defines it. For a Workflow deliverable, an agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.
 
 Only then specify the files, configurations, fixtures, scripts, and README changes that make the journey executable and repeatable. Do not present an artefact list as the dogfooding solution or as user value.
 

--- a/tools/dev-workflow-v2/planning-stages/task-creation.md
+++ b/tools/dev-workflow-v2/planning-stages/task-creation.md
@@ -165,6 +165,20 @@ This section must:
 - explain the boundary between this ticket and neighbouring work where that boundary matters
 - stay source-backed by the approved PRD, solution exploration where referenced by the PRD, and delivery plan
 
+Write the solution in this order:
+
+1. Start with the high-level purpose of the change.
+2. Add the relevant capability detail and clarification.
+3. Explain why the resulting capability matters to the user or customer.
+
+For a dogfooding ticket, the first sentence may name the update to the customer demo. It must then name the supported capabilities exercised through the customer journey and why users or customers need that demonstration. For example:
+
+```text
+Update ecommerce-demo-app to test and validate the new Workflow capabilities through the customer journey. It shows how code extraction, EventCatalog, AsyncAPI, AI assistance, and validation combine into one supported result, so users can see and assess the complete workflow on a realistic system.
+```
+
+The solution must never be only a to-do list or an artefact inventory, such as adding a root Workflow file, stage configs, fixtures, tooling, and README documentation. Those details belong in `## Agreed target architecture and design` after the purpose, capability, and user value are clear.
+
 Do not describe detailed technical architecture, code, config, or runtime flow here. That belongs in `## Agreed target architecture and design`.
 
 Do not list acceptance criteria here. Those belong in `## What "done" looks like`.
@@ -498,6 +512,9 @@ Block task creation if any of these are true:
 30. `## Problem` does not state a source-backed user or product consequence
 31. `## Problem` does not explain the concrete user task, difficulty, or failure mode covered by this ticket
 32. `## Problem` does not explain how the ticket's problem fits into the wider approved problem context
+33. `## Solution` does not begin with the high-level purpose, add the relevant capability detail and clarification, and explain why the result matters to the user or customer
+34. a dogfooding ticket presents source files, configurations, fixtures, tooling, or README changes as its solution instead of explaining the supported customer journey it demonstrates
+35. a dogfooding ticket claims to demonstrate a capability that the product cannot yet run through the demo
 
 If blocked, the current planning command must produce:
 

--- a/tools/dev-workflow-v2/planning-stages/task-creation.md
+++ b/tools/dev-workflow-v2/planning-stages/task-creation.md
@@ -129,6 +129,8 @@ Describe what users are trying to do, what makes that difficult or unreliable to
 
 Do not define the problem as the absence of the proposed solution, deliverable, artefact, component, or implementation. For example, "users have no complete, executable reference" describes a missing solution rather than the underlying user problem.
 
+For a learning or adoption ticket, do not say that users lack a demo, example, guide, configuration, or documentation. Those are possible solutions. State what people cannot learn, understand, do, or adopt in their own work.
+
 Use concrete, plain-language nouns and actions. Do not use umbrella terms or project jargon when the approved sources provide more specific language. For example, replace "architecture facts" with the actual information and sources involved: components, operations, events, and relationships obtained from source code, EventCatalog, AsyncAPI, and AI-assisted discovery.
 
 The problem must be understandable without ticket IDs, deliverable IDs, milestone names, or knowledge of the delivery plan. Never justify the problem by saying that another ticket depends on this ticket, that the ticket appears in an approved delivery sequence, or that delaying it would affect later implementation. Dependency information belongs only in `## Dependencies`.
@@ -136,7 +138,7 @@ The problem must be understandable without ticket IDs, deliverable IDs, mileston
 Bad:
 
 ```text
-Product-level tests alone do not prove that a real multi-domain customer can author the complete Workflow or that exact accumulated state remains correct after each stage. This slice matters because D0.3 is an explicit dependency in the approved delivery sequence and an incomplete boundary would push design decisions into later implementation tickets.
+Product-level tests alone do not prove that a real multi-domain customer can use the product. This slice matters because D0.3 is an explicit dependency in the approved delivery sequence and an incomplete boundary would push design decisions into later implementation tickets.
 ```
 
 This is project verification and delivery-sequence rationale, not the difficulty or consequence experienced by users.
@@ -171,10 +173,12 @@ Write the solution in this order:
 2. Add the relevant capability detail and clarification.
 3. Explain why the resulting capability matters to the user or customer.
 
-For a dogfooding ticket, the first sentence may name the update to the customer demo. It must then name the supported capabilities exercised through the customer journey and why users or customers need that demonstration. For example:
+High-level purpose does not mean abstract wording. The first sentence must name the product capability, the action the user takes, and the result the user needs. Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, “everything”, or “works together”. At the point of reference, name the file, stages, sources, commands, outputs, or decision involved, or link to the exact source that defines it. An agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.
+
+For a dogfooding ticket, the first sentence may name the update to the named demo repository. It must then name the product capabilities, user actions, and outputs that the repository exercises. For example:
 
 ```text
-Update ecommerce-demo-app to test and validate the new Workflow capabilities through the customer journey. It shows how code extraction, EventCatalog, AsyncAPI, AI assistance, and validation combine into one supported result, so users can see and assess the complete workflow on a realistic system.
+Update ecommerce-demo-app to help people new to Riviere learn how TypeScript code extraction, EventCatalog import, AsyncAPI import, AI assistance, and schema validation work. The README shows people how to run riviere-workflow.yaml and inspect its graph and log, so they can apply the same setup to their own application.
 ```
 
 The solution must never be only a to-do list or an artefact inventory, such as adding a root Workflow file, stage configs, fixtures, tooling, and README documentation. Those details belong in `## Agreed target architecture and design` after the purpose, capability, and user value are clear.
@@ -513,8 +517,9 @@ Block task creation if any of these are true:
 31. `## Problem` does not explain the concrete user task, difficulty, or failure mode covered by this ticket
 32. `## Problem` does not explain how the ticket's problem fits into the wider approved problem context
 33. `## Solution` does not begin with the high-level purpose, add the relevant capability detail and clarification, and explain why the result matters to the user or customer
-34. a dogfooding ticket presents source files, configurations, fixtures, tooling, or README changes as its solution instead of explaining the supported customer journey it demonstrates
+34. a dogfooding ticket presents source files, configurations, fixtures, tooling, or README changes as its solution instead of naming the user action, product capabilities, and observable result it demonstrates
 35. a dogfooding ticket claims to demonstrate a capability that the product cannot yet run through the demo
+36. `## Solution` uses an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, “everything”, or “works together” instead of naming the file, stages, sources, commands, outputs, decision, or exact source reference at the point of reference
 
 If blocked, the current planning command must produce:
 

--- a/tools/dev-workflow-v2/planning-stages/task-creation.md
+++ b/tools/dev-workflow-v2/planning-stages/task-creation.md
@@ -173,12 +173,12 @@ Write the solution in this order:
 2. Add the relevant capability detail and clarification.
 3. Explain why the resulting capability matters to the user or customer.
 
-High-level purpose does not mean abstract wording. The first sentence must name the product capability, the action the user takes, and the result the user needs. Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, “everything”, or “works together”. At the point of reference, name the file, stages, sources, commands, outputs, or decision involved, or link to the exact source that defines it. An agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.
+High-level purpose does not mean abstract wording. The first sentence must name the product capability, the action the user takes, and the result the user needs. Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, “everything”, or “works together”. At the point of reference, name the file, stages, sources, commands, outputs, or decision involved, or link to the exact source that defines it. For a Workflow deliverable, an agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.
 
 For a dogfooding ticket, the first sentence may name the update to the named demo repository. It must then name the product capabilities, user actions, and outputs that the repository exercises. For example:
 
 ```text
-Update ecommerce-demo-app to help people new to Riviere learn how TypeScript code extraction, EventCatalog import, AsyncAPI import, AI assistance, and schema validation work. The README shows people how to run riviere-workflow.yaml and inspect its graph and log, so they can apply the same setup to their own application.
+Update ecommerce-demo-app to help people new to Riviere learn how TypeScript code extraction, EventCatalog import, AsyncAPI import, additive AI extraction, additive AI enrichment, and schema validation work. The README shows people how to run riviere-workflow.yaml and inspect its graph and log, so they can apply the same setup to their own application.
 ```
 
 The solution must never be only a to-do list or an artefact inventory, such as adding a root Workflow file, stage configs, fixtures, tooling, and README documentation. Those details belong in `## Agreed target architecture and design` after the purpose, capability, and user value are clear.

--- a/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
@@ -151,10 +151,10 @@ describe('reviewer workflow preflight', () => {
 })
 
 describe('task creation planning guidance', () => {
-  it('keeps problem statements focused on concrete user problems and consequences', () => {
+  it('requires concrete user problems and solution references', () => {
     const taskCreation = readPluginFile('planning-stages/task-creation.md')
     const badExample =
-      'Product-level tests alone do not prove that a real multi-domain customer can author the complete Workflow or that exact accumulated state remains correct after each stage. This slice matters because D0.3 is an explicit dependency in the approved delivery sequence and an incomplete boundary would push design decisions into later implementation tickets.'
+      'Product-level tests alone do not prove that a real multi-domain customer can use the product. This slice matters because D0.3 is an explicit dependency in the approved delivery sequence and an incomplete boundary would push design decisions into later implementation tickets.'
     const goodExample =
       'Users trying to create one accurate architecture graph from multiple codebases, EventCatalog, AsyncAPI, and AI-assisted findings must determine for themselves how to combine those inputs, in what order, and whether each step produced the correct result. This makes Rivière difficult to learn, adapt, and trust. Users who cannot confidently apply it to their own systems are less likely to adopt it.'
     const badLabelPosition = taskCreation.indexOf('Bad:')
@@ -181,10 +181,16 @@ describe('task creation planning guidance', () => {
       requiresConcreteUserProblem: taskCreation.includes(
         'does not explain the concrete user task, difficulty, or failure mode',
       ),
+      rejectsSolutionAsAdoptionProblem: taskCreation.includes(
+        'For a learning or adoption ticket, do not say that users lack a demo, example, guide, configuration, or documentation.',
+      ),
       requiresWiderProblemContext: taskCreation.includes(
         "does not explain how the ticket's problem fits into the wider approved problem context",
       ),
       showsJargonReplacement: taskCreation.includes('replace "architecture facts"'),
+      requiresConcreteSolutionReferences: taskCreation.includes(
+        'Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, “everything”, or “works together”.',
+      ),
       showsCompleteOrderedExamples:
         badLabelPosition > -1 &&
         badLabelPosition < badExamplePosition &&
@@ -197,9 +203,22 @@ describe('task creation planning guidance', () => {
       requiresConcreteLanguage: true,
       requiresSourceBackedConsequence: true,
       requiresConcreteUserProblem: true,
+      rejectsSolutionAsAdoptionProblem: true,
       requiresWiderProblemContext: true,
       showsJargonReplacement: true,
+      requiresConcreteSolutionReferences: true,
       showsCompleteOrderedExamples: true,
     })
+  })
+
+  it('requires concrete references in dogfooding purposes', () => {
+    const dogfooding = readPluginFile('planning-stages/dogfooding.md')
+
+    expect(dogfooding).toContain(
+      'Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, or “everything”.',
+    )
+    expect(dogfooding).toContain(
+      'An agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.',
+    )
   })
 })

--- a/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
@@ -218,7 +218,7 @@ describe('task creation planning guidance', () => {
       'Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, or “everything”.',
     )
     expect(dogfooding).toContain(
-      'An agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.',
+      'For a Workflow deliverable, an agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.',
     )
   })
 })


### PR DESCRIPTION
## Problem

Task creation guidance allowed dogfooding issues to describe files, fixtures, and tooling rather than the customer journey and value they demonstrate. That makes it possible to label preparation for an unavailable feature as a customer demo.

## Outcome

Dogfooding and task-creation guidance now define `ecommerce-demo-app` as a runnable user and customer demo. Solution statements must begin with the high-level purpose, add capability detail, and explain user or customer value.

## Changes

- Require dogfooding deliverables to exercise supported capabilities through a realistic customer journey.
- Distinguish source preparation from an executable demo of a supported feature.
- Add the approved Workflow solution-statement example.
- Block artefact-list solutions and unsupported demo claims during task creation.
- Bump the workflow plugin patch version.

## Acceptance criteria

- Future dogfooding issues cannot present fixtures or tooling as the solution without naming the supported customer journey and its value.
- An unavailable capability cannot be claimed as demonstrated by the demo app.

## Validation

- `pnpm lint:md`
- `pnpm verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified dogfooding guidance to distinguish runnable customer demos from fixture repositories.
  - Added requirements to describe supported capabilities, customer journeys, observable outcomes, and customer value before implementation details.
  - Updated task-creation guidance to improve learning and adoption problem statements and require clear, concrete solution references.
  - Added rules preventing unsupported capability claims and undefined references in planning content.

- **Chores**
  - Updated the development workflow plugin version to 0.0.152.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->