### PR TITLE
docs(planning): define pull request diff problem

### DIFF
--- a/docs/project/PRD/pull-request-diffs/ARCH.md
+++ b/docs/project/PRD/pull-request-diffs/ARCH.md
@@ -1,0 +1,73 @@
+# Architecture: Pull Request Architecture Diffs
+
+**Status:** Draft
+
+---
+
+## 1. Product feasibility check
+
+**Decision status:** Approved
+
+Feasibility remains plausible at architecture depth. The revised product concept and PRD are approved, so architecture drafting can continue.
+
+The repository contains a throwaway TypeScript proof of concept for a GitHub architecture diff and a separate, half finished graph comparison built into the Éclair UI. Neither is the intended foundation for the approved product. Rivière needs one reusable architecture diff capability, decoupled from any UI. GitHub and Éclair consume the same generated `ArchitectureDiff` while providing tailored experiences.
+
+Architecture discovery established two independently named and retained workflow outputs. The `high-level graph` remains selective and shows flows and key concepts for exploration or other purposes. The `fine-grained-role-graph` maps every role annotated class and method together with the ownership, relationships, package information, and source evidence required by the architecture diff.
+
+The completed representation prototype proves that a valid Rivière graph can reproduce the existing pull request #478 architecture diff. It does not prove direct workflow extraction because it creates graph fixtures from the disposable TypeScript architecture snapshots. The user accepted this remaining uncertainty and decided that direct workflow generation, exact parity, and performance validation will be the first delivery ticket.
+
+## 2. Ownership and boundaries
+
+**Decision status:** Partially approved
+
+### Approved subdomain direction
+
+**`riviere-architecture` provides architectural insights based on Rivière graphs and other Rivière concepts.** Architecture comparison is one capability within this subdomain. It may also use Rivière roles directly or concepts introduced later, where justified by a specific insight. Neither those dependencies nor the relocation of existing Builder or Query capabilities has been decided.
+
+### Approved package and consumer responsibilities
+
+The responsibility split follows ADR-002:
+
+| Location | Responsibility |
+| --- | --- |
+| `packages/riviere-architecture/domain-model` | Architectural interpretation and comparison rules. |
+| `packages/riviere-architecture/use-cases` | Expose architecture comparison to callers, including loading its inputs. |
+| `packages/riviere-architecture/published-language` | Define the shared `ArchitectureDiff` contract, using Rivière published-language types where it returns graph elements. |
+| `apps/cli` | Expose comparison through the Rivière CLI and format the GitHub output. |
+| `apps/eclair` | Present the generated diff as the approved review page. |
+
+TypeScript extraction remains outside `riviere-architecture`. This split does not approve moving existing Query capabilities or introducing a direct dependency on Rivière roles.
+
+### Approved viewer hosting and diff file convention
+
+The review page uses the existing Éclair deployment at `https://living-architecture.dev/eclair/`. The reviewer clicks a link to view the diff in Éclair without downloading or selecting a file.
+
+The generated `ArchitectureDiff` is stored in one tracked file under the existing `.riviere` directory:
+
+```text
+.riviere/pr-diffs/riviere-architecture-diff.json
+```
+
+The file contains the architecture diff for the current commit. Users access an older diff by going back to the corresponding Git commit. There are no per-pull-request or commit-pair directories and no separate reports branch.
+
+The GitHub Action builds the GitHub report from the existing JSON file. It does not calculate the architecture diff.
+
+Generation timing and the exact URL-loading mechanism for Éclair remain undecided.
+
+## 3. Component design
+
+**Decision status:** Pending
+
+## 4. Feasibility confirmations
+
+**Decision status:** Pending
+
+## 5. Product impact notes
+
+Architecture discovery added requirements for separate `high-level graph` and `fine-grained-role-graph` workflow outputs, retained graph output, and measured performance. The approved review experience remains unchanged. These requirements are now approved in the revised PRD.
+
+## 6. Task generation consequences
+
+**Decision status:** Partially confirmed
+
+The first delivery ticket must directly generate the `fine-grained-role-graph` through a Rivière workflow without using the disposable architecture snapshot as an intermediate. It must reproduce the pull request #478 architecture diff exactly and report elapsed time, peak memory, and generated graph size. Later delivery work must not rely on the direct extraction path until this validation passes.

--- a/docs/project/PRD/pull-request-diffs/ARCH.md
+++ b/docs/project/PRD/pull-request-diffs/ARCH.md
@@ -40,7 +40,7 @@ TypeScript extraction remains outside `riviere-architecture`. This split does no
 
 ### Approved viewer hosting and diff file convention
 
-The review page uses the existing Éclair deployment at `https://living-architecture.dev/eclair/`. The reviewer clicks a link to view the diff in Éclair without downloading or selecting a file.
+The review page uses the existing Éclair deployment at `https://living-architecture.dev/eclair/`. For public repositories, the reviewer clicks a link to view the diff in Éclair without downloading or selecting a file. Private repositories use file upload as described below.
 
 The generated `ArchitectureDiff` is stored in one tracked file under the existing `.riviere` directory:
 
@@ -52,7 +52,27 @@ The file contains the architecture diff for the current commit. Users access an 
 
 The GitHub Action builds the GitHub report from the existing JSON file. It does not calculate the architecture diff.
 
-Generation timing and the exact URL-loading mechanism for Éclair remain undecided.
+### Approved pull request identity and diff resolution
+
+The Éclair link uses `pr-diff` to identify a repository and pull request ID, not a caller-supplied JSON URL. The tracked diff path above is a convention for the GitHub integration, not merely this repository's local storage choice.
+
+For public repositories, Éclair resolves the diff as follows:
+
+1. Fetch pull request metadata from `https://api.github.com/repos/{owner}/{repository}/pulls/{pullRequestId}`.
+2. Use the returned `head.repo.full_name` and `head.sha` to generate `https://raw.githubusercontent.com/{head.repo.full_name}/{head.sha}/.riviere/pr-diffs/riviere-architecture-diff.json`.
+3. Load and validate the generated `ArchitectureDiff` for presentation.
+
+For pull request #478, the metadata URL is `https://api.github.com/repos/NTCoding/living-architecture/pulls/478`. The raw file URL uses the actual head repository and commit SHA returned by that request. Using the head repository accommodates forks; pinning the file request to the returned SHA avoids following a moving branch during loading. Reopening the link resolves the pull request's current head again.
+
+The exact encoding of repository and pull request ID in the Éclair URL remains to be specified. Loading failure behaviour remains unresolved. Generation timing is a separate repository adoption decision and remains undecided.
+
+### Approved private repository file upload
+
+Private repositories use diff file upload instead of authenticated GitHub loading. Éclair has no backend; uploaded files are processed in the browser.
+
+The uploaded file must contain the extra GitHub metadata unavailable in this mode, including the pull request title, description, repository and pull request link, and revision-specific source links. The review must not depend on fetching private GitHub metadata. The exact file contract and the mechanism for supplying this metadata during generation remain to be designed.
+
+Private repository support is included through upload, not excluded or deferred. This qualifies the previously recorded link-based review path. The user approved revising the PRD and solution exploration to distinguish public GitHub loading from private file upload. Both documents now include that distinction; the revised PRD awaits review before architecture resumes.
 
 ## 3. Component design
 

--- a/docs/project/PRD/pull-request-diffs/ARCH.md
+++ b/docs/project/PRD/pull-request-diffs/ARCH.md
@@ -18,7 +18,7 @@ The completed representation prototype proves that a valid Rivière graph can re
 
 ## 2. Ownership and boundaries
 
-**Decision status:** Partially approved
+**Decision status:** Approved
 
 ### Approved subdomain direction
 
@@ -48,7 +48,7 @@ The generated `ArchitectureDiff` is stored in one tracked file under the existin
 .riviere/pr-diffs/riviere-architecture-diff.json
 ```
 
-The file contains the architecture diff for the current commit. Users access an older diff by going back to the corresponding Git commit. There are no per-pull-request or commit-pair directories and no separate reports branch.
+The file contains the architecture diff comparing `main` against the current commit. Users access an older diff by going back to the corresponding Git commit. There are no per-pull-request or commit-pair directories and no separate reports branch.
 
 The GitHub Action builds the GitHub report from the existing JSON file. It does not calculate the architecture diff.
 
@@ -64,19 +64,2245 @@ For public repositories, Éclair resolves the diff as follows:
 
 For pull request #478, the metadata URL is `https://api.github.com/repos/NTCoding/living-architecture/pulls/478`. The raw file URL uses the actual head repository and commit SHA returned by that request. Using the head repository accommodates forks; pinning the file request to the returned SHA avoids following a moving branch during loading. Reopening the link resolves the pull request's current head again.
 
-The exact encoding of repository and pull request ID in the Éclair URL remains to be specified. Loading failure behaviour remains unresolved. Generation timing is a separate repository adoption decision and remains undecided.
+The Éclair `pr-diff` link encodes the repository and pull request ID as path parameters: `https://living-architecture.dev/eclair/#/pr-diff/<owner>/<repository>/<pullRequestId>`. `owner` and `repository` identify the base repository where the pull request lives; the pull request ID is that repository's. Query parameters were rejected because they add a second encoding style next to Éclair's existing path-parameter routes and read less cleanly when shared.
+
+When the diff cannot be loaded, Éclair shows an explicit error state with as much detail as possible about what failed — pull request metadata not fetched, diff file not found, or diff failed validation — and always links to the pull request on GitHub so the reviewer still reaches the complete GitHub architecture diff. There is no automatic retry loop.
+
+How and when the diff is generated and committed is up to each application to decide, using the Rivière library. The living-architecture repository will use a commit-hook step, which generates the diff comparing `main` against the current commit. Comment-only and artifact-only delivery were rejected because neither places the file in the head commit that the public resolution reads.
 
 ### Approved private repository file upload
 
 Private repositories use diff file upload instead of authenticated GitHub loading. Éclair has no backend; uploaded files are processed in the browser.
 
-The uploaded file must contain the extra GitHub metadata unavailable in this mode, including the pull request title, description, repository and pull request link, and revision-specific source links. The review must not depend on fetching private GitHub metadata. The exact file contract and the mechanism for supplying this metadata during generation remain to be designed.
+The uploaded file is one self-contained JSON envelope with two top-level keys: `metadata` (repository and pull request identity and link, pull request title and description, base and head revision, and revision-specific source links) and `diff` (the generated `ArchitectureDiff`). The review must not depend on fetching private GitHub metadata. The commit hook writes `metadata.repository`, `metadata.baseRevision`, `metadata.headRevision`, `metadata.sourceLinks`, and `diff`; the PR-time GitHub Action writes `metadata.pullRequest.number`, `.title`, `.description`, and `.url`, which do not exist at commit time. Two files were rejected because the upload path would need a second convention; embedding metadata inside the `ArchitectureDiff` schema was rejected because it couples GitHub-specific identity fields into the language-agnostic comparison contract.
 
-Private repository support is included through upload, not excluded or deferred. This qualifies the previously recorded link-based review path. The user approved revising the PRD and solution exploration to distinguish public GitHub loading from private file upload. Both documents now include that distinction; the revised PRD awaits review before architecture resumes.
+Private repository support is included through upload, not excluded or deferred. This qualifies the previously recorded link-based review path. The PRD and solution exploration now both distinguish public GitHub loading from private file upload and are approved.
 
 ## 3. Component design
 
 **Decision status:** Pending
+
+### Design Options: Rivière Architecture Diff
+
+<!-- component-design-option-1:start -->
+#### Option 1: DDD value objects and domain-facade comparison exposed as a query model
+
+This option makes architecture comparison a read-side domain capability inside `riviere-architecture`. The comparison input is a pair of file paths; the `riviere-architecture` use-cases package owns loading its inputs (the two `fine-grained-role-graph` files) exactly like the canonical riviere-builder query loaders; the comparison rules (diffing, grouping, association detection, affected-aggregate resolution, totals) live in explicit `domain-service` functions coordinated by a `domain-facade`; and the capability is exposed to callers as a `query-model` loaded by a `query-model-loader` and orchestrated by a `query-model-use-case`. The shared `ArchitectureDiff` serialization contract lives in a published-language package; the tracked `.riviere/pr-diffs/riviere-architecture-diff.json` envelope is modelled as a second query so the PR-time GitHub Action merges its fields and formats the report from already-generated state without recalculating. `apps/cli` passes only options and formats/writes output; every comparison rule sits in the domain.
+
+##### Domain model change
+
+```mermaid
+flowchart LR
+  fineGrainedRoleGraph["FineGrainedRoleGraph<br/>(role graph state)"]
+  roleElement["RoleElement<br/>(role-annotated element)"]
+  diffFacade["ArchitectureDiffFacade<br/>(coordinates services)"]
+  architectureDiff["ArchitectureDiff<br/>(published contract)"]
+
+  fineGrainedRoleGraph --"indexes"--> roleElement
+  diffFacade --"compares base and head"--> fineGrainedRoleGraph
+  diffFacade --"produces"--> architectureDiff
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+  class fineGrainedRoleGraph statusNew
+  class roleElement statusNew
+  class diffFacade statusOpen
+  class architectureDiff statusNew
+```
+
+Legend: green = new, red = open decision (domain-facade instance awaiting `approvedInstances` approval), gray = existing, yellow = changed.
+
+No aggregate here: the comparison only reads `base`/`head` and derives a result, so the owning class is a query model, and the behaviour is domain services plus a facade. `ArchitectureDiff` (green) is the published-language contract shown as a domain output, not a consumer-API mapping. The tracked-file envelope (`ArchitectureDiffEnvelope`) is deliberately **not** in this diagram: it is an app-facing read shape (query model), not a domain concept. There is no existing `riviere-architecture` subdomain, so all concepts are new.
+
+##### Runtime call diagram
+
+```mermaid
+flowchart LR
+  compareEntrypoint["createCompareArchitectureCommand<br/>(apps/cli feature entrypoint)"]
+  compareUseCase["CompareArchitecture<br/>(query-model-use-case)"]
+  comparisonLoader["ArchitectureComparisonLoader<br/>(query-model-loader)"]
+  roleGraph["FineGrainedRoleGraph<br/>(value-object)"]
+  comparisonModel["ArchitectureComparison<br/>(query-model)"]
+  diffFacade["ArchitectureDiffFacade<br/>(domain-facade)"]
+  commitFormatter["composeCommitArchitectureDiffEnvelope<br/>(cli-output-formatter)"]
+  commitWriter["writeCommitArchitectureDiffEnvelope<br/>(cli-response-writer)"]
+  publishEntrypoint["createPublishPullRequestArchitectureDiffCommand<br/>(apps/cli feature entrypoint)"]
+  envelopeUseCase["LoadGeneratedArchitectureDiff<br/>(query-model-use-case)"]
+  envelopeLoader["GeneratedArchitectureDiffLoader<br/>(query-model-loader)"]
+  diffParser["parseArchitectureDiff<br/>(published-language-parser)"]
+  mergeFormatter["composePullRequestArchitectureDiffEnvelope<br/>(cli-output-formatter)"]
+  githubFormatter["formatGitHubArchitectureDiff<br/>(cli-output-formatter)"]
+  mergeWriter["writeMergedArchitectureDiffEnvelope<br/>(cli-response-writer)"]
+  reportWriter["writeGitHubArchitectureDiffReport<br/>(cli-response-writer)"]
+
+  compareEntrypoint --"execute"--> compareUseCase
+  compareUseCase --"load"--> comparisonLoader
+  comparisonLoader --"parse"--> roleGraph
+  comparisonLoader --"from"--> comparisonModel
+  compareEntrypoint --"compare"--> comparisonModel
+  comparisonModel --"build"--> diffFacade
+  compareEntrypoint --"compose envelope"--> commitFormatter
+  compareEntrypoint --"write envelope file"--> commitWriter
+  publishEntrypoint --"execute"--> envelopeUseCase
+  envelopeUseCase --"load"--> envelopeLoader
+  envelopeLoader --"parse diff"--> diffParser
+  publishEntrypoint --"merge pull request metadata"--> mergeFormatter
+  publishEntrypoint --"write merged envelope"--> mergeWriter
+  publishEntrypoint --"format markdown"--> githubFormatter
+  publishEntrypoint --"write report"--> reportWriter
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+  class compareEntrypoint statusNew
+  class compareUseCase statusNew
+  class comparisonLoader statusNew
+  class roleGraph statusNew
+  class comparisonModel statusNew
+  class diffFacade statusOpen
+  class commitFormatter statusNew
+  class commitWriter statusNew
+  class publishEntrypoint statusNew
+  class envelopeUseCase statusNew
+  class envelopeLoader statusNew
+  class diffParser statusNew
+  class mergeFormatter statusNew
+  class githubFormatter statusNew
+  class mergeWriter statusNew
+  class reportWriter statusNew
+```
+
+Legend: green = new, red = open decision (facade instance approval), gray = existing, yellow = changed. Left cluster = commit-hook phase; right cluster = PR-time Action phase.
+
+##### State loading and persistence description
+
+**Load 1 — comparison inputs (commit-hook phase):**
+
+- **Loaded state:** exactly two `fine-grained-role-graph` files — `base` (the `main` revision) and `head` (the current commit). These are retained outputs of the two independently named Rivière workflows.
+- **Owning component and role:** `ArchitectureComparisonLoader` (`query-model-loader`) in `packages/riviere-architecture/use-cases/src/features/architecture-diff/data-access/architecture-comparison/`. This honours the approved ownership "Expose architecture comparison to callers, including loading its inputs"; the CLI passes only paths and never reads files.
+- **Exact load call:** `load(baseGraphPath, headGraphPath)`; per path it resolves the path against the working directory, checks `existsSync`, reads with `readFileSync`, `JSON.parse`s, then parses via `FineGrainedRoleGraph.parse` — mirroring `packages/riviere-builder/use-cases/src/features/query/data-access/graph/query-loaders.ts` (`loadQueryModel`/`resolveGraphPath`). Both paths are required; there is no default-path convention.
+- **Load inputs and origins:** `CompareArchitectureInput = { baseGraphPath: string; headGraphPath: string }` ← CLI options `--base-graph` / `--head-graph` supplied by the commit-hook script. How the hook generates and materialises the base (`main`) and head graph files (retained output paths, worktree, or checkout) is **deferred to the approved first delivery ticket** (ARCH.md §6); the loader therefore takes explicit required paths and invents no path convention.
+- **Loaded output:** `ArchitectureComparison` query model. `base` ← success value of `FineGrainedRoleGraph.parse(base file JSON)`; `head` ← success value of `FineGrainedRoleGraph.parse(head file JSON)`; combined via `ArchitectureComparison.from(base, head)`. Missing file → `FineGrainedRoleGraphNotFoundError`; unreadable/invalid JSON or failed parse → `FineGrainedRoleGraphCorruptedError` (both `data-access-error`).
+- **Invoked by:** `CompareArchitecture.execute` only. Never invoked by an entrypoint.
+- **Owning object after loading:** `ArchitectureComparison` holds both `FineGrainedRoleGraph` values as private read-only data members. Source location lives on each `RoleElement` (from `riviere-schema` `SourceLocation`); revision-specific URLs are composed at the app boundary inside the envelope metadata.
+
+**Load 2 — tracked diff envelope (PR-time Action phase):**
+
+- **Loaded state:** the tracked file `.riviere/pr-diffs/riviere-architecture-diff.json` (approved convention; used as the `envelopePathOption` default).
+- **Owning component and role:** `GeneratedArchitectureDiffLoader` (`query-model-loader`) in `.../data-access/architecture-diff-envelope/`.
+- **Exact load call:** `load(envelopePathOption)` → `readFileSync` → `JSON.parse` → `parseArchitectureDiff(envelope.diff)` (published-language parser, explicit success/failure result, no throwing validation).
+- **Load inputs and origins:** `LoadGeneratedArchitectureDiffInput = { envelopePathOption: string | undefined }` ← CLI option `--envelope` (default `.riviere/pr-diffs/riviere-architecture-diff.json`) supplied by the workflow step.
+- **Loaded output:** `ArchitectureDiffEnvelope`. `metadata` ← passthrough of the file's metadata object (`repository`, `baseRevision`, `headRevision`, `sourceLinks`, optional `pullRequest`); `diff` ← `parseArchitectureDiff` success value. Missing file → `ArchitectureDiffEnvelopeNotFoundError`; corrupt metadata or failed diff validation → `ArchitectureDiffEnvelopeCorruptedError` (`data-access-error`).
+- **Invoked by:** `LoadGeneratedArchitectureDiff.execute` only.
+
+**Persistence — tracked envelope writes (field-level ownership per ARCH.md):**
+
+- **Commit-hook write:** `writeCommitArchitectureDiffEnvelope(envelope, outputPath)` (`cli-response-writer`) writes `{ metadata: { repository, baseRevision, headRevision, sourceLinks }, diff }`. Field origins: `repository` ← `git remote get-url origin`; `baseRevision` ← `git rev-parse main`; `headRevision` ← `git rev-parse HEAD` — each passed by the commit-hook script as `--repository` / `--base-revision` / `--head-revision` options (the CLI performs no git subprocess calls; no `external-client-service` role is allowed in `apps/cli`). `sourceLinks` ← composed by `composeCommitArchitectureDiffEnvelope` from repository + revisions as base/head blob-URL prefixes (`https://github.com/{repository}/blob/{revision}/`) used by both GitHub and Éclair to build element source-line links from `SourceLocation`. `diff` ← `architectureComparison.compare()`. `outputPath` ← `--output`, default `.riviere/pr-diffs/riviere-architecture-diff.json`.
+- **PR-time write-back:** `writeMergedArchitectureDiffEnvelope(mergedEnvelope, envelopePath)` (`cli-response-writer`) writes the same file with only `metadata.pullRequest.{ number, title, description, url }` added by `composePullRequestArchitectureDiffEnvelope`. Field origins: GitHub Actions pull-request event context (`github.event.pull_request.number`, `.title`, `.body`, `.html_url`) passed as options by the workflow step. These fields do not exist at commit time.
+- **Report write:** `writeGitHubArchitectureDiffReport(markdown, reportPath)` (`cli-response-writer`) writes the markdown file the workflow posts as the pull-request comment; the report is built from the parsed envelope, never recalculated.
+
+##### Components
+
+Subdomain packages (`packages/riviere-architecture/`):
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `ArchitectureDiff` | `published-language/src/published-language` | New | `published-language-schema` | Root `diff` contract: subdomains, elements, associations, affected aggregates, totals. | Medium |
+| `ArchitectureSubdomainChange` | published-language | New | `published-language-data-structure` | Subdomain change with status, affected aggregates, per-package-kind additions/removals. | Medium |
+| `ArchitectureElementChange` | published-language | New | `published-language-data-structure` | Element change: direction, layer, group, before/after element reference, source evidence. | Large |
+| `ApplicationAssociationChange` | published-language | New | `published-language-data-structure` | Application↔subdomain association change with base and head source evidence. | Small |
+| `AffectedAggregate` | published-language | New | `published-language-data-structure` | Aggregate named as affected with separated added/removed members. | Small |
+| `ArchitectureDiffTotals` | published-language | New | `published-language-data-structure` | changedSubdomains, changedPackages, affectedAggregates. | Small |
+| `ARCHITECTURE_CHANGE_DIRECTION` / `ArchitectureChangeDirection` | published-language | New | `published-language-enumeration` / `published-language-enumeration-type` | `added` / `removed` / `modified`. | Small |
+| `ARCHITECTURE_PACKAGE_KIND` / `ArchitecturePackageKind` | published-language | New | `published-language-enumeration` / `published-language-enumeration-type` | `use-cases` / `domain-model` / `published-language` / `application`. | Small |
+| `ARCHITECTURE_LAYER_NAME` / `ArchitectureLayerName` | published-language | New | `published-language-enumeration` / `published-language-enumeration-type` | `entrypoints` / `use-cases` / `domain`. | Small |
+| `architecture-diff-field-names` | published-language | New | `published-language-field-name` | String-literal field-name constants. | Small |
+| `parseArchitectureDiff` | published-language | New | `published-language-parser` | Parse `unknown` → `ArchitectureDiff` or a declared failure shape; used by the envelope loader and by Éclair readers. | Medium |
+| `FineGrainedRoleGraph` | `domain-model/src/domain/comparison` | New | `value-object` | Owns a validated `RiviereGraph`; exposes `elements()` as `RoleElement[]`. | Medium |
+| `RoleElement` | domain-model | New | `value-object` | One role-annotated element: identity, `architectureRole`, `packageKind`, `aggregateOwnerId`, methods, source location; `sameAs`. | Medium |
+| `diffRoleElements` | domain-model `domain/comparison` | New | `domain-service` | Produce `ArchitectureElementChange[]` (added/removed/modified) via `RoleElement` identity. | Medium |
+| `groupChangesBySubdomainAndLayer` | domain-model | New | `domain-service` | Group element changes by subdomain → layer → direction → package/use-case/aggregate group. | Medium |
+| `detectApplicationAssociationChanges` | domain-model | New | `domain-service` | Detect application↔subdomain reassignment with base and head evidence. | Medium |
+| `resolveAffectedAggregates` | domain-model | New | `domain-service` | Enforce "changed on both sides ⇒ affected, not created+deleted". | Small |
+| `summarizeDiffTotals` | domain-model | New | `domain-service` | Compute `ArchitectureDiffTotals` from changes, grouping, associations. | Small |
+| `ArchitectureDiffFacade` | domain-model | New | `domain-facade` *(open decision)* | One stable `build(base, head)` interface coordinating the five comparison services held as private readonly members. | Small |
+| `CompareArchitecture` | `use-cases/src/features/architecture-diff/queries` | New | `query-model-use-case` | Translate input into loader criteria; load and return the comparison query model. | Small |
+| `CompareArchitectureInput` | use-cases `queries` | New | `query-model-use-case-input` | `{ baseGraphPath: string; headGraphPath: string }` — paths only, no file content. | Small |
+| `ArchitectureComparison` | use-cases `queries` | New | `query-model` | Read model holding base+head; exposes `compare(): ArchitectureDiff` via the facade. | Small |
+| `ArchitectureComparisonLoader` | use-cases `data-access/architecture-comparison` | New | `query-model-loader` | `load(baseGraphPath, headGraphPath)`: read both graph files via `node:fs`, parse value objects, construct the query model. Owns "loading its inputs". | Medium |
+| `FineGrainedRoleGraphNotFoundError` / `FineGrainedRoleGraphCorruptedError` | use-cases `data-access/architecture-comparison` | New | `data-access-error` | Missing or corrupt/unparseable graph file (not a domain violation). | Small |
+| `LoadGeneratedArchitectureDiff` | use-cases `queries` | New | `query-model-use-case` | Load and return the tracked envelope as a query model. | Small |
+| `LoadGeneratedArchitectureDiffInput` | use-cases `queries` | New | `query-model-use-case-input` | `{ envelopePathOption: string \| undefined }`. | Small |
+| `ArchitectureDiffEnvelope` | use-cases `queries` | New | `query-model` | `{ metadata, diff }` interface — the tracked-file read shape and app write target. | Small |
+| `ArchitectureDiffEnvelopeMetadata` / `ArchitectureDiffPullRequestMetadata` | use-cases `queries` | New | `query-model-value` | Commit-time metadata (repository, revisions, sourceLinks, optional pullRequest) and PR-time metadata (number, title, description, url). | Small |
+| `GeneratedArchitectureDiffLoader` | use-cases `data-access/architecture-diff-envelope` | New | `query-model-loader` | `load(envelopePathOption)`: read tracked file, validate `diff` via `parseArchitectureDiff`, return the envelope. | Medium |
+| `ArchitectureDiffEnvelopeNotFoundError` / `ArchitectureDiffEnvelopeCorruptedError` | use-cases `data-access/architecture-diff-envelope` | New | `data-access-error` | Missing tracked file or invalid envelope/diff. | Small |
+
+Consumer boundaries:
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `createCompareArchitectureCommand` + `CompareArchitectureEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/compare-architecture` | New | `cli-entrypoint` + `cli-entrypoint-dependencies` | Register `--base-graph`/`--head-graph`/`--repository`/`--base-revision`/`--head-revision`/`--output` options; translate options into `CompareArchitectureInput` inline (canonical query pattern; **no input factory**); invoke query; call `compare()`; compose and write the commit-time envelope. | Small |
+| `composeCommitArchitectureDiffEnvelope` | `apps/cli` `entrypoint/compare-architecture` | New | `cli-output-formatter` | Compose `{ metadata: { repository, baseRevision, headRevision, sourceLinks }, diff }` from the diff and git-context options; derive sourceLinks URL prefixes. | Small |
+| `writeCommitArchitectureDiffEnvelope` | `apps/cli` `entrypoint/compare-architecture` | New | `cli-response-writer` | Write the envelope JSON to the tracked output path. | Small |
+| `createPublishPullRequestArchitectureDiffCommand` + `PublishPullRequestArchitectureDiffEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/publish-pr-architecture-diff` | New | `cli-entrypoint` + `cli-entrypoint-dependencies` | Register `--envelope`/`--pull-request-number`/`--pull-request-title`/`--pull-request-description`/`--pull-request-url`/`--report-output` options; translate into `LoadGeneratedArchitectureDiffInput`; invoke query; merge, write back, format, and write the report. | Small |
+| `composePullRequestArchitectureDiffEnvelope` | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-output-formatter` | Add only `metadata.pullRequest.*` to the loaded envelope (approved PR-time field ownership). | Small |
+| `formatGitHubArchitectureDiff` (+ sibling section formatters) | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-output-formatter` | Format the parsed envelope (diff + sourceLinks) as the complete GitHub markdown report; decomposes into section formatter functions like the existing proof of concept. | Large |
+| `writeMergedArchitectureDiffEnvelope` | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-response-writer` | Write the merged envelope back to the tracked file. | Small |
+| `writeGitHubArchitectureDiffReport` | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-response-writer` | Write the markdown report file the workflow posts as the pull-request comment. | Small |
+| `pr-diff` review page | `apps/eclair/src/features/pr-diff` | New | (Éclair is unassigned) | Public link load and private upload both validate `diff` via `parseArchitectureDiff`; presents metadata from the envelope. | — |
+| Commit-hook script + PR workflow steps | `.githooks/` + `.github/workflows/` | Changed | (outside enforced packages) | Supply git context and GitHub event context as CLI options; invoke the two commands; post the report comment. | — |
+
+### .riviere role options
+
+| Element | Kind | Sublocation | Candidate roles | Preferred role | Reason | Open decision |
+|---|---|---|---|---|---|---|
+| `ArchitectureDiff` | interface | `riviere-architecture/published-language` | `published-language-schema`, `published-language-data-structure` | `published-language-schema` | Root cross-boundary contract, not a nested member shape. | none |
+| `ArchitectureSubdomainChange`, `ArchitectureElementChange`, `ApplicationAssociationChange`, `AffectedAggregate`, `ArchitectureDiffTotals` | interfaces | published-language | `published-language-data-structure` | `published-language-data-structure` | Member shapes of the schema; must be data structures. | none |
+| `ARCHITECTURE_CHANGE_DIRECTION`/`ArchitectureChangeDirection` (and package-kind, layer-name pairs) | variable + type alias | published-language | `published-language-enumeration` + `-enumeration-type` | same | Closed string unions follow the repo enumeration pair convention. | none |
+| `architecture-diff-field-names` | const | published-language | `published-language-field-name` | `published-language-field-name` | Unchecked string-literal duplication is forbidden repo-wide. | none |
+| `parseArchitectureDiff` | function | published-language | `published-language-parser` | `published-language-parser` | Parses the complete schema with an explicit failure branch; used by the envelope loader and Éclair. | none |
+| `FineGrainedRoleGraph`, `RoleElement` | classes | `riviere-architecture/domain-model` `domain/comparison` | `value-object` | `value-object` | Immutable parsed graph state with `parse`/`from` factories and brand members; no invariants beyond integrity. | `RoleElement` terminology confirmation |
+| `diffRoleElements`, `groupChangesBySubdomainAndLayer`, `detectApplicationAssociationChanges`, `resolveAffectedAggregates`, `summarizeDiffTotals` | functions | domain-model `domain/comparison` | `domain-service` | `domain-service` | Operate on two value-object states (base and head) that no single object owns; each carries the required justification ("comparison of two states has no single owning aggregate/value object"). | none |
+| `ArchitectureDiffFacade` | class | domain-model `domain/comparison` | `domain-facade`, `domain-service` | `domain-facade` | Consumer (`ArchitectureComparison` query model) needs one stable interface over five services with sequencing; `domain-service` forbids depending on other domain services. Requires `approvedInstances` entry with justification answering the configured question. | **yes** — user approval required |
+| `CompareArchitecture`, `LoadGeneratedArchitectureDiff` | classes | `riviere-architecture/use-cases` `features/architecture-diff/queries` | `query-model-use-case` | `query-model-use-case` | Read-only load-and-return orchestration. | none |
+| `CompareArchitectureInput`, `LoadGeneratedArchitectureDiffInput` | interfaces | use-cases `queries` | `query-model-use-case-input` | `query-model-use-case-input` | Name matches `.*(Input\|Options)$`; paths/options only. | none |
+| `ArchitectureComparison` | class | use-cases `queries` | `query-model` | `query-model` | Read model for the concrete compare read; depends on the facade (allowed dependent role). | none |
+| `ArchitectureDiffEnvelope` | interface | use-cases `queries` | `query-model`, `query-model-value` | `query-model` | The tracked-file read shape returned by the query; `query-model` (interface target) is also accepted by `cli-response-writer.allowedInputs`. | none |
+| `ArchitectureDiffEnvelopeMetadata`, `ArchitectureDiffPullRequestMetadata` | interfaces | use-cases `queries` | `query-model-value` | `query-model-value` | Result shapes flowing out of the envelope query model. | none |
+| `ArchitectureComparisonLoader`, `GeneratedArchitectureDiffLoader` | classes | use-cases `data-access/{architecture-comparison, architecture-diff-envelope}` | `query-model-loader` | `query-model-loader` | Load concrete query models from persisted files; canonical `query-loaders.ts` shape; no save. | none |
+| `FineGrainedRoleGraphNotFoundError`/`…CorruptedError`, `ArchitectureDiffEnvelopeNotFoundError`/`…CorruptedError` | classes | use-cases `data-access/*` | `data-access-error` | `data-access-error` | File-level failures, mirroring `GraphNotFoundError`/`GraphCorruptedError`. | none |
+| `createCompareArchitectureCommand`, `createPublishPullRequestArchitectureDiffCommand` | functions | `apps/cli` `features/architecture-diff/entrypoint/*` | `cli-entrypoint` | `cli-entrypoint` | Register command, translate options into query input inline, invoke query, delegate formatting/writing. | none |
+| `CompareArchitectureEntrypointDependencies`, `PublishPullRequestArchitectureDiffEntrypointDependencies` | interfaces | apps/cli entrypoints | `cli-entrypoint-dependencies` | `cli-entrypoint-dependencies` | Name matches `.*EntrypointDependencies$`; collaborator roles all allowed. | none |
+| `composeCommitArchitectureDiffEnvelope`, `composePullRequestArchitectureDiffEnvelope`, `formatGitHubArchitectureDiff` (+ section formatters) | functions | apps/cli entrypoints | `cli-output-formatter` | `cli-output-formatter` | Decide envelope/report presentation from a typed result; no file I/O, no loading. | none |
+| `writeCommitArchitectureDiffEnvelope`, `writeMergedArchitectureDiffEnvelope`, `writeGitHubArchitectureDiffReport` | functions | apps/cli entrypoints | `cli-response-writer` | `cli-response-writer` | Perform the output side effect (file writes); envelope input is a `query-model`. | none |
+
+No `command-input-factory` appears on the query path: its `allowedOutputs`/`allowedDependencyRoles` only permit `command-use-case-input`, and the canonical "CLI Invoking Query Model Use Case" pattern has no factory — the `cli-entrypoint` translates options inline, matching `apps/cli/src/features/query/entrypoint/components/entrypoint.ts`.
+
+### Canonical role pattern
+
+Pattern: `CLI Invoking Query Model Use Case` and `Query Model Use Case loading and querying a query model` (from `.riviere/canonical-role-configurations.md`), applied twice. The commit-hook command invokes `CompareArchitecture` and formats/writes the envelope; the PR-time Action invokes `LoadGeneratedArchitectureDiff` and formats/writes the merged envelope plus report. Both loaders follow the canonical `query-loaders.ts` data-access shape (path option in, file read via `node:fs`, `data-access-error` on failure, concrete query model out).
+
+### Tangled responsibility findings
+
+- **Resolved:** the previous draft had the app-side entrypoint/factory read graph files and pass raw content — an "entrypoint directly imports persistence" tangle, plus a `command-input-factory` producing a `query-model-use-case-input` (incompatible role). Corrected: all file reading lives in `ArchitectureComparisonLoader`/`GeneratedArchitectureDiffLoader` (use-cases data-access); the factory is dropped.
+- **Checked, not tangled:** the PR-time merge is presentation-side composition (`cli-output-formatter`) plus a `cli-response-writer` file write at the CLI output boundary — the same precedent as `writeFinalizedGraph`/`writePullRequestArchitectureDiff`. No write behaviour exists on a query model or loader, so the "write behind a query model" check passes.
+
+No tangled responsibilities identified beyond the resolved finding above.
+
+#### Output contract reconciliation
+
+`CompareArchitecture.execute` returns `ArchitectureComparison` (role `query-model`), satisfying `allowedOutputs = ['query-model', 'query-model-value']`. Its `compare()` returns the published-language `ArchitectureDiff` via the facade. `LoadGeneratedArchitectureDiff.execute` returns `ArchitectureDiffEnvelope` (interface annotated `query-model`) whose `diff` member is the validated `ArchitectureDiff` and whose `metadata` members are `query-model-value` shapes. `apps/cli` never imports published-language directly (features may only import subdomain `queries`/`commands`): it consumes the `ArchitectureDiff` type via the query package's exported types and the envelope, and `parseArchitectureDiff` is invoked inside `GeneratedArchitectureDiffLoader` (data-access may import any subdomain published-language) and by Éclair. The envelope keeps GitHub-specific identity fields out of the language-agnostic `ArchitectureDiff` schema, per the approved rejection. Conformance between query results and the schema is asserted in use-cases tests by round-tripping through `parseArchitectureDiff`. The approved field-level write ownership is visible in the two composers: commit-time writes `repository`/`baseRevision`/`headRevision`/`sourceLinks`/`diff`; PR-time adds only `pullRequest.number`/`.title`/`.description`/`.url`.
+
+##### Runtime call outline
+
+```text
+createCompareArchitectureCommand  (commit-hook phase)
+  ├─ compareArchitecture.execute({ baseGraphPath, headGraphPath })
+  │  └─ architectureComparisonLoader.load(baseGraphPath, headGraphPath)
+  │     ├─ readFileSync(baseGraphPath)
+  │     ├─ FineGrainedRoleGraph.parse(baseGraphJson)
+  │     ├─ readFileSync(headGraphPath)
+  │     ├─ FineGrainedRoleGraph.parse(headGraphJson)
+  │     └─ ArchitectureComparison.from(base, head)
+  ├─ architectureComparison.compare()
+  │  └─ architectureDiffFacade.build(base, head)
+  │     ├─ diffRoleElements(base.elements(), head.elements())
+  │     ├─ groupChangesBySubdomainAndLayer(elementChanges, base, head)
+  │     ├─ detectApplicationAssociationChanges(base.elements(), head.elements())
+  │     ├─ resolveAffectedAggregates(elementChanges)
+  │     └─ summarizeDiffTotals(elementChanges, grouping, associationChanges)
+  ├─ composeCommitArchitectureDiffEnvelope(architectureDiff, commitContext)
+  └─ writeCommitArchitectureDiffEnvelope(envelope, outputPath)
+
+createPublishPullRequestArchitectureDiffCommand  (PR-time Action phase)
+  ├─ loadGeneratedArchitectureDiff.execute({ envelopePathOption })
+  │  └─ generatedArchitectureDiffLoader.load(envelopePathOption)
+  │     ├─ readFileSync(envelopePath)
+  │     └─ parseArchitectureDiff(envelopeJson.diff)
+  ├─ composePullRequestArchitectureDiffEnvelope(envelope, pullRequestMetadata)
+  ├─ writeMergedArchitectureDiffEnvelope(mergedEnvelope, envelopePath)
+  ├─ formatGitHubArchitectureDiff(mergedEnvelope)
+  └─ writeGitHubArchitectureDiffReport(markdown, reportPath)
+```
+
+##### Code stress test
+
+```typescript
+// ── riviere-architecture/use-cases: queries ──────────────────────────────
+/** @riviere-role query-model-use-case */
+export class CompareArchitecture {
+  constructor(private readonly loader: ArchitectureComparisonLoader) {}
+  execute(input: CompareArchitectureInput): ArchitectureComparison {
+    return this.loader.load(input.baseGraphPath, input.headGraphPath)
+  }
+}
+
+// ── riviere-architecture/use-cases: data-access (owns loading its inputs) ─
+/** @riviere-role query-model-loader */
+export class ArchitectureComparisonLoader {
+  load(baseGraphPath: string, headGraphPath: string): ArchitectureComparison {
+    const base = loadFineGrainedRoleGraph(baseGraphPath)
+    const head = loadFineGrainedRoleGraph(headGraphPath)
+    return ArchitectureComparison.from(base, head)
+  }
+}
+
+function loadFineGrainedRoleGraph(graphPath: string): FineGrainedRoleGraph {
+  if (!existsSync(graphPath)) {
+    throw new FineGrainedRoleGraphNotFoundError(graphPath)
+  }
+  let json: unknown
+  try {
+    json = JSON.parse(readFileSync(graphPath, 'utf-8'))
+  } catch (error) {
+    throw new FineGrainedRoleGraphCorruptedError(graphPath, { cause: error })
+  }
+  const parsed = FineGrainedRoleGraph.parse(json)
+  if (!parsed.success) {
+    throw new FineGrainedRoleGraphCorruptedError(graphPath)
+  }
+  return parsed.graph
+}
+
+/** @riviere-role query-model */
+export class ArchitectureComparison {
+  private readonly facade = new ArchitectureDiffFacade()
+  private constructor(
+    private readonly base: FineGrainedRoleGraph,
+    private readonly head: FineGrainedRoleGraph,
+  ) {}
+  static from(base: FineGrainedRoleGraph, head: FineGrainedRoleGraph): ArchitectureComparison {
+    return new ArchitectureComparison(base, head)
+  }
+  compare(): ArchitectureDiff {
+    return this.facade.build(this.base, this.head)
+  }
+}
+
+// ── riviere-architecture/domain-model: facade holds its services ─────────
+/** @riviere-role domain-facade */
+export class ArchitectureDiffFacade {
+  private readonly diffElements = diffRoleElements
+  private readonly groupChanges = groupChangesBySubdomainAndLayer
+  private readonly detectAssociationChanges = detectApplicationAssociationChanges
+  private readonly resolveAffected = resolveAffectedAggregates
+  private readonly summarizeTotals = summarizeDiffTotals
+
+  build(base: FineGrainedRoleGraph, head: FineGrainedRoleGraph): ArchitectureDiff {
+    const elements = this.diffElements(base.elements(), head.elements())
+    const grouping = this.groupChanges(elements, base, head)
+    const associations = this.detectAssociationChanges(base.elements(), head.elements())
+    const affectedAggregates = this.resolveAffected(elements)
+    const totals = this.summarizeTotals(elements, grouping, associations)
+    return { subdomains: grouping.subdomains, elements, associations, affectedAggregates, totals }
+  }
+}
+
+// ── domain service: element diff by stable identity (added/removed/modified)
+/** @riviere-role domain-service */
+export function diffRoleElements(
+  base: readonly RoleElement[],
+  head: readonly RoleElement[],
+): readonly ArchitectureElementChange[] {
+  const baseById = new Map(base.map((element) => [element.id, element]))
+  const headById = new Map(head.map((element) => [element.id, element]))
+  const added = [...headById.values()]
+    .filter((element) => !baseById.has(element.id))
+    .map((after) => ({ direction: 'added', after }) as ArchitectureElementChange)
+  const removed = [...baseById.values()]
+    .filter((element) => !headById.has(element.id))
+    .map((before) => ({ direction: 'removed', before }) as ArchitectureElementChange)
+  const modified = [...headById.values()]
+    .filter((element) => baseById.has(element.id) && !baseById.get(element.id)!.sameAs(element))
+    .map((after) => ({ direction: 'modified', before: baseById.get(after.id)!, after }) as ArchitectureElementChange)
+  return [...added, ...removed, ...modified]
+}
+
+// ── apps/cli: approved field-level envelope ownership ────────────────────
+/** @riviere-role cli-output-formatter */
+export function composeCommitArchitectureDiffEnvelope(
+  architectureDiff: ArchitectureDiff,
+  commitContext: { repository: string; baseRevision: string; headRevision: string },
+): ArchitectureDiffEnvelope {
+  return {
+    metadata: {
+      repository: commitContext.repository,
+      baseRevision: commitContext.baseRevision,
+      headRevision: commitContext.headRevision,
+      sourceLinks: {
+        base: `https://github.com/${commitContext.repository}/blob/${commitContext.baseRevision}/`,
+        head: `https://github.com/${commitContext.repository}/blob/${commitContext.headRevision}/`,
+      },
+    },
+    diff: architectureDiff,
+  }
+}
+
+/** @riviere-role cli-output-formatter */
+export function composePullRequestArchitectureDiffEnvelope(
+  envelope: ArchitectureDiffEnvelope,
+  pullRequest: ArchitectureDiffPullRequestMetadata,
+): ArchitectureDiffEnvelope {
+  return { metadata: { ...envelope.metadata, pullRequest }, diff: envelope.diff }
+}
+```
+
+`groupChangesBySubdomainAndLayer`, `detectApplicationAssociationChanges`, `resolveAffectedAggregates`, and `summarizeDiffTotals` keep the previous option's domain-service shapes (grouping by `RoleElement.domain`/`.layer`/`.packageKind`; association reassignment with base+head evidence; "changed on both sides ⇒ affected"; three totals). `RoleElement.sameAs(other)` implements structural equality over `architectureRole`, `packageKind`, `aggregateOwnerId`, `methods`, and `sourceLocation`, ignoring `id`.
+
+##### New dependencies
+
+| Dependency | Status | Used by | Purpose |
+|---|---|---|---|
+| `@living-architecture/riviere-schema-published-language` | Existing | `riviere-architecture-published-language`, `riviere-architecture-domain-model` | Reuse `Component`, `Link`, `SourceLocation`, `RiviereGraph` for element references and graph parsing. |
+| `@living-architecture/riviere-architecture-published-language` | New | `riviere-architecture-domain-model`, `riviere-architecture-use-cases`, `apps/eclair` | The single shared `ArchitectureDiff` contract and `parseArchitectureDiff` for readers. |
+| `@living-architecture/riviere-architecture-use-cases` | New | `apps/cli` | The two query use cases, query models, envelope types, and loaders; apps may only import subdomain queries/commands. |
+| None | — | — | No runtime/adapter libraries; comparison is pure domain logic over parsed graphs; file access is `node:fs` in data-access and CLI writers only. |
+
+##### Code shape
+
+```text
+packages/riviere-architecture/
+  published-language/src/published-language/
+    architecture-diff.ts                    (root schema)
+    architecture-element-change.ts          (data structure)
+    architecture-subdomain-change.ts
+    application-association-change.ts
+    affected-aggregate.ts
+    architecture-diff-totals.ts
+    architecture-change-direction.ts        (enumeration + type)
+    architecture-package-kind.ts
+    architecture-layer-name.ts
+    architecture-diff-field-names.ts
+    parse-architecture-diff.ts              (parser)
+    index.ts
+  domain-model/src/domain/comparison/
+    fine-grained-role-graph.ts              (value-object)
+    role-element.ts                         (value-object)
+    diff-role-elements.ts                   (domain-service)
+    group-changes-by-subdomain-and-layer.ts (domain-service)
+    detect-application-association-changes.ts (domain-service)
+    resolve-affected-aggregates.ts          (domain-service)
+    summarize-diff-totals.ts                (domain-service)
+    architecture-diff-facade.ts             (domain-facade)
+  use-cases/src/features/architecture-diff/
+    queries/compare-architecture.ts               (query-model-use-case)
+    queries/compare-architecture-input.ts
+    queries/architecture-comparison.ts            (query-model)
+    queries/load-generated-architecture-diff.ts   (query-model-use-case)
+    queries/load-generated-architecture-diff-input.ts
+    queries/architecture-diff-envelope.ts         (query-model)
+    queries/architecture-diff-envelope-metadata.ts        (query-model-value)
+    queries/architecture-diff-pull-request-metadata.ts    (query-model-value)
+    data-access/architecture-comparison/architecture-comparison-loader.ts
+    data-access/architecture-comparison/fine-grained-role-graph-not-found-error.ts
+    data-access/architecture-comparison/fine-grained-role-graph-corrupted-error.ts
+    data-access/architecture-diff-envelope/generated-architecture-diff-loader.ts
+    data-access/architecture-diff-envelope/architecture-diff-envelope-not-found-error.ts
+    data-access/architecture-diff-envelope/architecture-diff-envelope-corrupted-error.ts
+apps/cli/src/features/architecture-diff/entrypoint/
+  compare-architecture/entrypoint.ts
+  compare-architecture/compose-commit-architecture-diff-envelope.ts
+  compare-architecture/write-commit-architecture-diff-envelope.ts
+  publish-pr-architecture-diff/entrypoint.ts
+  publish-pr-architecture-diff/compose-pull-request-architecture-diff-envelope.ts
+  publish-pr-architecture-diff/format-github-architecture-diff.ts   (+ section formatters)
+  publish-pr-architecture-diff/write-merged-architecture-diff-envelope.ts
+  publish-pr-architecture-diff/write-github-architecture-diff-report.ts
+apps/eclair/src/features/pr-diff/             (minimal review page)
+```
+
+##### Design validation
+
+- **Domain terminology:** pass. `FineGrainedRoleGraph`, `ArchitectureDiff`, `ArchitectureComparison`, `ArchitectureDiffEnvelope`, `metadata`/`diff` envelope keys, `sourceLinks`, commit hook, and PR-time Action reuse PRD/ARCH terms. `RoleElement` is proposed for a single role-annotated element (no existing shared term).
+- **Application/domain separation:** pass. Both use cases only translate-and-load-and-return; the comparison query model delegates computation to the facade; every comparison rule is a domain service; envelope merge and report formatting are presentation-side; no loops or private logic in use cases.
+- **Role and location fit:** pass, with one open decision. Every element maps to a real role and an allowed sublocation; loading lives in use-cases data-access per the approved "including loading its inputs" ownership; no `command-input-factory` on the query path; writers take a `query-model`/strings. `ArchitectureDiffFacade` is a new `domain-facade` instance needing `approvedInstances` approval.
+- **Implementability:** pass. ADR-002 allows domain-model→any published-language, use-cases→own domain + any published-language, and apps→subdomain queries only; the envelope query makes `parseArchitectureDiff` reachable without apps importing published-language; both file reads mirror the canonical `query-loaders.ts` pattern.
+
+##### Rejected sub-ideas
+
+- **Aggregate + aggregate-repository + command-use-case:** rejected — the comparison is read-only over immutable inputs and derives a result without mutating or persisting domain state, so the write-side roles are wrong.
+- **App-side generic JSON reader passing raw content:** rejected — ARCH.md assigns input loading to `riviere-architecture/use-cases`, the canonical query loaders read files by path in data-access, and no reader role exists in `apps/cli`.
+- **`command-input-factory` on the query path:** rejected — its role constraints only allow producing `command-use-case-input`; the canonical query pattern translates options in the `cli-entrypoint` with no factory.
+- **Returning the published-language `ArchitectureDiff` directly from the use case:** rejected — `query-model-use-case` `allowedOutputs` are `query-model`/`query-model-value`; the query models own the read and the published-language package owns serialization.
+- **A single monolithic `buildArchitectureDiff` domain-service:** rejected — it hides the grouping, association, affected-aggregate, and totals rules behind one entry point; the per-capability services make each rule reviewable.
+- **Sequencing services inside the query model:** rejected — that would leak comparison orchestration into the query layer; the facade keeps it in the domain.
+- **Moving grouping into the CLI formatter:** rejected — grouping and association detection are comparison rules, not presentation, and must stay consistent across GitHub and Éclair.
+- **Modelling the PR-time merge as a command use case:** rejected — the merge adds presentation metadata to an already-generated file at the CLI output boundary; no domain state changes, so the writer/formatter pair is sufficient and matches `writeFinalizedGraph` precedent.
+
+##### Open decisions
+
+- **New domain-facade instance `ArchitectureDiffFacade`.** Requires approval to be added to `approvedInstances` in `.riviere/roles.ts`. Justification answering the configured question: the consumer is the `ArchitectureComparison` query model (plus any future query needing the same read); it needs one stable domain interface because correctly assembling the comparison requires five services in a fixed sequence (diff → group + detect associations → resolve affected aggregates → totals), a discovery and assembly burden that must not leak into the query layer.
+- **`RoleElement` terminology.** Proposed domain term for a single role-annotated element in the fine-grained-role-graph; confirm before it becomes shared vocabulary.
+<!-- component-design-option-1:end -->
+
+<!-- component-design-option-2:start -->
+#### Option 2: Lean query-model-only comparison
+
+Comparing two `fine-grained-role-graph` states is a **read-only** operation: a pure function over two immutable inputs producing one immutable result, so `riviere-architecture` stays **query-only** — one comparison query (`CompareArchitecture`) and one envelope-loading query (`LoadArchitectureDiffEnvelope`), with no aggregate, repository, or command use case in the subdomain. The graph-to-architecture projection — selecting review elements, resolving ownership links, grouping into subdomains and layers — is `ArchitectureGraph.from(riviereGraph)` in the domain-model, the architectural interpretation ARCH §2 assigns to `packages/riviere-architecture/domain-model`; the use-cases loaders own only reading and validating inputs. The retained file convention is delivered by two named `apps/cli` writers: the commit hook records the `ArchitectureDiff` plus commit-time metadata into `.riviere/pr-diffs/riviere-architecture-diff.json`, and the PR-time Action loads that same file, records `metadata.pullRequest`, and formats the GitHub report **from the file — never from a live comparison**. The envelope contract (`metadata` + `diff`, commit-time vs PR-time field split) is owned by `riviere-architecture/published-language`, and Éclair consumes the same envelope through its parser.
+
+##### Domain model change
+
+The comparison rules move from the dead `living-documentation` proof of concept into `riviere-architecture`, expressed **in Rivière graph concepts, not TypeScript symbols**. No aggregate is introduced: comparison has no lifecycle, protected state, or invariant beyond validity of inputs and output, and validity is owned by published-language parsing and value-object construction.
+
+```mermaid
+flowchart LR
+    graphArchitecture["ArchitectureGraph<br/>(value-object)"]
+    item["ArchitectureElement<br/>(value-object)"]
+    aggregateView["AggregateView<br/>(value-object)"]
+    comparison["ArchitectureComparison<br/>(domain-service)"]
+    diff["ArchitectureDiff<br/>(published output)"]
+
+    graphArchitecture -->|"selects and normalises"| item
+    graphArchitecture -->|"resolves ownership links into"| aggregateView
+    aggregateView -->|"owns members"| item
+    comparison -->|"accepts two graphs"| graphArchitecture
+    comparison -->|"emits"| diff
+    diff -->|"reports changes of"| item
+    diff -->|"reports changes of"| aggregateView
+
+    classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+    classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+    classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+    classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+    class graphArchitecture statusNew
+    class item statusNew
+    class aggregateView statusNew
+    class comparison statusNew
+    class diff statusNew
+```
+
+Legend: green = new domain concept. There are no changed or open-decision domain concepts in this option.
+
+##### Runtime call diagram
+
+```mermaid
+flowchart LR
+    subgraph appsCli["apps/cli"]
+        recordEntrypoint["createRecordArchitectureDiffCommand<br/>(apps/cli entrypoint)"]
+        recordPrEntrypoint["createRecordPullRequestMetadataCommand<br/>(apps/cli entrypoint)"]
+        formatReviewEntrypoint["createFormatArchitectureDiffReviewCommand<br/>(apps/cli entrypoint)"]
+        writeEnvelope["writeArchitectureDiffEnvelope<br/>(apps/cli cli-response-writer)"]
+        writeEnvelopePr["writeArchitectureDiffEnvelopePullRequest<br/>(apps/cli cli-response-writer)"]
+        formatReview["formatArchitectureDiffReview<br/>(apps/cli cli-output-formatter)"]
+        sourceLinks["githubSourceLinkTemplate<br/>(apps/cli cli-output-formatter)"]
+    end
+    subgraph useCases["riviere-architecture / use-cases"]
+        compare["CompareArchitecture<br/>(query-model-use-case)"]
+        loadEnvelope["LoadArchitectureDiffEnvelope<br/>(query-model-use-case)"]
+        graphLoader["FineGrainedRoleGraphLoader<br/>(query-model-loader)"]
+        envelopeLoader["ArchitectureDiffEnvelopeLoader<br/>(query-model-loader)"]
+    end
+    subgraph domainModel["riviere-architecture / domain-model"]
+        projection["ArchitectureGraph<br/>(value-object)"]
+        element["ArchitectureElement<br/>(value-object)"]
+        aggregateView["AggregateView<br/>(value-object)"]
+        comparison["ArchitectureComparison<br/>(domain-service)"]
+    end
+    subgraph parsers["shared published-language parsers"]
+        parseEnvelope["parseArchitectureDiffEnvelope<br/>(riviere-architecture published-language)"]
+        parseGraph["parseRiviereGraph<br/>(riviere-schema published-language)"]
+    end
+    eclairPage["PrDiffReviewPage<br/>(apps/eclair)"]
+
+    recordEntrypoint -->|"execute comparison input"| compare
+    recordEntrypoint -->|"write envelope file"| writeEnvelope
+    compare -->|"load base and head graph"| graphLoader
+    graphLoader -->|"validate graph json"| parseGraph
+    graphLoader -->|"project graph into architecture view"| projection
+    projection -->|"normalise review element fields"| element
+    projection -->|"resolve aggregate owned entities"| aggregateView
+    compare -->|"compare base and head graphs"| comparison
+    recordPrEntrypoint -->|"execute envelope load input"| loadEnvelope
+    recordPrEntrypoint -->|"write pull request metadata"| writeEnvelopePr
+    formatReviewEntrypoint -->|"execute envelope load input"| loadEnvelope
+    formatReviewEntrypoint -->|"format github report markdown"| formatReview
+    loadEnvelope -->|"load retained envelope file"| envelopeLoader
+    envelopeLoader -->|"validate envelope json"| parseEnvelope
+    writeEnvelope -->|"compose revision source link"| sourceLinks
+    eclairPage -->|"validate fetched or uploaded envelope"| parseEnvelope
+
+    classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+    classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+    classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+    classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+    class recordEntrypoint statusChanged
+    class recordPrEntrypoint statusChanged
+    class formatReviewEntrypoint statusChanged
+    class writeEnvelope statusChanged
+    class writeEnvelopePr statusChanged
+    class formatReview statusChanged
+    class sourceLinks statusChanged
+    class compare statusNew
+    class loadEnvelope statusNew
+    class graphLoader statusNew
+    class envelopeLoader statusNew
+    class projection statusNew
+    class element statusNew
+    class aggregateView statusNew
+    class comparison statusNew
+    class parseEnvelope statusNew
+    class parseGraph statusExisting
+    class eclairPage statusOpen
+```
+
+Legend: green = new (the three `riviere-architecture` packages are new); yellow = changed (new commands added to the existing `apps/cli`); gray = existing (`parseRiviereGraph` in `riviere-schema-published-language`); red = open decision (`PrDiffReviewPage`, Éclair is explicitly unassigned).
+
+##### Components
+
+All three `packages/riviere-architecture/*` packages are new; `apps/cli` and `apps/eclair` are changed.
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `ArchitectureGraph` | `packages/riviere-architecture/domain-model/src/domain/architecture-graph.ts` | New | `value-object` | Owns the architectural interpretation (ARCH §2): `from(riviereGraph)` selects `architecture-review-element` components, resolves `aggregate-owns-entity` and `supports-primary-element` links, groups members into subdomains/layers, splits application-owned elements out, canonicalises ordering. | Medium |
+| `ArchitectureElement` | `packages/riviere-architecture/domain-model/src/domain/architecture-element.ts` | New | `value-object` | One role-annotated element; `fromReviewElementComponent` owns field normalisation: name, subdomain, `architectureRole`, `packageKind` into the closed union, `externalClient`, `methods`, related-to references, source evidence. | Small |
+| `AggregateView` | `packages/riviere-architecture/domain-model/src/domain/aggregate-view.ts` | New | `value-object` | Read view of one aggregate; `fromAggregateComponent` owns field normalisation plus resolved owned-entity names: name, packageKind, methods, entities, source evidence. | Small |
+| `InvalidArchitectureGraphError` | `packages/riviere-architecture/domain-model/src/domain/invalid-architecture-graph-error.ts` | New | `domain-error` | Thrown by the projection when a review element's required custom properties are missing or outside the closed unions (schema-valid graph, untrustworthy custom values). | Small |
+| `ArchitectureComparison` | `packages/riviere-architecture/domain-model/src/domain/architecture-comparison.ts` | New | `domain-service` | Pure `compare(base, head) → ArchitectureDiff`; owns change direction, layer-change composition, aggregate member grouping, association-change detection. | Medium |
+| `ArchitectureDiff` (+ nested change data structures, `ARCHITECTURE_PACKAGE_KIND`/`ArchitecturePackageKind` and `ARCHITECTURE_LAYER_NAME`/`ArchitectureLayerName` enumeration pairs) | `packages/riviere-architecture/published-language/src/published-language/architecture-diff.ts` | New | `published-language-schema`, `published-language-data-structure`, `published-language-enumeration`/`-enumeration-type` | Stable language-agnostic comparison contract (subdomain → layer → added/removed change sets); method-free. | Medium |
+| `ArchitectureDiffEnvelope` (+ `ArchitectureDiffEnvelopeMetadata`, `RevisionReference`, source-link and pull-request structures) | `packages/riviere-architecture/published-language/src/published-language/architecture-diff-envelope.ts` | New | `published-language-schema`, `published-language-data-structure` | The retained-file contract: both top-level keys, with the commit-time (`repository`, `baseRevision`, `headRevision`, `sourceLinks`, `diff`) vs PR-time (`pullRequest`) field split. | Small |
+| `parseArchitectureDiffEnvelope` | `packages/riviere-architecture/published-language/src/published-language/architecture-diff-envelope-parser.ts` | New | `published-language-parser` | Validates an unknown JSON value into an `ArchitectureDiffEnvelope`; commit-time fields required, `pullRequest` optional; browser-safe (no Node built-ins). | Small |
+| `CompareArchitecture` (+ `CompareArchitectureInput`) | `packages/riviere-architecture/use-cases/src/features/comparison/queries/compare-architecture.ts` | New | `query-model-use-case` (+ `query-model-use-case-input`) | Load base → load head → compare → return `ArchitectureDiffView`; no domain decisions. | Small |
+| `LoadArchitectureDiffEnvelope` (+ `LoadArchitectureDiffEnvelopeInput`) | `packages/riviere-architecture/use-cases/src/features/comparison/queries/load-architecture-diff-envelope.ts` | New | `query-model-use-case` (+ `query-model-use-case-input`) | Loads and validates the retained envelope file; returns `ArchitectureDiffEnvelopeView`. | Small |
+| `ArchitectureDiffView` | `packages/riviere-architecture/use-cases/src/features/comparison/queries/architecture-diff-view.ts` | New | `query-model` | App-facing read shape: validated `ArchitectureDiff` plus base and head `RevisionReference`s. | Small |
+| `ArchitectureDiffEnvelopeView` | `packages/riviere-architecture/use-cases/src/features/comparison/queries/architecture-diff-envelope-view.ts` | New | `query-model` | App-facing read shape wrapping the validated envelope. | Small |
+| `FineGrainedRoleGraphView` | `packages/riviere-architecture/use-cases/src/features/comparison/queries/fine-grained-role-graph-view.ts` | New | `query-model` | One loaded `ArchitectureGraph` plus its `RevisionReference`. | Small |
+| `FineGrainedRoleGraphLoader` (+ `ArchitectureGraphLoadError`) | `packages/riviere-architecture/use-cases/src/features/comparison/data-access/fine-grained-role-graph/` | New | `query-model-loader` (+ `data-access-error`) | Reads a retained graph file by required path, validates with `parseRiviereGraph`, invokes the domain factory `ArchitectureGraph.from`, attaches the `RevisionReference`. Contains no interpretation logic. | Small |
+| `ArchitectureDiffEnvelopeLoader` (+ `ArchitectureDiffEnvelopeLoadError`) | `packages/riviere-architecture/use-cases/src/features/comparison/data-access/architecture-diff-envelope/` | New | `query-model-loader` (+ `data-access-error`) | Reads `.riviere/pr-diffs/riviere-architecture-diff.json` (default) by path and validates it with `parseArchitectureDiffEnvelope`. | Small |
+| `createRecordArchitectureDiffCommand` + `RecordArchitectureDiffEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/record-architecture-diff/entrypoint.ts` | Changed | `cli-entrypoint` + `cli-entrypoint-dependencies` | Commit-hook command: receives exactly one dependencies interface (composition-root assembled) holding `compareArchitecture` and `writeArchitectureDiffEnvelope`; translates options into `CompareArchitectureInput` inline; executes the query; calls the writer through dependencies. | Small |
+| `writeArchitectureDiffEnvelope` | `apps/cli/src/features/architecture-diff/entrypoint/record-architecture-diff/write-architecture-diff-envelope.ts` | Changed | `cli-response-writer` | Serialises the `ArchitectureDiff` plus commit-time metadata into the envelope and writes the retained file; composes `sourceLinks` via `githubSourceLinkTemplate`. | Small |
+| `createRecordPullRequestMetadataCommand` + `RecordPullRequestMetadataEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/record-pull-request-metadata/entrypoint.ts` | Changed | `cli-entrypoint` + `cli-entrypoint-dependencies` | PR-time Action command: dependencies interface holding `loadArchitectureDiffEnvelope` and `writeArchitectureDiffEnvelopePullRequest`. | Small |
+| `writeArchitectureDiffEnvelopePullRequest` | `apps/cli/src/features/architecture-diff/entrypoint/record-pull-request-metadata/write-architecture-diff-envelope-pull-request.ts` | Changed | `cli-response-writer` | Merges `metadata.pullRequest` into the loaded envelope and rewrites the retained file. | Small |
+| `createFormatArchitectureDiffReviewCommand` + `FormatArchitectureDiffReviewEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/format-architecture-diff-review/entrypoint.ts` | Changed | `cli-entrypoint` + `cli-entrypoint-dependencies` | PR-time Action command: dependencies interface holding `loadArchitectureDiffEnvelope` and `formatArchitectureDiffReview`. | Small |
+| `formatArchitectureDiffReview` | `apps/cli/src/features/architecture-diff/entrypoint/format-architecture-diff-review/format-architecture-diff-review.ts` | Changed | `cli-output-formatter` | Formats the complete GitHub Markdown report from the loaded envelope; builds evidence links from `metadata.sourceLinks`. | Medium |
+| `githubSourceLinkTemplate` | `apps/cli/src/features/architecture-diff/entrypoint/_platform/cli/github-source-link-template.ts` | Changed | `cli-output-formatter` | Per-revision GitHub blob-link template; invoked inside `writeArchitectureDiffEnvelope` (not an entrypoint dependency — no `cli-entrypoint` calls it, and only `cli-entrypoint` forbids imported function calls). | Small |
+| `PrDiffReviewPage` | `apps/eclair/src/features/comparison/...` | Changed | open role decision (Éclair unassigned) | Presents the approved review page from the validated envelope; public resolution and upload processing owned by Éclair (see Open decisions). | Medium |
+
+##### .riviere role options
+
+| Component(s) | Kind | Chosen role | Alternative considered and why not |
+|---|---|---|---|
+| `ArchitectureGraph`, `ArchitectureElement`, `AggregateView` | class | `value-object` | Projection inside `FineGrainedRoleGraphLoader` — rejected: ARCH §2 assigns "Architectural interpretation" to the domain-model, and the `value-object` static-factory contract (`from*`) is the natural owner of parsing/normalisation (per the look-for-missing-value-objects memory). `aggregate` — rejected: comparison state has no lifecycle or invariant to protect. |
+| `ArchitectureComparison` | class | `domain-service` (with `@riviere-role-justification`) | Method on `ArchitectureGraph` — rejected: a change set spans two graphs; neither graph owns behaviour between revisions. |
+| `InvalidArchitectureGraphError` | class | `domain-error` | `data-access-error` — rejected: it reports an invalid domain value (custom-property normalisation failure), not a file-access failure. |
+| `ArchitectureDiff`, `ArchitectureDiffEnvelope` + nested structures and enumeration pairs | interface / variable / type-alias | `published-language-schema` / `published-language-data-structure` / `published-language-enumeration` + `-enumeration-type` | Domain-model value objects — rejected: the contract crosses package boundaries to `apps/cli` and `apps/eclair`. |
+| `parseArchitectureDiffEnvelope` | function | `published-language-parser` | Validation inside a use-cases loader only — rejected: Éclair (browser) must validate envelopes without importing Node-dependent packages. |
+| `CompareArchitecture`, `LoadArchitectureDiffEnvelope` | class | `query-model-use-case` | `command-use-case` — rejected: the subdomain performs no writes; the retained file is application delivery. |
+| Query inputs, views | interface / class | `query-model-use-case-input`, `query-model` | — |
+| `FineGrainedRoleGraphLoader`, `ArchitectureDiffEnvelopeLoader` | class | `query-model-loader` | `aggregate-repository` — rejected: there is no aggregate to reconstruct or persist. Loader-owned interpretation — rejected: the projection is domain behaviour and lives in `ArchitectureGraph.from`; the enforcement config permits data-access to import own-subdomain value objects, so the loader invokes the factory without containing interpretation logic. |
+| `ArchitectureGraphLoadError`, `ArchitectureDiffEnvelopeLoadError` | class | `data-access-error` | `domain-error` — rejected: load failures are not domain failures (ADR-002). |
+| `create*Command` functions | function | `cli-entrypoint` | Statically imported use case/writer calls — rejected: `cli-entrypoint` sets `forbiddenImportedFunctionCalls: true`; every callable arrives through the one dependencies interface. |
+| `RecordArchitectureDiffEntrypointDependencies`, `RecordPullRequestMetadataEntrypointDependencies`, `FormatArchitectureDiffReviewEntrypointDependencies` | interface | `cli-entrypoint-dependencies` | Separate dependency parameters — rejected: the role contract requires exactly one dependencies interface (name `.*EntrypointDependencies$`) assembled by the composition root. `githubSourceLinkTemplate` is deliberately not a member: no entrypoint calls it; it is invoked inside the writer. |
+| `writeArchitectureDiffEnvelope`, `writeArchitectureDiffEnvelopePullRequest` | function | `cli-response-writer` | Subdomain command use cases — rejected: ARCH §2 leaves how/when the diff is generated and committed to each application. |
+| `formatArchitectureDiffReview`, `githubSourceLinkTemplate` | function | `cli-output-formatter` | — |
+| `PrDiffReviewPage` | React component | open role decision | Éclair is explicitly unassigned in `.riviere/role-enforcement.config.ts`; no role may be invented for it. |
+
+##### Canonical role pattern
+
+Both CLI flows follow **CLI Invoking Query Model Use Case** from `.riviere/canonical-role-configurations.md`: each `cli-entrypoint` receives exactly one `*EntrypointDependencies` interface assembled by the composition root (the `createComponentsCommand`/`CreateComponentsCommandEntrypointDependencies` precedent), translates options into the `query-model-use-case-input` inline (no factory on the query path), executes the `query-model-use-case` through dependencies, and passes the returned `query-model` to the `cli-response-writer` / `cli-output-formatter`, also through dependencies. There is no command use case and no save step inside the subdomain; the app-level writer step matches the existing `finalize` → `writeFinalizedGraph` precedent in `apps/cli`. `githubSourceLinkTemplate` is invoked inside the writer because only the `cli-entrypoint` role forbids imported function calls. Éclair follows its own unassigned configuration (Dependency Cruiser rules remain active).
+
+##### Tangled responsibility findings
+
+- The existing POC query `GeneratePullRequestArchitectureDiff` (`living-documentation`) tangles comparison with delivery: it receives an `outputPath` and the app formats and writes the diff. This design splits them — the comparison query is delivery-free, and both envelope writes are named single-purpose app writers.
+- Formatting the GitHub report from a live in-memory comparison (the tangle the review caught) would duplicate the diff pipeline at PR time and break the retained-file convention. Resolution: `formatArchitectureDiffReview` accepts only an `ArchitectureDiffEnvelopeView` loaded from the file.
+- Projection buried in a data-access loader (an earlier draft of this option described it as loader-internal prose): resolved — the interpretation rules are `ArchitectureGraph.from(riviereGraph)` in the domain-model, exactly where ARCH §2 places "Architectural interpretation"; `FineGrainedRoleGraphLoader` reads, validates, invokes the factory, and attaches the revision.
+
+No further tangled responsibilities identified.
+
+##### State loading and persistence
+
+**Loaded state 1 — base graph:** `FineGrainedRoleGraphLoader.load(graphPath: string, revision: RevisionReference): FineGrainedRoleGraphView` (role `query-model-loader`, `riviere-architecture/use-cases` data-access — ARCH §2 assigns use-cases "loading its inputs"). Inputs: `graphPath` ← **required** CLI option `--base-graph` with **no default** — this design invents no retained-graph path convention; how the hook materialises the base graph (retained output path, worktree, checkout) is deferred to the approved first delivery ticket (ARCH §1). `revision` ← CLI options `--repository` + `--base-commit`; the commit-hook script resolves the commit with `git rev-parse main` and the CLI runs no git subprocess. Exact internals: `existsSync`/`readFileSync` → `parseRiviereGraph` (missing file or schema-invalid JSON → `ArchitectureGraphLoadError`) → `ArchitectureGraph.from(riviereGraph)` — the architectural interpretation owned by the domain-model: it selects `Custom` components with `customTypeName === 'architecture-review-element'` (single named constant), resolves `aggregate-owns-entity` and `supports-primary-element` links, reads `architectureRole`, `packageKind`, `externalClient`, and `methods` custom properties (invalid values → `InvalidArchitectureGraphError`), and groups into subdomains/layers — the projection proven by the representation prototype → `FineGrainedRoleGraphView.from(graph, revision)`. Output: the `ArchitectureGraph` plus its `RevisionReference`. Element fields come from component `name`, `domain`, and custom properties; aggregate entities from `aggregate-owns-entity` link targets; source evidence from `metadata.sources[].repository`/`commit` plus each component's `sourceLocation`.
+
+**Loaded state 2 — head graph:** the same loader call with `--head-graph` and `--head-commit` (the hook resolves it with `git rev-parse HEAD`); identical internals and output shape.
+
+**Loaded state 3 — retained envelope (PR-time and review reads):** `ArchitectureDiffEnvelopeLoader.load(envelopePathOption: string | undefined): ArchitectureDiffEnvelopeView`. `envelopePathOption` ← CLI option `--envelope`, default `.riviere/pr-diffs/riviere-architecture-diff.json` (the approved convention; the `DEFAULT_GRAPH_PATH` precedent). Internals: `readFileSync` → `parseArchitectureDiffEnvelope` (throws `ArchitectureDiffEnvelopeLoadError`).
+
+**Persisted state 1 — commit-time envelope write:** `writeArchitectureDiffEnvelope(view: ArchitectureDiffView, outputPath: string): void` (`apps/cli`, `cli-response-writer`), invoked by the entrypoint through `RecordArchitectureDiffEntrypointDependencies`. `outputPath` ← CLI option `--output`, default `.riviere/pr-diffs/riviere-architecture-diff.json`. Field origins: `diff` ← `view.diff`; `metadata.repository` and `metadata.baseRevision`/`headRevision` ← the view's revision references (hook-resolved options); `metadata.sourceLinks` ← `githubSourceLinkTemplate(repository, commit)` per revision (imported by the writer from `_platform/cli`). Writes the file with `writeFileSync` + `JSON.stringify`; the Action/commit hook then commits it to the branch (workflow mechanics, not CLI code). Output is validated by `parseArchitectureDiffEnvelope` on every read.
+
+**Persisted state 2 — PR-time metadata write:** `writeArchitectureDiffEnvelopePullRequest(view: ArchitectureDiffEnvelopeView, pullRequest: { number; title; description; url }, outputPath: string): void`, invoked through `RecordPullRequestMetadataEntrypointDependencies`. Fields come from the Action environment (`github.event.pull_request.*`) via CLI options; `outputPath` is the loaded envelope path, so the writer merges into `metadata` by spread, leaves `diff` untouched, and rewrites the same file.
+
+##### Runtime call outline
+
+```text
+createRecordArchitectureDiffCommand(dependencies)                 // commit hook — apps/cli
+  ├─ dependencies.compareArchitecture.execute(input)              // input translated inline from options
+  │  ├─ fineGrainedRoleGraphLoader.load(baseGraphPath, baseRevision)
+  │  │  ├─ readFileSync(baseGraphPath)                            // retained fine-grained-role-graph, required option
+  │  │  ├─ parseRiviereGraph(json)                                // riviere-schema parser
+  │  │  ├─ ArchitectureGraph.from(riviereGraph)                   // domain-model interpretation (ARCH §2)
+  │  │  │  ├─ ArchitectureElement.fromReviewElementComponent(component, relatedTo, revision)
+  │  │  │  └─ AggregateView.fromAggregateComponent(component, ownedEntityNames, revision)
+  │  │  └─ FineGrainedRoleGraphView.from(graph, baseRevision)
+  │  ├─ fineGrainedRoleGraphLoader.load(headGraphPath, headRevision)
+  │  │  ├─ readFileSync(headGraphPath)
+  │  │  ├─ parseRiviereGraph(json)
+  │  │  ├─ ArchitectureGraph.from(riviereGraph)
+  │  │  │  ├─ ArchitectureElement.fromReviewElementComponent(component, relatedTo, revision)
+  │  │  │  └─ AggregateView.fromAggregateComponent(component, ownedEntityNames, revision)
+  │  │  └─ FineGrainedRoleGraphView.from(graph, headRevision)
+  │  ├─ architectureComparison.compare(base.graph, head.graph)    // domain-service → ArchitectureDiff
+  │  └─ ArchitectureDiffView.from(diff, base.revision, head.revision)
+  └─ dependencies.writeArchitectureDiffEnvelope(diffView, outputPath)
+     ├─ githubSourceLinkTemplate(repository, commit)              // per revision
+     └─ writeFileSync(outputPath)                                 // default .riviere/pr-diffs/riviere-architecture-diff.json
+createRecordPullRequestMetadataCommand(dependencies)              // PR-time Action — apps/cli
+  ├─ dependencies.loadArchitectureDiffEnvelope.execute({ envelopePathOption })
+  │  └─ architectureDiffEnvelopeLoader.load(envelopePathOption)
+  │     ├─ readFileSync(envelopePath)                             // retained envelope, default path
+  │     └─ parseArchitectureDiffEnvelope(json)                    // published-language-parser
+  └─ dependencies.writeArchitectureDiffEnvelopePullRequest(view, pullRequest, envelopePath)
+     └─ writeFileSync(envelopePath)
+createFormatArchitectureDiffReviewCommand(dependencies)           // PR-time Action — apps/cli
+  ├─ dependencies.loadArchitectureDiffEnvelope.execute({ envelopePathOption })
+  │  └─ architectureDiffEnvelopeLoader.load(envelopePathOption)
+  └─ dependencies.formatArchitectureDiffReview(view)              // cli-output-formatter → GitHub Markdown
+PrDiffReviewPage(route, upload)                                   // apps/eclair — Éclair-owned, open
+  ├─ fetch('api.github.com/repos/{owner}/{repository}/pulls/{id}')   // public mode — Éclair-owned
+  ├─ fetch(rawEnvelopeUrl pinned to head.sha)                        // public mode — Éclair-owned
+  └─ parseArchitectureDiffEnvelope(envelopeJson)                     // upload mode and public mode
+```
+
+##### Code stress test
+
+```typescript
+// --- domain-model: ArchitectureGraph.from owns the architectural interpretation ---
+// ARCH §2 assigns "Architectural interpretation and comparison rules" to this package.
+const ARCHITECTURE_REVIEW_ELEMENT_TYPE_NAME = 'architecture-review-element'
+const AGGREGATE_OWNS_ENTITY_RELATIONSHIP = 'aggregate-owns-entity'
+const SUPPORTS_PRIMARY_ELEMENT_RELATIONSHIP = 'supports-primary-element'
+const AGGREGATE_ARCHITECTURE_ROLE = 'aggregate'
+
+type LayerName = 'entrypoints' | 'use-cases' | 'domain'
+type ArchitectureMember = ArchitectureElement | AggregateView // discriminated by the `kind` member; matched exhaustively, never with `in`
+type SubdomainPackageKind = Exclude<ArchitecturePackageKind, 'application'>
+
+/** @riviere-role value-object */
+export class ArchitectureGraph {
+  declare private readonly brand: 'ArchitectureGraph'
+
+  private constructor(
+    readonly subdomains: ReadonlyMap<string, SubdomainLayers>,
+    readonly applicationElements: readonly ArchitectureElement[],
+  ) {}
+
+  static from(riviereGraph: RiviereGraph): ArchitectureGraph {
+    const revision = revisionSourceOf(riviereGraph) // metadata.sources → { repository, commit }
+    const reviewComponents = riviereGraph.components.filter(isArchitectureReviewElement)
+    const elements = reviewComponents.map((component) =>
+      ArchitectureElement.fromReviewElementComponent(
+        component,
+        supportedPrimaryNames(riviereGraph, component.id), // supports-primary-element link targets
+        revision,
+      ))
+    const aggregates = reviewComponents
+      .filter((component) => architectureRoleOf(component) === AGGREGATE_ARCHITECTURE_ROLE)
+      .map((component) =>
+        AggregateView.fromAggregateComponent(
+          component,
+          ownedEntityNames(riviereGraph, component.id),
+          revision,
+        ))
+    return new ArchitectureGraph(
+      groupIntoSubdomains(elements, aggregates), // subdomain ← element.domain; canonical sorted ordering
+      elements.filter((element) => element.packageKind === 'application'),
+    )
+  }
+}
+
+// Element selection: schema-validated component union narrowed by type, no `in` operator.
+function isArchitectureReviewElement(component: Component): component is CustomComponent {
+  return component.type === 'Custom'
+    && component.customTypeName === ARCHITECTURE_REVIEW_ELEMENT_TYPE_NAME
+}
+
+// aggregate-owns-entity resolution: aggregate source → owned entity target names.
+function ownedEntityNames(riviereGraph: RiviereGraph, aggregateId: string): readonly string[] {
+  return riviereGraph.links
+    .filter((link) =>
+      link.source === aggregateId
+      && link.relationshipType === AGGREGATE_OWNS_ENTITY_RELATIONSHIP)
+    .map((link) => componentName(riviereGraph, link.target))
+}
+
+// Subdomain/layer grouping rule (PRD lines 60–63): layer ← packageKind, exhaustive match;
+// 'application' elements never enter a subdomain (they stay under their application owner).
+function subdomainLayerOf(packageKind: SubdomainPackageKind): LayerName {
+  switch (packageKind) {
+    case 'use-cases': return 'use-cases'
+    case 'entrypoints': return 'entrypoints'
+    case 'domain-model': return 'domain'
+    case 'published-language': return 'domain'
+  }
+}
+
+// ArchitectureElement.fromReviewElementComponent normalises name, domain, architectureRole,
+// packageKind (validated into the closed ARCHITECTURE_PACKAGE_KIND union), externalClient,
+// methods, and combines component.sourceLocation with the revision into source evidence;
+// AggregateView.fromAggregateComponent normalises the same fields plus the resolved
+// owned-entity names. Both are private-constructor value objects; invalid custom-property
+// values throw InvalidArchitectureGraphError (domain-error).
+```
+
+```typescript
+// --- use-cases: load → invoke → return. No save step exists in the subdomain ---
+/** @riviere-role query-model-use-case */
+export class CompareArchitecture {
+  constructor(
+    private readonly graphs: FineGrainedRoleGraphLoader,
+    private readonly comparison: ArchitectureComparison,
+  ) {}
+
+  execute(input: CompareArchitectureInput): ArchitectureDiffView {
+    const base = this.graphs.load(input.baseGraphPath, input.baseRevision)
+    const head = this.graphs.load(input.headGraphPath, input.headRevision)
+    return ArchitectureDiffView.from(
+      this.comparison.compare(base.graph, head.graph),
+      base.revision,
+      head.revision,
+    )
+  }
+}
+
+/** @riviere-role query-model-use-case-input */
+export interface CompareArchitectureInput {
+  readonly baseGraphPath: string          // required --base-graph option, no default
+  readonly headGraphPath: string          // required --head-graph option, no default
+  readonly baseRevision: RevisionReference // --repository + --base-commit (hook: git rev-parse main)
+  readonly headRevision: RevisionReference // --repository + --head-commit (hook: git rev-parse HEAD)
+}
+
+/** @riviere-role query-model-loader */
+export class FineGrainedRoleGraphLoader {
+  load(graphPath: string, revision: RevisionReference): FineGrainedRoleGraphView {
+    const riviereGraph = readValidatedGraph(graphPath)
+    return FineGrainedRoleGraphView.from(ArchitectureGraph.from(riviereGraph), revision)
+  }
+}
+
+function readValidatedGraph(graphPath: string): RiviereGraph {
+  if (!existsSync(graphPath)) throw new ArchitectureGraphLoadError(graphPath)
+  const parsed = parseRiviereGraph(JSON.parse(readFileSync(graphPath, 'utf8')))
+  if (!parsed.success) throw new ArchitectureGraphLoadError(graphPath, parsed.issues)
+  return parsed.graph
+}
+
+/** @riviere-role query-model-loader */
+export class ArchitectureDiffEnvelopeLoader {
+  load(envelopePathOption: string | undefined): ArchitectureDiffEnvelopeView {
+    const path = envelopePathOption ?? '.riviere/pr-diffs/riviere-architecture-diff.json'
+    const parsed = parseArchitectureDiffEnvelope(JSON.parse(readFileSync(path, 'utf8')))
+    if (!parsed.success) throw new ArchitectureDiffEnvelopeLoadError(path)
+    return ArchitectureDiffEnvelopeView.from(parsed.value)
+  }
+}
+```
+
+```typescript
+// --- domain-model: ArchitectureComparison (domain-service) owns every comparison rule ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification A change set spans two whole ArchitectureGraph
+ *  states; no single graph, element, or aggregate view owns behaviour between
+ *  two revisions, and no aggregate exists to hold it. */
+export class ArchitectureComparison {
+  compare(base: ArchitectureGraph, head: ArchitectureGraph): ArchitectureDiff {
+    return buildDiff(base.subdomains, head.subdomains)
+  }
+}
+
+// Layer-change composition: one added/removed change-set pair per layer for both sides.
+function composite(
+  base: Layers | undefined,
+  head: Layers | undefined,
+): Record<LayerName, ArchitectureLayerChange>
+
+function subdomainChange(
+  base: SubdomainArchitecture | undefined,
+  head: SubdomainArchitecture | undefined,
+): 'added' | 'changed' | 'removed'
+
+function hasChanges(layers: Record<LayerName, ArchitectureLayerChange>): boolean
+function emptyLayers(): Layers
+function sourceEvidence(element: ArchitectureElement): ArchitectureSourceEvidence
+
+function buildDiff(base: SubdomainMap, head: SubdomainMap): ArchitectureDiff {
+  const names = new Set([...base.keys(), ...head.keys()])
+  return { subdomains: [...names].sort().flatMap((name) => {
+    const b = base.get(name); const h = head.get(name)
+    const layers = composite(b?.layers ?? emptyLayers(), h?.layers ?? emptyLayers())
+    return hasChanges(layers) ? [{ name, change: subdomainChange(b, h), layers }] : []
+  }) }
+}
+
+// Association rule (PRD §4, lines 62–63): base/head application elements matched by
+// (packageKind, role, name) that moved subdomain emit ONE association change carrying
+// BOTH revisions' evidence — never a create + delete pair.
+function associateApplicationElements(
+  base: readonly ArchitectureElement[],
+  head: readonly ArchitectureElement[],
+): ArchitectureAssociationChange[] {
+  const headByKey = new Map(head.map((element) => [element.key(), element]))
+  return base.flatMap((baseElement) => {
+    const headElement = headByKey.get(baseElement.key())
+    return headElement !== undefined && headElement.subdomain !== baseElement.subdomain
+      ? [{ from: sourceEvidence(baseElement), to: sourceEvidence(headElement) }]
+      : []
+  })
+}
+```
+
+```typescript
+// --- apps/cli: the entrypoint receives exactly one dependencies interface ---
+/** @riviere-role cli-entrypoint-dependencies */
+export interface RecordArchitectureDiffEntrypointDependencies {
+  readonly compareArchitecture: CompareArchitecture
+  readonly writeArchitectureDiffEnvelope: typeof writeArchitectureDiffEnvelope
+}
+
+/** @riviere-role cli-entrypoint */
+export function createRecordArchitectureDiffCommand(
+  dependencies: RecordArchitectureDiffEntrypointDependencies,
+): Command {
+  return new Command('record-architecture-diff')
+    .description('Record the architecture diff envelope for the commit hook')
+    .requiredOption('--base-graph <path>', 'Retained base fine-grained-role-graph path')
+    .requiredOption('--head-graph <path>', 'Retained head fine-grained-role-graph path')
+    .requiredOption('--repository <name>', 'Repository owner/name')
+    .requiredOption('--base-commit <sha>', 'Base revision (hook: git rev-parse main)')
+    .requiredOption('--head-commit <sha>', 'Head revision (hook: git rev-parse HEAD)')
+    .option('--output <path>', 'Envelope output path', '.riviere/pr-diffs/riviere-architecture-diff.json')
+    .action((options) => {
+      const diffView = dependencies.compareArchitecture.execute({
+        baseGraphPath: options.baseGraph,
+        headGraphPath: options.headGraph,
+        baseRevision: { repository: options.repository, commit: options.baseCommit },
+        headRevision: { repository: options.repository, commit: options.headCommit },
+      })
+      dependencies.writeArchitectureDiffEnvelope(diffView, options.output)
+    })
+}
+
+/** @riviere-role cli-response-writer */
+export function writeArchitectureDiffEnvelope(
+  view: ArchitectureDiffView, // query model returned by CompareArchitecture
+  outputPath: string,
+): void {
+  const envelope = { // structural match of ArchitectureDiffEnvelope; parser-gated on every read
+    metadata: {
+      repository: view.baseRevision.repository,
+      baseRevision: view.baseRevision,
+      headRevision: view.headRevision,
+      sourceLinks: {
+        base: githubSourceLinkTemplate(view.baseRevision.repository, view.baseRevision.commit),
+        head: githubSourceLinkTemplate(view.headRevision.repository, view.headRevision.commit),
+      },
+    },
+    diff: view.diff,
+  }
+  writeFileSync(outputPath, JSON.stringify(envelope, null, 2), 'utf8')
+}
+
+/** @riviere-role cli-response-writer */
+export function writeArchitectureDiffEnvelopePullRequest(
+  view: ArchitectureDiffEnvelopeView, // query model returned by LoadArchitectureDiffEnvelope
+  pullRequest: { number: number; title: string; description: string; url: string },
+  outputPath: string,
+): void {
+  writeFileSync(outputPath, JSON.stringify({
+    metadata: { ...view.envelope.metadata, pullRequest },
+    diff: view.envelope.diff,
+  }, null, 2), 'utf8')
+}
+```
+
+```typescript
+// --- published-language: the retained-file contract with the approved field split ---
+/** @riviere-role published-language-schema */
+export interface ArchitectureDiffEnvelope {
+  readonly metadata: ArchitectureDiffEnvelopeMetadata
+  readonly diff: ArchitectureDiff
+}
+
+/** @riviere-role published-language-data-structure */
+export interface ArchitectureDiffEnvelopeMetadata {
+  readonly repository: string                          // commit hook
+  readonly baseRevision: RevisionReference             // commit hook
+  readonly headRevision: RevisionReference             // commit hook
+  readonly sourceLinks: { base: string; head: string } // commit hook — per-revision blob-link templates
+  readonly pullRequest?: {                             // PR-time Action only
+    readonly number: number; readonly title: string
+    readonly description: string; readonly url: string
+  }
+}
+
+/** @riviere-role published-language-data-structure */
+export interface RevisionReference { readonly repository: string; readonly commit: string }
+
+/** @riviere-role published-language-parser */
+export function parseArchitectureDiffEnvelope(
+  value: unknown,
+): { success: true; value: ArchitectureDiffEnvelope } | { success: false; error: string }
+```
+
+The remaining grouping rule — an aggregate present on both sides is named once as affected while its added/removed members are distinguished (PRD line 70) — follows the same shape: `subdomainChange` derives the direction from presence, and the layer change sets group members by `AggregateView.key()`.
+
+##### New dependencies
+
+| Dependency | Status | Used by | Purpose |
+|---|---|---|---|
+| `@living-architecture/riviere-schema-published-language` | Existing | domain-model, use-cases | `RiviereGraph`/`Component`/`CustomComponent` types for the projection; `parseRiviereGraph` for input validation. |
+| `@living-architecture/riviere-architecture-published-language` | New | domain-model, use-cases, apps/eclair | `ArchitectureDiff`, envelope contract, kind/layer enumerations, and `parseArchitectureDiffEnvelope`. |
+| `@living-architecture/riviere-architecture-domain-model` | New | use-cases | Graph projection value objects and `ArchitectureComparison`. |
+| `@living-architecture/riviere-architecture-use-cases` | New | apps/cli | The compare and envelope-loading queries. |
+
+Enforced app packages (`apps/cli`) import only subdomain queries — the app import rule allows `anySubdomain: ['commands','queries','external-clients']` and forbids published-language, which is why the writers and formatter take query models and primitives. `apps/eclair` is explicitly unassigned; it imports `parseArchitectureDiffEnvelope` from the published-language package directly, mirroring its existing direct imports of `riviere-schema-published-language`. The published-language package must therefore stay browser-safe (schemas and parser only, no Node built-ins). The domain-model imports only schema **types** (plus nothing else); `parseRiviereGraph` is invoked by the use-cases loader, keeping file I/O out of the domain.
+
+##### Code shape
+
+```text
+packages/riviere-architecture/                    (new subdomain packages)
+  domain-model/src/domain/
+    architecture-graph.ts                         ArchitectureGraph.from + selection/link/grouping helpers
+    architecture-element.ts                       ArchitectureElement
+    aggregate-view.ts                             AggregateView
+    invalid-architecture-graph-error.ts           InvalidArchitectureGraphError
+    architecture-comparison.ts                    ArchitectureComparison + helpers
+  published-language/src/published-language/
+    architecture-diff.ts                          ArchitectureDiff + change structures + kind/layer enumerations
+    architecture-diff-envelope.ts                 envelope + metadata + RevisionReference
+    architecture-diff-envelope-parser.ts          parseArchitectureDiffEnvelope
+  use-cases/src/features/comparison/
+    queries/
+      compare-architecture.ts + compare-architecture-input.ts
+      load-architecture-diff-envelope.ts + load-architecture-diff-envelope-input.ts
+      architecture-diff-view.ts                   ArchitectureDiffView
+      architecture-diff-envelope-view.ts          ArchitectureDiffEnvelopeView
+      fine-grained-role-graph-view.ts             FineGrainedRoleGraphView
+    data-access/fine-grained-role-graph/
+      fine-grained-role-graph-loader.ts           + architecture-graph-load-error.ts
+    data-access/architecture-diff-envelope/
+      architecture-diff-envelope-loader.ts        + architecture-diff-envelope-load-error.ts
+apps/cli/src/features/architecture-diff/entrypoint/
+  record-architecture-diff/
+    entrypoint.ts                                 createRecordArchitectureDiffCommand + RecordArchitectureDiffEntrypointDependencies
+    write-architecture-diff-envelope.ts           writeArchitectureDiffEnvelope
+  record-pull-request-metadata/
+    entrypoint.ts                                 createRecordPullRequestMetadataCommand + RecordPullRequestMetadataEntrypointDependencies
+    write-architecture-diff-envelope-pull-request.ts
+  format-architecture-diff-review/
+    entrypoint.ts                                 createFormatArchitectureDiffReviewCommand + FormatArchitectureDiffReviewEntrypointDependencies
+    format-architecture-diff-review.ts            formatArchitectureDiffReview
+  _platform/cli/
+    github-source-link-template.ts                githubSourceLinkTemplate
+.github/workflows/pr-architecture-review.yml      (rewritten to run the PR-time commands)
+apps/eclair/src/features/comparison/...           (PrDiffReviewPage — Éclair-owned)
+```
+
+##### Design validation
+
+- Domain terminology: **pass** — uses Rivière terms (`Component`, `Link`, `Domain`, `fine-grained-role-graph`, `ArchitectureDiff`); proposes `ArchitectureComparison`, `ArchitectureGraph`, `ArchitectureDiffEnvelope`, and `RevisionReference` as named new contract concepts rather than pretending they exist.
+- Application/domain separation: **pass** — queries do load → invoke → return only; the architectural interpretation is `ArchitectureGraph.from` in the domain-model (ARCH §2) and the loaders contain no interpretation logic; both file writes are named app writers following the `finalize`/`writeFinalizedGraph` precedent; every comparison rule lives in `ArchitectureComparison`.
+- Role and location fit: **pass** — every `riviere-architecture` and `apps/cli` element maps to a real role and allowed sublocation (data-access may import own-subdomain value objects per the enforcement config, so the loader invoking the domain factory is legal); each `cli-entrypoint` receives exactly one `*EntrypointDependencies` interface (composition-root assembled, no imported function calls); `PrDiffReviewPage` is the only open role decision because Éclair is explicitly unassigned; the `domain-service` carries a `@riviere-role-justification`.
+- Implementability: **pass** — import rules hold (apps/cli → queries only; use-cases → own domain + any published-language; domain-model → published-language types; published-language imports no workspace package); base/head graph paths are required options so the load contract is total; envelope writes are structural at the app layer and parser-gated on every read; no `in`-operator use, exhaustive union matching, and no consumer-shaped method names on domain objects.
+
+##### Open decisions
+
+- `PrDiffReviewPage` is an open role decision because `apps/eclair` is explicitly unassigned in `.riviere/role-enforcement.config.ts`. Éclair's own architecture owns the approved public resolution steps (GitHub API pull request metadata → raw file URL pinned to the returned head SHA → load and validate) and the browser upload processing, consuming the envelope through `parseArchitectureDiffEnvelope`. Only the page's existence, its envelope-validation boundary, and its presentation responsibility are fixed here; its internal decomposition is deferred to Éclair's approved configuration.
+- If `architecture-comparison.ts` approaches the 400-line limit as more layer rules land, the growth is a modelling signal about a missing domain concept, not a file-splitting decision. The role-valid responses are: identify missing value objects that own part of the composition (for example a `LayerChanges` value object owning per-layer added/removed composition, which removes the layer logic from the service), or — only if several capabilities genuinely need one stable interface — propose a `domain-facade` coordinator, which requires explicit user approval and an `approvedInstances` entry. Splitting into layer-scoped domain services is role-invalid because a `domain-service` may not depend on another `domain-service`. No decomposition is proposed now.
+- Whether `ArchitectureGraph` should later expose a public query interface for direct Éclair exploration of the `fine-grained-role-graph` (PRD §4 line 51) is out of scope; the projection is comparison-only for now.
+
+##### Rejected alternative sub-ideas
+
+- **An `ArchitectureDiff` aggregate with an `ArchitectureDiffRepository`:** rejected — a diff has no lifecycle, invariant, or persistence need; an aggregate would invent state and a save step the product does not have.
+- **The graph-to-architecture projection inside `FineGrainedRoleGraphLoader` (use-cases data-access):** rejected — ARCH §2 assigns "Architectural interpretation and comparison rules" to `packages/riviere-architecture/domain-model`; element selection, ownership-link resolution, and subdomain/layer grouping are domain behaviour, and the `value-object` static-factory contract makes `ArchitectureGraph.from(riviereGraph)` (with `ArchitectureElement`/`AggregateView` owning their field normalisation) the natural owner. The loader reads, validates, invokes the factory, and attaches the revision.
+- **Envelope-writing command use cases in `riviere-architecture`:** rejected — ARCH §2 leaves how and when the diff is generated and committed to each application; write behaviour stays behind named app writers (`cli-response-writer`), keeping the subdomain query-only.
+- **Enforced apps importing `riviere-architecture-published-language` directly:** rejected — the app import rule forbids it, so `apps/cli` receives everything through query-model outputs and primitives. Éclair is the explicit, already-established exception as an unassigned browser app, not an instance of this rejected alternative.
+- **Comparison rules in the use case (loops/conditionals over change sets):** rejected — the transaction-script anti-pattern and the exact failure in `rejected-workflow-use-case-dumping-case-study.md`; grouping and direction belong in the domain service.
+- **A `domain-facade` wrapper around comparison:** rejected — `domain-facade` is for several related capabilities with a common consumer; the comparison is one capability, so the query use case talks to the domain service directly.
+<!-- component-design-option-2:end -->
+
+<!-- component-design-option-3:start -->
+#### Option 3: Fine-grained comparison decomposition
+
+This option decomposes the comparison into small, single-responsibility domain components: four `domain-service` comparisons that each span two revision snapshots (subdomain grouping, entrypoint layer, use-case layer, domain layer), three value objects that own behaviour over state a single object does hold (`ArchitectureSource` projection, `ArchitectureElementCollection` element diffing and evidence resolution, `AssociationMove` dual-evidence pairing), and one `domain-facade` composing them. It designs **both approved phases**: the **commit-hook command** compares two retained `fine-grained-role-graph` revisions, composes the commit-time metadata, and writes the tracked `{ metadata, diff }` envelope to `.riviere/pr-diffs/riviere-architecture-diff.json`; the **PR-time Action command** loads that tracked envelope, adds only `metadata.pullRequest.*`, writes the merged envelope back, and formats the GitHub report from the loaded JSON without recalculating the diff. Both commands follow the codebase's established query pattern exactly: the **query-model** consumes the facade, the **query-model-loader** owns file read + JSON parse, and the **query-model-use-case** only delegates and maps load failures. There is **no aggregate and no repository**: comparison and publication are read-only computations over already-persisted files, no method mutates state, and every rule stays in `domain-model`. Application-owned elements never enter subdomain layers; their association changes are paired into one recorded move with dual base/head evidence; an aggregate changed on both sides is published with machine-distinguishable `status: 'affected'`, never as created-plus-deleted.
+
+##### Domain model change
+
+No new aggregate. Comparison and publication mutate nothing and own no lifecycle invariant, so an `ArchitectureDiffAggregate` + repository would be a forced fit. The proof-of-concept's monolithic `Architecture` value object is replaced by: one per-revision facts value object, one element-collection value object that is the single shared home of element diffing and evidence resolution, one association-move value object, four justified cross-snapshot comparison services, and one facade. Published-contract changes this correction adds: `AggregateDiff.status` (`created` / `affected` / `removed`) so an aggregate affected on both sides is machine-distinguishable from a newly created one (the PRD summary rule), domain layer diffs carry a named `affectedAggregates` list, and element relationships are published as the POC-modelled `ArchitectureRelationship` collection (`relatedTo`) with `associatedSubdomains` rather than a single optional string. `ArchitectureElementCollection` and `AssociationMove` are proposed terms — there is no existing domain vocabulary for "one layer's element list at one revision" or for the PRD's "application association change" as a first-class concept.
+
+```mermaid
+flowchart LR
+  architectureSource["ArchitectureSource<br/>(per revision facts)"]
+  elementCollection["ArchitectureElementCollection<br/>(layer element list)"]
+  associationMove["AssociationMove<br/>(changed association)"]
+  architectureComparison["ArchitectureComparison"]
+  groupSubdomainDiff["groupSubdomainDiff"]
+  compareEntrypointLayer["compareEntrypointLayer"]
+  compareUseCaseLayer["compareUseCaseLayer"]
+  compareDomainLayer["compareDomainLayer"]
+  aggregateDiff["AggregateDiff<br/>(status created affected removed)"]
+  architectureDiff["ArchitectureDiff<br/>(compared facts)"]
+
+  architectureComparison -->|"compares two"| architectureSource
+  architectureSource -->|"contains per layer"| elementCollection
+  elementCollection -->|"pairs both sides into"| associationMove
+  architectureComparison -->|"pairs subdomains through"| groupSubdomainDiff
+  groupSubdomainDiff -->|"labels presence of"| architectureSource
+  architectureComparison -->|"compares entrypoint layer through"| compareEntrypointLayer
+  compareEntrypointLayer -->|"diffs element lists through"| elementCollection
+  architectureComparison -->|"compares use case layer through"| compareUseCaseLayer
+  compareUseCaseLayer -->|"diffs element lists through"| elementCollection
+  architectureComparison -->|"compares domain layer through"| compareDomainLayer
+  compareDomainLayer -->|"diffs element lists through"| elementCollection
+  compareDomainLayer -->|"labels each aggregate"| aggregateDiff
+  architectureComparison -->|"diffs application associations through"| elementCollection
+  associationMove -->|"carries dual evidence into"| architectureDiff
+  aggregateDiff -->|"fills affectedAggregates of"| architectureDiff
+  architectureComparison -->|"exposes result as"| architectureDiff
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+  class architectureSource statusNew
+  class elementCollection statusNew
+  class associationMove statusNew
+  class architectureComparison statusOpen
+  class groupSubdomainDiff statusNew
+  class compareEntrypointLayer statusNew
+  class compareUseCaseLayer statusNew
+  class compareDomainLayer statusNew
+  class aggregateDiff statusNew
+  class architectureDiff statusNew
+```
+
+Legend: gray = existing, yellow = changed, green = new, red = unclear/open decision. All concepts are new to the `riviere-architecture` subdomain, though `ArchitectureSource`, `ArchitectureDiff`, and the relationship vocabulary carry over the comparison-facts vocabulary validated in the `living-documentation` proof of concept. `ArchitectureComparison` is red because the new `domain-facade` instance awaits user approval (see Open decisions).
+
+##### Runtime call diagram
+
+```mermaid
+flowchart LR
+  generateEntrypoint["createGeneratePrArchitectureDiffCommand<br/>(apps/cli feature entrypoint)"]
+  compareUseCase["CompareArchitectures<br/>(use-cases queries)"]
+  graphLoader["ArchitectureDiffLoader<br/>(use-cases data-access)"]
+  diffResult["ArchitectureDiffResult<br/>(use-cases queries)"]
+  failureMapper["toArchitectureGraphLoadFailure<br/>(use-cases queries)"]
+  facade["ArchitectureComparison<br/>(domain-model)"]
+  architectureSource["ArchitectureSource<br/>(domain-model)"]
+  groupSubdomainDiff["groupSubdomainDiff<br/>(domain-model)"]
+  compareEntrypointLayer["compareEntrypointLayer<br/>(domain-model)"]
+  compareUseCaseLayer["compareUseCaseLayer<br/>(domain-model)"]
+  compareDomainLayer["compareDomainLayer<br/>(domain-model)"]
+  elementCollection["ArchitectureElementCollection<br/>(domain-model)"]
+  associationMove["AssociationMove<br/>(domain-model)"]
+  commitComposer["composeCommitArchitectureDiffEnvelope<br/>(apps/cli feature entrypoint)"]
+  envelopeWriter["writeArchitectureDiffEnvelope<br/>(apps/cli feature entrypoint)"]
+  loadFailureFormatter["formatArchitectureGraphLoadFailure<br/>(apps/cli feature entrypoint)"]
+  publishEntrypoint["createPublishPrArchitectureDiffCommand<br/>(apps/cli feature entrypoint)"]
+  envelopeUseCase["LoadArchitectureDiffEnvelope<br/>(use-cases queries)"]
+  envelopeLoader["ArchitectureDiffEnvelopeLoader<br/>(use-cases data-access)"]
+  diffParser["parseArchitectureDiff<br/>(riviere-architecture published-language)"]
+  envelopeFailureMapper["toArchitectureDiffEnvelopeLoadFailure<br/>(use-cases queries)"]
+  envelopeFailureFormatter["formatArchitectureDiffEnvelopeLoadFailure<br/>(apps/cli feature entrypoint)"]
+  prMetadataFormatter["withPullRequestMetadata<br/>(apps/cli feature entrypoint)"]
+  envelopeWriteBack["writePublishedArchitectureDiffEnvelope<br/>(apps/cli feature entrypoint)"]
+  reportFormatter["formatArchitectureDiffReport<br/>(apps/cli feature entrypoint)"]
+  reportWriter["writeArchitectureDiffReport<br/>(apps/cli feature entrypoint)"]
+
+  generateEntrypoint -->|execute| compareUseCase
+  compareUseCase -->|load| graphLoader
+  compareUseCase -->|toArchitectureGraphLoadFailure| failureMapper
+  graphLoader -->|parse| diffResult
+  diffResult -->|fromRevisions| facade
+  diffResult -->|compare| facade
+  facade -->|fromGraph| architectureSource
+  facade -->|applicationElements| architectureSource
+  facade -->|groupSubdomainDiff| groupSubdomainDiff
+  groupSubdomainDiff -->|subdomainNames, subdomain| architectureSource
+  facade -->|compareEntrypointLayer| compareEntrypointLayer
+  compareEntrypointLayer -->|fromStates, addedIn, removedIn| elementCollection
+  facade -->|compareUseCaseLayer| compareUseCaseLayer
+  compareUseCaseLayer -->|fromStates, addedIn, removedIn| elementCollection
+  facade -->|compareDomainLayer| compareDomainLayer
+  compareDomainLayer -->|fromStates, addedIn, removedIn| elementCollection
+  facade -->|applicationAssociationChanges| elementCollection
+  elementCollection -->|fromStates| associationMove
+  generateEntrypoint -->|formatArchitectureGraphLoadFailure| loadFailureFormatter
+  generateEntrypoint -->|composeCommitArchitectureDiffEnvelope| commitComposer
+  generateEntrypoint -->|writeArchitectureDiffEnvelope| envelopeWriter
+  publishEntrypoint -->|execute| envelopeUseCase
+  envelopeUseCase -->|load| envelopeLoader
+  envelopeUseCase -->|toArchitectureDiffEnvelopeLoadFailure| envelopeFailureMapper
+  envelopeLoader -->|parseArchitectureDiff| diffParser
+  publishEntrypoint -->|formatArchitectureDiffEnvelopeLoadFailure| envelopeFailureFormatter
+  publishEntrypoint -->|withPullRequestMetadata| prMetadataFormatter
+  publishEntrypoint -->|writePublishedArchitectureDiffEnvelope| envelopeWriteBack
+  publishEntrypoint -->|formatArchitectureDiffReport| reportFormatter
+  publishEntrypoint -->|writeArchitectureDiffReport| reportWriter
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+  class generateEntrypoint statusNew
+  class compareUseCase statusNew
+  class graphLoader statusNew
+  class diffResult statusNew
+  class failureMapper statusNew
+  class facade statusOpen
+  class architectureSource statusNew
+  class groupSubdomainDiff statusNew
+  class compareEntrypointLayer statusNew
+  class compareUseCaseLayer statusNew
+  class compareDomainLayer statusNew
+  class elementCollection statusNew
+  class associationMove statusNew
+  class commitComposer statusNew
+  class envelopeWriter statusNew
+  class loadFailureFormatter statusNew
+  class publishEntrypoint statusNew
+  class envelopeUseCase statusNew
+  class envelopeLoader statusNew
+  class diffParser statusNew
+  class envelopeFailureMapper statusNew
+  class envelopeFailureFormatter statusNew
+  class prMetadataFormatter statusNew
+  class envelopeWriteBack statusNew
+  class reportFormatter statusNew
+  class reportWriter statusNew
+```
+
+Legend: gray = existing, yellow = changed, green = new, red = unclear ownership / open decision. `ArchitectureComparison` is red because the new `domain-facade` instance awaits user approval. Left cluster = commit-hook phase; right cluster = PR-time Action phase.
+
+##### Components
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `ArchitectureDiff` (+ `ApplicationDiff`, `SubdomainDiff`, `ArchitectureLayerDiff`, `ArchitectureChangeSet`, `UseCaseChangeGroup`, `ArchitectureElement`, `AggregateDiff`, `ArchitectureRelationship`, `SourceEvidence`) | `packages/riviere-architecture/published-language/src/published-language/architecture-diff.ts` | New | `published-language-schema` / `published-language-data-structure` | Minimal stable wire contract consumed by GitHub and Éclair. `SourceEvidence = { base?, head? }` reusing `SourceLocation`. `AggregateDiff.status: 'created' \| 'affected' \| 'removed'` makes an aggregate affected on both sides machine-distinguishable from a newly created one; domain layer diffs carry `affectedAggregates` only when non-empty. `ArchitectureElement.relatedTo` is an `ArchitectureRelationship[]` collection (`{ name, role }`, POC vocabulary) plus `associatedSubdomains: string[]`. `application.associationChanges` holds dual-evidence association moves recorded once. No application behaviour. | Medium |
+| `SubdomainChange` / `ArchitecturePackageKind` / `ElementChangeDirection` / `AggregateChangeStatus` | same package | New | `published-language-union` | Closed unions: `added\|changed\|removed`, `application\|use-cases\|domain-model\|published-language`, `added\|removed`, `created\|affected\|removed`. | Small |
+| `parseArchitectureDiff` | `.../published-language/parse-architecture-diff.ts` | New | `published-language-parser` | Parses `unknown` into `{ success: true, diff } \| { success: false, issues }`; consumed by the envelope loader (data-access may import any subdomain published-language) and later by Éclair. | Medium |
+| `ArchitectureSource` | `packages/riviere-architecture/domain-model/src/domain/architecture-source.ts` | New | `value-object` | Projects one `RiviereGraph` into comparison facts via `static fromGraph` (custom-component filter, application/subdomain ownership split, layer mapping by `packageKind`, aggregate split, `aggregateOwnerId` resolution, **all** `supports-primary-element` links collected into a canonicalised relationship collection, source evidence); exposes `subdomain(name)`, `subdomainNames()`, `applicationElements()`. Internal fact shapes (`ElementState`, `ElementRelationship`, `AggregateState`, `ArchitectureLayerState`, `SubdomainFacts`) are inline-typed like the builder's `GraphDiff` nested shapes. | Medium |
+| `ArchitectureElementCollection` | `.../domain/architecture-element-collection.ts` | New | `value-object` | The one shared home of element-list diffing: `fromStates`, `addedIn`, `removedIn` (single-side evidence resolved here), `applicationAssociationChanges` (identity pairing over the relationship collection, move/add/remove split). Owns the element identity key and the association identity. | Medium |
+| `AssociationMove` | `.../domain/association-move.ts` | New | `value-object` | One application-owned element present on both sides whose association changed; `toElement()` records it once with dual base/head evidence. | Small |
+| `InvalidArchitectureGraphError` | `.../domain/invalid-architecture-graph-error.ts` | New | `domain-error` | Thrown by the facade when a graph fails published-language validation; the loader surfaces it as `GraphCorruptedError`. | Small |
+| `ArchitectureComparison` | `.../domain/architecture-comparison.ts` | New | `domain-facade` *(open decision)* | One stable interface over the four comparisons: `static fromRevisions(baseJson, headJson)` + `compare(): ArchitectureDiff`. Consumed by the query-model, not the use case. | Medium |
+| `groupSubdomainDiff` | `.../domain/subdomain-grouper.ts` | New | `domain-service` (justified) | Pairs subdomain facts from the union of both snapshots' names and labels each pair's presence `added\|changed\|removed` (absorbs the former `classifyChange`). | Small |
+| `compareEntrypointLayer` | `.../domain/entrypoint-layer-comparison.ts` | New | `domain-service` (justified) | Compares subdomain-owned entrypoint-layer items; returns `undefined` when unchanged. Application-owned entry points never reach it. | Small |
+| `compareUseCaseLayer` | `.../domain/use-case-layer-comparison.ts` | New | `domain-service` (justified) | Compares use-case-layer items and groups changed supporting elements under each named use case from the element's `relatedTo` relationships (an element supporting several use cases appears in each named group, POC parity); unattached changes stay in `items` as the supporting group. | Small |
+| `compareDomainLayer` | `.../domain/domain-layer-comparison.ts` | New | `domain-service` (justified) | Compares domain-layer aggregates and items; owns the both-sides rule: an aggregate present on both sides with member changes is published once with `status: 'affected'` in `affectedAggregates`, head-only aggregates get `status: 'created'` in `added.aggregates`, vanished ones `status: 'removed'` in `removed.aggregates` — never created-plus-deleted. | Medium |
+| `CompareArchitectures` | `packages/riviere-architecture/use-cases/src/features/architecture-comparison/queries/compare-architectures.ts` | New | `query-model-use-case` | `execute(input)` → `loader.load(...)` in a try/catch that maps thrown data-access errors via `toArchitectureGraphLoadFailure` (mirrors `ListDomains`). One method, no domain logic. | Small |
+| `CompareArchitecturesInput` | `.../queries/compare-architectures-input.ts` | New | `query-model-use-case-input` | `{ baseGraphPath: string; headGraphPath: string }` — the two retained graph file paths. | Small |
+| `ArchitectureDiffResult` | `.../queries/architecture-diff-result.ts` | New | `query-model` | Concrete result class (private constructor + `static parse(baseJson, headJson)`) that consumes the facade: `ArchitectureComparison.fromRevisions(...).compare()`. | Small |
+| `CompareArchitecturesResult` / `ArchitectureGraphLoadFailure` / `toArchitectureGraphLoadFailure` | `.../queries/compare-architectures-result.ts`, `.../queries/architecture-graph-load-failure.ts` | New | `query-model-value` / `query-model` | Result union `ArchitectureDiffResult \| ArchitectureGraphLoadFailure`; the mapper converts thrown `GraphNotFoundError`/`GraphCorruptedError` into the failure union. | Small |
+| `ArchitectureDiffLoader` | `.../data-access/architecture-diff/architecture-diff-loader.ts` | New | `query-model-loader` | `load(baseGraphPath, headGraphPath)` reads both files (`node:fs`), `JSON.parse`s, and calls `ArchitectureDiffResult.parse`; wraps any parse/validation failure in `GraphCorruptedError`. | Small |
+| `GraphNotFoundError` / `GraphCorruptedError` | `.../data-access/architecture-diff/` | New | `data-access-error` | Thrown by the graph loader; mapped onto `ArchitectureGraphLoadFailure` by the use case. | Small |
+| `LoadArchitectureDiffEnvelope` | `.../queries/load-architecture-diff-envelope.ts` | New | `query-model-use-case` | `execute(input)` → `loader.load(...)` in a try/catch that maps thrown data-access errors via `toArchitectureDiffEnvelopeLoadFailure`. One method, no domain logic. | Small |
+| `LoadArchitectureDiffEnvelopeInput` | `.../queries/load-architecture-diff-envelope-input.ts` | New | `query-model-use-case-input` | `{ envelopePathOption: string \| undefined }` — undefined means the tracked default path. | Small |
+| `ArchitectureDiffEnvelope` | `.../queries/architecture-diff-envelope.ts` | New | `query-model` | `{ metadata, diff }` interface — the tracked-file read shape and the CLI write target; `diff` is the validated `ArchitectureDiff`, so apps consume the schema through this query export without importing published-language. | Small |
+| `ArchitectureDiffEnvelopeMetadata` / `ArchitectureDiffSourceLinks` / `ArchitectureDiffPullRequestMetadata` | `.../queries/architecture-diff-envelope-metadata.ts` | New | `query-model-value` | Commit-time metadata (`repository`, `baseRevision`, `headRevision`, `sourceLinks`, optional `pullRequest`) and PR-time metadata (`number`, `title`, `description`, `url`); keeps GitHub-specific identity fields out of the language-agnostic diff schema per the approved rejection. | Small |
+| `LoadArchitectureDiffEnvelopeResult` / `ArchitectureDiffEnvelopeLoadFailure` / `toArchitectureDiffEnvelopeLoadFailure` | `.../queries/load-architecture-diff-envelope-result.ts` | New | `query-model-value` / `query-model` | Result union `ArchitectureDiffEnvelope \| ArchitectureDiffEnvelopeLoadFailure`; the mapper converts thrown envelope data-access errors into the failure union. | Small |
+| `ArchitectureDiffEnvelopeLoader` | `.../data-access/architecture-diff-envelope/architecture-diff-envelope-loader.ts` | New | `query-model-loader` | `load(envelopePathOption)` resolves the tracked default path, `existsSync`/`readFileSync`/`JSON.parse`s the envelope, validates `diff` via `parseArchitectureDiff` and the four commit-time metadata fields, and returns the envelope; failures throw the errors below. | Small |
+| `ArchitectureDiffEnvelopeNotFoundError` / `ArchitectureDiffEnvelopeCorruptedError` | `.../data-access/architecture-diff-envelope/` | New | `data-access-error` | Missing tracked file or invalid envelope JSON/diff/metadata. | Small |
+| `createGeneratePrArchitectureDiffCommand` + options/dependencies interfaces | `apps/cli/src/features/architecture-diff/entrypoint/generate-pr-architecture-diff/entrypoint.ts` | New | `cli-entrypoint` / `cli-entrypoint-dependencies` | Commit-hook command. Builds `CompareArchitecturesInput` directly from parsed `--base-graph`/`--head-graph` flags (canonical query pattern — no input factory), executes the use case, and on success composes the envelope from the result plus `--repository`/`--base-revision`/`--head-revision` and writes it to `--output` (default tracked path); on failure prints the formatted load failure. | Small |
+| `composeCommitArchitectureDiffEnvelope` | `.../generate-pr-architecture-diff/compose-commit-architecture-diff-envelope.ts` | New | `cli-output-formatter` | Composes `{ metadata: { repository, baseRevision, headRevision, sourceLinks }, diff }` with explicit field origins: the three commit-context fields verbatim from the flags (supplied by the hook's git commands — the CLI runs no git subprocess), `sourceLinks` derived as base/head blob-URL prefixes, `diff` from the query result. Writes no `pullRequest` keys. | Small |
+| `writeArchitectureDiffEnvelope` | `.../generate-pr-architecture-diff/write-architecture-diff-envelope.ts` | New | `cli-response-writer` | `writeArchitectureDiffEnvelope(envelope, outputPath)` — one `writeFile` of `JSON.stringify(envelope, null, 2)` to the tracked path (mirrors `writeFinalizedGraph`); input is the `query-model` envelope, satisfying `cli-response-writer.allowedInputs`. | Small |
+| `formatArchitectureGraphLoadFailure` | `.../generate-pr-architecture-diff/format-architecture-graph-load-failure.ts` | New | `cli-output-formatter` | Formats `ArchitectureGraphLoadFailure` for CLI output. Lives in the feature entrypoint folder (not root infra) because it consumes the subdomain queries contract. | Small |
+| `createPublishPrArchitectureDiffCommand` + options/dependencies interfaces | `apps/cli/src/features/architecture-diff/entrypoint/publish-pr-architecture-diff/entrypoint.ts` | New | `cli-entrypoint` / `cli-entrypoint-dependencies` | PR-time Action command. Builds `LoadArchitectureDiffEnvelopeInput` from `--envelope` (default tracked path), executes the envelope query — the diff is **never recalculated** — then merges `--pull-request-number/-title/-description/-url`, writes the merged envelope back, formats the report, and writes it to `--report-output`. | Small |
+| `withPullRequestMetadata` | `.../publish-pr-architecture-diff/with-pull-request-metadata.ts` | New | `cli-output-formatter` | Adds only `metadata.pullRequest.{number,title,description,url}` to the loaded envelope (approved PR-time field ownership); touches no other field. | Small |
+| `formatArchitectureDiffReport` (+ section formatters) | `.../publish-pr-architecture-diff/format-architecture-diff-report.ts` | New | `cli-output-formatter` | Formats the complete GitHub Markdown report from the merged envelope (`diff` facts + `sourceLinks`); selects affected aggregates for the summary via `status === 'affected'`; decomposes into section formatter files like the POC (`architecture-review-*.ts`) before any file reaches 400 lines. | Large |
+| `formatArchitectureDiffEnvelopeLoadFailure` | `.../publish-pr-architecture-diff/format-architecture-diff-envelope-load-failure.ts` | New | `cli-output-formatter` | Formats `ArchitectureDiffEnvelopeLoadFailure` for CLI output. | Small |
+| `writePublishedArchitectureDiffEnvelope` | `.../publish-pr-architecture-diff/write-published-architecture-diff-envelope.ts` | New | `cli-response-writer` | `writePublishedArchitectureDiffEnvelope(envelope, envelopePath)` — writes the merged envelope back to the tracked file; input is the `query-model` envelope. | Small |
+| `writeArchitectureDiffReport` | `.../publish-pr-architecture-diff/write-architecture-diff-report.ts` | New | `cli-response-writer` | `writeArchitectureDiffReport(markdown, reportPath)` — writes the Markdown file the workflow posts as the pull-request comment. | Small |
+| Éclair review page | `apps/eclair/src/features/pr-diff/...` | New | unassigned (`apps/eclair` is in `unassignedPackages`) | Boundary only. The Éclair feature design — public PR link resolution, upload-envelope parsing, the approved review page — is a deferred open decision (see Open decisions); the envelope and `ArchitectureDiff` above already fix the contract it consumes. | — (deferred) |
+| Commit-hook script + PR workflow steps | `.githooks/` + `.github/workflows/` | Changed | outside enforced packages | The hook supplies `--base-graph`/`--head-graph` and the git-context flags (`git remote get-url origin`, `git rev-parse main`, `git rev-parse HEAD`); the PR workflow supplies the GitHub event-context flags and posts the written report as the comment. | — |
+
+### .riviere role options
+
+| Decision | Candidate roles considered | Preferred role | Reason | Open decision |
+|---|---|---|---|---|
+| Cross-revision comparison behaviour (subdomain grouping, three layer comparisons) | aggregate + `aggregate-repository`; methods on one `Architecture` value object; `domain-service` | `domain-service` (per declaration, each justified) | Aggregate rejected: comparison mutates nothing and owns no lifecycle invariant. Monolithic value object rejected: it would have to hold both revisions' facts. Each comparison spans two `ArchitectureSource` snapshots, so no single value object owns the state it reads. | None |
+| Element-list diffing and evidence pairing | `domain-service`; unexported per-file helpers shared across layer files | `value-object` (`ArchitectureElementCollection`) | Identity keys and single-side evidence are behaviour of one layer's element list; two layer services need one shared legal home, and `domain-service`→`domain-service` dependencies are forbidden. | None |
+| Application association change | `domain-service`; `value-object` | `value-object` (`AssociationMove`) | Pairs two states of one application-owned element; dual base/head evidence defines the concept, per the `look-for-missing-value-objects-before-domain-services` memory. | None |
+| Stable compare interface | query-model calling each capability directly; `domain-facade` | `domain-facade` (`ArchitectureComparison`) | Query-model consumers need one stable interface over the grouper and layer comparisons instead of sequencing them (same rationale as approved `RiviereQuery`). | New facade instance requires explicit user approval (`roles.ts` `approvedInstances`). |
+| Tracked-envelope query (load + validate the published JSON) | app-side JSON read; `query-model-loader` + `query-model-use-case` in the subdomain | `query-model-loader` (`ArchitectureDiffEnvelopeLoader`) + `query-model-use-case` (`LoadArchitectureDiffEnvelope`) | Approved ownership assigns loading its inputs to `riviere-architecture/use-cases`; mirrors `ListDomains` + `query-loaders.ts`; keeps the Action's read inside the canonical pattern with no write behaviour on the query side. | None |
+| Envelope composition and PR-metadata merge | inside the writers; a command use case; `cli-output-formatter` | `cli-output-formatter` (`composeCommitArchitectureDiffEnvelope`, `withPullRequestMetadata`) | Pure presentation-side composition of already-generated facts with explicit field origins; no state change, no loading — same precedent as the POC formatter / `writeFinalizedGraph` separation. | None |
+| Complete GitHub report formatting | root `infra/cli/presentation`; feature entrypoint folder | feature entrypoint folder (`cli-output-formatter`) | ADR-002 forbids root infra importing application/domain code and `app.ts` gives `/infra` own-subtree-only imports; the report consumes the full subdomain contract. POC precedent keeps `pull-request-architecture-diff-formatter.ts` in the feature entrypoint folder. | None |
+| Output file writes | formatters writing directly; `cli-response-writer` | `cli-response-writer` (three small writers, one per entrypoint folder) | Writers perform the output side effect only; envelope writers take the `query-model` envelope, satisfying `allowedInputs: ['command-use-case-result', 'query-model']`. | None |
+| Query input translation | `command-input-factory`; direct construction in `cli-entrypoint` | direct construction in `cli-entrypoint` | `command-input-factory` `allowedOutputs` is `command-use-case-input` only; the canonical "CLI Invoking Query Model Use Case" pattern and existing query entrypoints construct the query input in the entrypoint. | None |
+| Load failure handling | loader returns a failure union; loader throws + use case maps | loader throws + use case maps via `query-model` mappers | Mirrors `ListDomains` + `toQueryGraphLoadFailure`; both loaders stay load-or-throw. | None |
+
+### Canonical role pattern
+
+This option follows **"CLI Invoking Query Model Use Case"** and **"Query Model Use Case loading and querying a query model"** from `.riviere/canonical-role-configurations.md`, applied to both commands: each `cli-entrypoint` orchestrates everything and constructs the `query-model-use-case-input` directly from parsed flags (no factory), each `query-model-use-case` injects its `query-model-loader` and maps load failures, each loader reads and parses its input files into a `query-model`, the comparison query model consumes the `domain-facade`, and there is no save step — publication writes happen through `cli-output-formatter` composition and `cli-response-writer` file writes at the CLI output boundary.
+
+### Tangled responsibility findings
+
+No tangled responsibilities identified in existing production code — the design creates the new `riviere-architecture` package rather than modifying existing packages. Tangles present in earlier drafts of this option were resolved: (1) `addedItems`/`itemKey` shared across two layer-comparison files with no legal role home now live once on the `ArchitectureElementCollection` value object; (2) source evidence resolved in a separate pass after layer comparison now resolves inside the collection and `AssociationMove` at the moment presence is decided; (3) the complete-diff formatter previously placed in root `infra/cli/presentation` — which ADR-002 and `app.ts` forbid from importing the subdomain contract — now lives in the feature entrypoint folder, matching the POC precedent, with only genuinely generic formatters left in root infra; (4) the envelope write path previously had no composition component and contradicted its own outline — the commit composer and the `query-model` envelope writer input now make prose, table, outline, and stress test agree; (5) the PR-time publication phase previously dismissed as "outside this command" is now fully designed rather than silently dropped.
+
+#### State loading and persistence (constraint 4)
+
+All file reading and parsing is owned inside `riviere-architecture` — never pushed to the app. Both envelope writes go through `cli-response-writer` functions whose envelope input is the `query-model` `ArchitectureDiffEnvelope`.
+
+**Load 1 — comparison inputs (commit-hook phase).**
+
+- **What is loaded:** two `fine-grained-role-graph` files on disk (base = retained `main` graph, head = current-commit graph), each a JSON-encoded `RiviereGraph` whose `CustomComponent`s have `customTypeName === 'architecture-review-element'` carrying `architectureRole`, `packageKind`, optionally `aggregateOwnerId`/`externalClient`/`methods`, connected by `supports-primary-element` links (`aggregateOwnerId` mirrors the `aggregate-owns-entity` link), each with a `sourceLocation`.
+- **Loader:** `ArchitectureDiffLoader` (`query-model-loader`).
+- **Load method:** `load(baseGraphPath: string, headGraphPath: string): ArchitectureDiffResult`.
+- **Load inputs and provenance:** `input.baseGraphPath` ← CLI flag `--base-graph`; `input.headGraphPath` ← CLI flag `--head-graph`; the commit hook supplies both file paths. Per file, `readGraphJson` runs `existsSync` (missing → throws `GraphNotFoundError`), then `readFileSync` + `JSON.parse` (invalid JSON → throws `GraphCorruptedError`); any error thrown by `ArchitectureDiffResult.parse` (schema-invalid graph) is also wrapped as `GraphCorruptedError`.
+- **Loaded output:** an `ArchitectureDiffResult` (query-model) wrapping the published `ArchitectureDiff`, or — after the use case maps a thrown data-access error via `toArchitectureGraphLoadFailure` — an `ArchitectureGraphLoadFailure`.
+- **Projection into comparison facts (owned by domain):** `ArchitectureDiffResult.parse` calls `ArchitectureComparison.fromRevisions(baseJson, headJson)`, which builds two `ArchitectureSource` value objects via `ArchitectureSource.fromGraph(graph)`. The projection yields per-subdomain facts `layers: { entrypoints, useCases, domain }` (each `{ aggregates, items }`) plus one application-wide element collection.
+- **Field provenance:** subdomain name ← element `domain`; application vs subdomain placement ← `packageKind === 'application'`; layer ← `packageKind`; aggregate-vs-item split ← `role === 'aggregate'`; aggregate `entities` ← element `aggregateOwnerId` resolved through `componentsById`; `relatedTo` ← **every** `supports-primary-element` link collected per supporting element and canonicalised (unique by role+name, sorted — POC `canonicalRelationships` parity, so multi-relationship elements lose no facts); `associatedSubdomains` ← sorted unique domains of those primaries; `name`/`role`/`externalClient`/`methods` ← element fields; `sourceEvidence` ← element `sourceLocation`.
+
+**Persist 1 — commit-time tracked envelope write.**
+
+- **Composer:** `composeCommitArchitectureDiffEnvelope(result: ArchitectureDiffResult, commitContext: ArchitectureDiffCommitContext): ArchitectureDiffEnvelope` (`cli-output-formatter`); `commitContext` is `{ repository, baseRevision, headRevision }` ← CLI flags `--repository`/`--base-revision`/`--head-revision`, each supplied by the commit hook from `git remote get-url origin`, `git rev-parse main`, and `git rev-parse HEAD` (the CLI runs no git subprocess). `metadata.sourceLinks` ← composer-derived base/head blob-URL prefixes `https://github.com/{repository}/blob/{revision}/` used by the GitHub formatter and Éclair to build source-line links from `SourceLocation`. `diff` ← `result.diff`. No `pullRequest` keys exist at commit time.
+- **Writer:** `writeArchitectureDiffEnvelope(envelope: ArchitectureDiffEnvelope, outputPath: string): Promise<void>` (`cli-response-writer`) — one `writeFile(outputPath, JSON.stringify(envelope, null, 2))`; `outputPath` ← `--output`, default `.riviere/pr-diffs/riviere-architecture-diff.json`.
+
+**Load 2 — tracked envelope (PR-time Action phase; the diff is never recalculated).**
+
+- **What is loaded:** the tracked file `.riviere/pr-diffs/riviere-architecture-diff.json` — the `{ metadata, diff }` envelope written by Load/Persist 1 and committed to the head commit.
+- **Loader:** `ArchitectureDiffEnvelopeLoader` (`query-model-loader`).
+- **Load method:** `load(envelopePathOption: string | undefined): ArchitectureDiffEnvelope`.
+- **Load inputs and provenance:** `input.envelopePathOption` ← CLI flag `--envelope` supplied by the workflow step; `undefined` resolves to the tracked default path. `existsSync` (missing → `ArchitectureDiffEnvelopeNotFoundError`), `readFileSync` + `JSON.parse` (invalid → `ArchitectureDiffEnvelopeCorruptedError`), `parseArchitectureDiff(json.diff)` (schema-invalid diff → `ArchitectureDiffEnvelopeCorruptedError`), and required-field validation of `metadata.repository`/`.baseRevision`/`.headRevision`/`.sourceLinks` (invalid → `ArchitectureDiffEnvelopeCorruptedError`).
+- **Loaded output:** `ArchitectureDiffEnvelope` — `metadata` ← typed passthrough of the file's metadata block (including `pullRequest` when a previous publish already added it); `diff` ← the `parseArchitectureDiff` success value. Or, after the use case maps a thrown data-access error via `toArchitectureDiffEnvelopeLoadFailure`, an `ArchitectureDiffEnvelopeLoadFailure`.
+
+**Persist 2 — PR-time write-back and report write.**
+
+- **Merge:** `withPullRequestMetadata(envelope: ArchitectureDiffEnvelope, pullRequest: ArchitectureDiffPullRequestMetadata): ArchitectureDiffEnvelope` (`cli-output-formatter`); `pullRequest.number/.title/.description/.url` ← CLI flags `--pull-request-number/-title/-description/-url` supplied by the workflow step from the GitHub Actions pull-request event context. Only `metadata.pullRequest.*` is added — the approved PR-time field ownership.
+- **Write-back:** `writePublishedArchitectureDiffEnvelope(publishedEnvelope: ArchitectureDiffEnvelope, envelopePath: string): Promise<void>` (`cli-response-writer`) — `writeFile` of the merged envelope to the same tracked path.
+- **Report:** `formatArchitectureDiffReport(publishedEnvelope): string` (`cli-output-formatter`) then `writeArchitectureDiffReport(markdown: string, reportPath: string): Promise<void>` (`cli-response-writer`); `reportPath` ← `--report-output`. The workflow posts this file as the pull-request comment, so the pull request continues to present one architecture diff.
+
+##### Code stress test
+
+```typescript
+// --- query-model-use-case (commit phase): load, map data-access failures, return ---
+/** @riviere-role query-model-use-case */
+export class CompareArchitectures {
+  constructor(private readonly loader: ArchitectureDiffLoader) {}
+
+  execute(input: CompareArchitecturesInput): CompareArchitecturesResult {
+    try {
+      return this.loader.load(input.baseGraphPath, input.headGraphPath)
+    } catch (error) {
+      const failure = toArchitectureGraphLoadFailure(error)
+      if (failure !== undefined) return failure
+      throw error
+    }
+  }
+}
+
+/** @riviere-role query-model-use-case-input */
+export interface CompareArchitecturesInput {
+  readonly baseGraphPath: string
+  readonly headGraphPath: string
+}
+
+// --- query-model-use-case (PR-time phase): same canonical shape ---
+/** @riviere-role query-model-use-case */
+export class LoadArchitectureDiffEnvelope {
+  constructor(private readonly loader: ArchitectureDiffEnvelopeLoader) {}
+
+  execute(input: LoadArchitectureDiffEnvelopeInput): LoadArchitectureDiffEnvelopeResult {
+    try {
+      return this.loader.load(input.envelopePathOption)
+    } catch (error) {
+      const failure = toArchitectureDiffEnvelopeLoadFailure(error)
+      if (failure !== undefined) return failure
+      throw error
+    }
+  }
+}
+
+/** @riviere-role query-model-use-case-input */
+export interface LoadArchitectureDiffEnvelopeInput {
+  readonly envelopePathOption: string | undefined
+}
+
+// --- query-model-loader: owns the envelope file read + JSON parse + schema validation ---
+/** @riviere-role query-model-loader */
+export class ArchitectureDiffEnvelopeLoader {
+  load(envelopePathOption: string | undefined): ArchitectureDiffEnvelope {
+    const envelopePath = envelopePathOption ?? '.riviere/pr-diffs/riviere-architecture-diff.json'
+    if (!existsSync(envelopePath)) throw new ArchitectureDiffEnvelopeNotFoundError(envelopePath)
+    let json: unknown
+    try {
+      json = JSON.parse(readFileSync(envelopePath, 'utf-8'))
+    } catch (error) {
+      throw new ArchitectureDiffEnvelopeCorruptedError(envelopePath, { cause: error })
+    }
+    // validate diff through the published-language parser and the four commit-time metadata
+    // fields; either failure throws ArchitectureDiffEnvelopeCorruptedError
+    return toValidatedEnvelope(json, envelopePath)
+  }
+}
+
+// --- query-model: the tracked-file read shape and the CLI write target ---
+/** @riviere-role query-model */
+export interface ArchitectureDiffEnvelope {
+  readonly metadata: ArchitectureDiffEnvelopeMetadata
+  readonly diff: ArchitectureDiff
+}
+
+/** @riviere-role query-model-value */
+export interface ArchitectureDiffEnvelopeMetadata {
+  readonly repository: string
+  readonly baseRevision: string
+  readonly headRevision: string
+  readonly sourceLinks: ArchitectureDiffSourceLinks
+  readonly pullRequest?: ArchitectureDiffPullRequestMetadata
+}
+
+/** @riviere-role query-model-value */
+export interface ArchitectureDiffSourceLinks {
+  readonly base: string
+  readonly head: string
+}
+
+/** @riviere-role query-model-value */
+export interface ArchitectureDiffPullRequestMetadata {
+  readonly number: number
+  readonly title: string
+  readonly description: string
+  readonly url: string
+}
+
+// --- query-model (commit phase): consumes the domain-facade
+//     (mirrors DomainList.parse -> RiviereQuery.fromJSON) ---
+/** @riviere-role query-model */
+export class ArchitectureDiffResult {
+  private constructor(readonly diff: ArchitectureDiff) {}
+
+  static parse(baseJson: unknown, headJson: unknown): ArchitectureDiffResult {
+    return new ArchitectureDiffResult(ArchitectureComparison.fromRevisions(baseJson, headJson).compare())
+  }
+}
+```
+
+```typescript
+// --- cli-entrypoint (commit-hook phase): query, compose envelope with explicit origins, write ---
+/** @riviere-role cli-entrypoint-dependencies */
+export interface GeneratePrArchitectureDiffEntrypointDependencies {
+  readonly compareArchitectures: CompareArchitectures
+  readonly composeCommitArchitectureDiffEnvelope: typeof composeCommitArchitectureDiffEnvelope
+  readonly writeArchitectureDiffEnvelope: typeof writeArchitectureDiffEnvelope
+  readonly formatArchitectureGraphLoadFailure: typeof formatArchitectureGraphLoadFailure
+}
+
+/** @riviere-role cli-entrypoint */
+export function createGeneratePrArchitectureDiffCommand(
+  dependencies: GeneratePrArchitectureDiffEntrypointDependencies,
+): Command {
+  return new Command('generate-pr-architecture-diff')
+    .requiredOption('--base-graph <path>', 'base fine-grained-role-graph file')
+    .requiredOption('--head-graph <path>', 'head fine-grained-role-graph file')
+    .requiredOption('--repository <ownerAndName>', 'repository owner/name')
+    .requiredOption('--base-revision <sha>', 'base revision sha')
+    .requiredOption('--head-revision <sha>', 'head revision sha')
+    .option('--output <path>', 'tracked envelope output path', '.riviere/pr-diffs/riviere-architecture-diff.json')
+    .action(async (options: GeneratePrArchitectureDiffOptions) => {
+      const result = dependencies.compareArchitectures.execute({
+        baseGraphPath: options.baseGraph,
+        headGraphPath: options.headGraph,
+      })
+      if (!(result instanceof ArchitectureDiffResult)) {
+        console.log(dependencies.formatArchitectureGraphLoadFailure(result))
+        return
+      }
+      const envelope = dependencies.composeCommitArchitectureDiffEnvelope(result, {
+        repository: options.repository,
+        baseRevision: options.baseRevision,
+        headRevision: options.headRevision,
+      })
+      await dependencies.writeArchitectureDiffEnvelope(envelope, options.output)
+    })
+}
+
+// --- cli-output-formatter: composes the commit-time envelope; every field origin explicit ---
+/** @riviere-role cli-output-formatter */
+export function composeCommitArchitectureDiffEnvelope(
+  result: ArchitectureDiffResult,
+  commitContext: ArchitectureDiffCommitContext,
+): ArchitectureDiffEnvelope {
+  return {
+    metadata: {
+      repository: commitContext.repository,     // --repository  (hook: git remote get-url origin)
+      baseRevision: commitContext.baseRevision, // --base-revision (hook: git rev-parse main)
+      headRevision: commitContext.headRevision, // --head-revision (hook: git rev-parse HEAD)
+      sourceLinks: {
+        base: `https://github.com/${commitContext.repository}/blob/${commitContext.baseRevision}/`,
+        head: `https://github.com/${commitContext.repository}/blob/${commitContext.headRevision}/`,
+      },
+    },
+    diff: result.diff,
+  }
+}
+
+// --- cli-response-writer: query-model input satisfies allowedInputs ---
+/** @riviere-role cli-response-writer */
+export async function writeArchitectureDiffEnvelope(
+  envelope: ArchitectureDiffEnvelope,
+  outputPath: string,
+): Promise<void> {
+  await writeFile(outputPath, JSON.stringify(envelope, null, 2), 'utf-8')
+}
+
+// --- cli-entrypoint (PR-time phase): load tracked JSON, add pullRequest metadata, write report ---
+/** @riviere-role cli-entrypoint */
+export function createPublishPrArchitectureDiffCommand(
+  dependencies: PublishPrArchitectureDiffEntrypointDependencies,
+): Command {
+  return new Command('publish-pr-architecture-diff')
+    .option('--envelope <path>', 'tracked diff envelope', '.riviere/pr-diffs/riviere-architecture-diff.json')
+    .requiredOption('--pull-request-number <number>', 'pull request number')
+    .requiredOption('--pull-request-title <title>', 'pull request title')
+    .requiredOption('--pull-request-description <description>', 'pull request description')
+    .requiredOption('--pull-request-url <url>', 'pull request URL')
+    .requiredOption('--report-output <path>', 'GitHub report file to write')
+    .action(async (options: PublishPrArchitectureDiffOptions) => {
+      const loaded = dependencies.loadArchitectureDiffEnvelope.execute({
+        envelopePathOption: options.envelope,
+      })
+      if ('kind' in loaded) {
+        console.log(dependencies.formatArchitectureDiffEnvelopeLoadFailure(loaded))
+        return
+      }
+      const published = dependencies.withPullRequestMetadata(loaded, {
+        number: Number(options.pullRequestNumber),
+        title: options.pullRequestTitle,
+        description: options.pullRequestDescription,
+        url: options.pullRequestUrl,
+      })
+      await dependencies.writePublishedArchitectureDiffEnvelope(
+        published,
+        options.envelope ?? '.riviere/pr-diffs/riviere-architecture-diff.json',
+      )
+      await dependencies.writeArchitectureDiffReport(
+        dependencies.formatArchitectureDiffReport(published),
+        options.reportOutput,
+      )
+    })
+}
+
+// --- cli-output-formatter: adds only the approved PR-time fields ---
+/** @riviere-role cli-output-formatter */
+export function withPullRequestMetadata(
+  envelope: ArchitectureDiffEnvelope,
+  pullRequest: ArchitectureDiffPullRequestMetadata,
+): ArchitectureDiffEnvelope {
+  return { metadata: { ...envelope.metadata, pullRequest }, diff: envelope.diff }
+}
+
+// --- cli-output-formatter: GitHub markdown from the envelope, never recalculated ---
+/** @riviere-role cli-output-formatter */
+export function formatArchitectureDiffReport(envelope: ArchitectureDiffEnvelope): string {
+  // affected aggregates are machine-distinguishable from created ones via status
+  const affectedAggregates = envelope.diff.subdomains.flatMap((subdomain) =>
+    subdomain.layers.domain?.affectedAggregates ?? [],
+  )
+  return [
+    formatReportSummary(envelope, affectedAggregates),
+    ...formatApplicationSections(envelope),
+    ...formatSubdomainSections(envelope),
+  ].join('\n')
+}
+```
+
+```typescript
+// --- domain-facade: one stable compare interface for query-model consumers ---
+/** @riviere-role domain-facade
+ *  @riviere-role-justification Query-model consumers (ArchitectureDiffResult.parse) need one stable
+ *  compare(base, head) interface over the subdomain grouper and the three layer comparisons instead
+ *  of discovering and sequencing each comparison capability themselves. */
+export class ArchitectureComparison {
+  private constructor(
+    private readonly base: ArchitectureSource,
+    private readonly head: ArchitectureSource,
+  ) {}
+
+  static fromRevisions(baseJson: unknown, headJson: unknown): ArchitectureComparison {
+    return new ArchitectureComparison(
+      ArchitectureSource.fromGraph(ArchitectureComparison.requireValidGraph(baseJson)),
+      ArchitectureSource.fromGraph(ArchitectureComparison.requireValidGraph(headJson)),
+    )
+  }
+
+  private static requireValidGraph(json: unknown): RiviereGraph {
+    const parsed = parseRiviereGraph(json)
+    if (parsed.success) return parsed.graph
+    throw new InvalidArchitectureGraphError(parsed.issues) // the loader surfaces this as GraphCorruptedError
+  }
+
+  compare(): ArchitectureDiff {
+    const changes = this.base.applicationElements().applicationAssociationChanges(this.head.applicationElements())
+    const application =
+      changes.moves.length === 0 && changes.added.length === 0 && changes.removed.length === 0
+        ? undefined
+        : {
+            associationChanges: changes.moves.map((move) => move.toElement()),
+            added: changes.added,
+            removed: changes.removed,
+          }
+    const subdomains = groupSubdomainDiff(this.base, this.head).flatMap((subdomain) => {
+      const entrypoints = compareEntrypointLayer(subdomain.base?.layers.entrypoints, subdomain.head?.layers.entrypoints)
+      const useCases = compareUseCaseLayer(subdomain.base?.layers.useCases, subdomain.head?.layers.useCases)
+      const domain = compareDomainLayer(subdomain.base?.layers.domain, subdomain.head?.layers.domain)
+      return entrypoints === undefined && useCases === undefined && domain === undefined
+        ? []
+        : [{ name: subdomain.name, change: subdomain.change, layers: { entrypoints, useCases, domain } }]
+    })
+    return { application, subdomains }
+  }
+}
+
+// --- domain-service: subdomain pairing + presence labelling (absorbs classifyChange) ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Pairs subdomain facts drawn from two different ArchitectureSource
+ *  snapshots and labels each pair's presence. No aggregate exists because comparison mutates no
+ *  state, and no single value object owns both sides of a base/head revision pair. */
+export function groupSubdomainDiff(
+  base: ArchitectureSource,
+  head: ArchitectureSource,
+): readonly {
+  readonly name: string
+  readonly change: SubdomainChange
+  readonly base: SubdomainFacts | undefined
+  readonly head: SubdomainFacts | undefined
+}[] {
+  const names = [...new Set([...base.subdomainNames(), ...head.subdomainNames()])]
+  return names.map((name) => {
+    const baseFacts = base.subdomain(name)
+    const headFacts = head.subdomain(name)
+    return {
+      name,
+      base: baseFacts,
+      head: headFacts,
+      change: baseFacts === undefined ? 'added' : headFacts === undefined ? 'removed' : 'changed',
+    }
+  })
+}
+
+// --- domain-service: subdomain-owned entrypoint layer comparison ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Entrypoint-layer comparison spans layer facts from two
+ *  ArchitectureSource snapshots and owns the ownership boundary: only genuinely subdomain-owned
+ *  entry points appear in a subdomain's entrypoint layer, because application-owned ones are
+ *  compared as application associations. No single value object owns both sides, and no aggregate
+ *  exists because comparison mutates nothing. */
+export function compareEntrypointLayer(
+  base: ArchitectureLayerState | undefined,
+  head: ArchitectureLayerState | undefined,
+): ArchitectureLayerDiff | undefined {
+  const baseElements = ArchitectureElementCollection.fromStates(base?.items ?? [])
+  const headElements = ArchitectureElementCollection.fromStates(head?.items ?? [])
+  const added = baseElements.addedIn(headElements)
+  const removed = baseElements.removedIn(headElements)
+  if (added.length === 0 && removed.length === 0) return undefined
+  return { added: { aggregates: [], items: added }, removed: { aggregates: [], items: removed } }
+}
+
+// --- domain-service: use-case layer comparison with named-use-case grouping ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Use-case-layer grouping spans layer facts from two
+ *  ArchitectureSource snapshots; no single value object owns both sides of a revision pair, and no
+ *  aggregate exists because comparison mutates nothing. */
+export function compareUseCaseLayer(
+  base: ArchitectureLayerState | undefined,
+  head: ArchitectureLayerState | undefined,
+): ArchitectureLayerDiff | undefined {
+  const baseElements = ArchitectureElementCollection.fromStates(base?.items ?? [])
+  const headElements = ArchitectureElementCollection.fromStates(head?.items ?? [])
+  const added = baseElements.addedIn(headElements)
+  const removed = baseElements.removedIn(headElements)
+  if (added.length === 0 && removed.length === 0) return undefined
+  // changed supporting elements group under EACH named use case they support (relatedTo is a
+  // canonicalised collection); changed elements without relationships stay in items
+  const groupsFor = (
+    direction: ElementChangeDirection,
+    elements: readonly ArchitectureElement[],
+  ): readonly UseCaseChangeGroup[] => {
+    const grouped = new Map<string, ArchitectureElement[]>()
+    for (const element of elements) {
+      for (const relationship of element.relatedTo) {
+        const items = grouped.get(relationship.name) ?? []
+        grouped.set(relationship.name, [...items, element])
+      }
+    }
+    return [...grouped].map(([useCaseName, items]) => ({ useCaseName, direction, items }))
+  }
+  return {
+    added: { aggregates: [], items: added },
+    removed: { aggregates: [], items: removed },
+    useCaseGroups: [...groupsFor('added', added), ...groupsFor('removed', removed)],
+  }
+}
+
+// --- domain-service: domain layer with the both-sides-affected rule ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Aggregate-member comparison spans domain-layer facts from two
+ *  ArchitectureSource snapshots; neither snapshot's value objects own both sides, and no aggregate
+ *  exists because comparison mutates nothing. */
+export function compareDomainLayer(
+  base: ArchitectureLayerState | undefined,
+  head: ArchitectureLayerState | undefined,
+): ArchitectureLayerDiff | undefined {
+  const baseElements = ArchitectureElementCollection.fromStates(base?.items ?? [])
+  const headElements = ArchitectureElementCollection.fromStates(head?.items ?? [])
+  const addedItems = baseElements.addedIn(headElements)
+  const removedItems = baseElements.removedIn(headElements)
+  const baseAggregates = base?.aggregates ?? []
+  const headAggregates = head?.aggregates ?? []
+  const baseByKey = new Map(baseAggregates.map((aggregate) => [aggregateKey(aggregate), aggregate]))
+  const headKeys = new Set(headAggregates.map((aggregate) => aggregateKey(aggregate)))
+  const created: AggregateDiff[] = []
+  const affected: AggregateDiff[] = []
+  const removedAggregates: AggregateDiff[] = []
+  for (const aggregate of headAggregates) {
+    const before = baseByKey.get(aggregateKey(aggregate))
+    const diff = memberDiff(before, aggregate)
+    if (diff === undefined) continue
+    // present on both sides => affected, published once with member changes (PRD rule);
+    // head-only => created; never created-plus-deleted
+    if (before === undefined) created.push(diff)
+    else affected.push(diff)
+  }
+  for (const aggregate of baseAggregates) {
+    if (!headKeys.has(aggregateKey(aggregate))) removedAggregates.push(removedAggregateDiff(aggregate))
+  }
+  if (
+    created.length === 0 && affected.length === 0 && removedAggregates.length === 0 &&
+    addedItems.length === 0 && removedItems.length === 0
+  ) {
+    return undefined
+  }
+  return {
+    added: { aggregates: created, items: addedItems },
+    removed: { aggregates: removedAggregates, items: removedItems },
+    affectedAggregates: affected,
+  }
+}
+
+function memberDiff(base: AggregateState | undefined, head: AggregateState): AggregateDiff | undefined {
+  const baseEntities = ArchitectureElementCollection.fromStates(base?.entities ?? [])
+  const headEntities = ArchitectureElementCollection.fromStates(head.entities)
+  const addedEntities = baseEntities.addedIn(headEntities)
+  const removedEntities = baseEntities.removedIn(headEntities)
+  const baseMethods = base?.methods ?? []
+  const addedMethods = head.methods.filter((method) => !baseMethods.includes(method))
+  const removedMethods = baseMethods.filter((method) => !head.methods.includes(method))
+  // a creation is itself a change even with zero members; a both-sides aggregate with no
+  // member changes is unchanged and not reported
+  if (
+    base !== undefined &&
+    addedEntities.length === 0 && removedEntities.length === 0 &&
+    addedMethods.length === 0 && removedMethods.length === 0
+  ) {
+    return undefined
+  }
+  return {
+    status: base === undefined ? 'created' : 'affected',
+    name: head.name,
+    packageKind: head.packageKind,
+    sourceEvidence:
+      base === undefined
+        ? { head: head.sourceEvidence }
+        : { base: base.sourceEvidence, head: head.sourceEvidence },
+    addedEntities,
+    removedEntities,
+    addedMethods,
+    removedMethods,
+  }
+}
+
+function removedAggregateDiff(aggregate: AggregateState): AggregateDiff {
+  return {
+    status: 'removed',
+    name: aggregate.name,
+    packageKind: aggregate.packageKind,
+    sourceEvidence: { base: aggregate.sourceEvidence },
+    addedEntities: [],
+    removedEntities: ArchitectureElementCollection.fromStates(aggregate.entities).removedIn(
+      ArchitectureElementCollection.fromStates([]),
+    ),
+    addedMethods: [],
+    removedMethods: [...aggregate.methods],
+  }
+}
+
+function aggregateKey(aggregate: { packageKind: string; name: string }): string {
+  return `${aggregate.packageKind}:${aggregate.name}`
+}
+```
+
+```typescript
+// --- value-object: the one legal home for shared element diffing and evidence resolution ---
+/** @riviere-role value-object */
+export class ArchitectureElementCollection {
+  declare private readonly brand: 'ArchitectureElementCollection'
+
+  private constructor(private readonly items: readonly ElementState[]) {}
+
+  static fromStates(items: readonly ElementState[]): ArchitectureElementCollection {
+    return new ArchitectureElementCollection(items)
+  }
+
+  /** head elements whose full identity is absent here; evidence resolves to the head revision */
+  addedIn(head: ArchitectureElementCollection): readonly ArchitectureElement[] {
+    const present = new Set(this.items.map((item) => this.elementKey(item)))
+    return head.items
+      .filter((item) => !present.has(this.elementKey(item)))
+      .map((item) => this.toElement(item, { head: item.sourceEvidence }))
+  }
+
+  /** base elements whose full identity is absent from the head; evidence resolves to the base revision */
+  removedIn(head: ArchitectureElementCollection): readonly ArchitectureElement[] {
+    const present = new Set(head.items.map((item) => this.elementKey(item)))
+    return this.items
+      .filter((item) => !present.has(this.elementKey(item)))
+      .map((item) => this.toElement(item, { base: item.sourceEvidence }))
+  }
+
+  /** application pairing: same identity on both sides with any changed association is ONE move
+   *  with dual evidence, never created-plus-deleted; new identities are added, vanished ones removed */
+  applicationAssociationChanges(head: ArchitectureElementCollection): {
+    readonly moves: readonly AssociationMove[]
+    readonly added: readonly ArchitectureElement[]
+    readonly removed: readonly ArchitectureElement[]
+  } {
+    const baseByIdentity = new Map(this.items.map((item) => [this.associationIdentity(item), item]))
+    const headIdentities = new Set(head.items.map((item) => this.associationIdentity(item)))
+    const moves: AssociationMove[] = []
+    const added: ArchitectureElement[] = []
+    for (const item of head.items) {
+      const before = baseByIdentity.get(this.associationIdentity(item))
+      if (before === undefined) {
+        added.push(this.toElement(item, { head: item.sourceEvidence }))
+      } else if (!this.sameRelationships(before.relatedTo, item.relatedTo)) {
+        moves.push(AssociationMove.fromStates(before, item))
+      }
+    }
+    const removed = this.items
+      .filter((item) => !headIdentities.has(this.associationIdentity(item)))
+      .map((item) => this.toElement(item, { base: item.sourceEvidence }))
+    return { moves, added, removed }
+  }
+
+  private elementKey(item: ElementState): string {
+    return JSON.stringify([
+      item.packageKind,
+      item.role,
+      item.name,
+      item.externalClient ?? null,
+      item.relatedTo,
+    ])
+  }
+
+  /** association identity is what the element IS, excluding the relationship collection */
+  private associationIdentity(item: ElementState): string {
+    return JSON.stringify([item.packageKind, item.role, item.name, item.externalClient ?? null])
+  }
+
+  /** both collections are canonicalised (unique + sorted), so index-wise comparison is equality */
+  private sameRelationships(
+    left: readonly ElementRelationship[],
+    right: readonly ElementRelationship[],
+  ): boolean {
+    return (
+      left.length === right.length &&
+      left.every((relationship, index) =>
+        relationship.name === right[index].name && relationship.role === right[index].role)
+    )
+  }
+
+  private toElement(item: ElementState, sourceEvidence: SourceEvidence): ArchitectureElement {
+    return {
+      name: item.name,
+      role: item.role,
+      packageKind: item.packageKind,
+      externalClient: item.externalClient,
+      relatedTo: item.relatedTo.map(({ name, role }) => ({ name, role })),
+      associatedSubdomains: [...item.associatedSubdomains],
+      methods: [...item.methods],
+      sourceEvidence,
+    }
+  }
+}
+
+/** @riviere-role value-object */
+export class AssociationMove {
+  declare private readonly brand: 'AssociationMove'
+
+  private constructor(
+    private readonly base: ElementState,
+    private readonly head: ElementState,
+  ) {}
+
+  /** invariant: both states share one application-owned identity and differ in association */
+  static fromStates(base: ElementState, head: ElementState): AssociationMove {
+    return new AssociationMove(base, head)
+  }
+
+  /** an association change carries BOTH revisions' evidence — recorded once */
+  toElement(): ArchitectureElement {
+    return {
+      name: this.head.name,
+      role: this.head.role,
+      packageKind: this.head.packageKind,
+      externalClient: this.head.externalClient,
+      relatedTo: this.head.relatedTo.map(({ name, role }) => ({ name, role })),
+      associatedSubdomains: [...this.head.associatedSubdomains],
+      methods: [...this.head.methods],
+      sourceEvidence: { base: this.base.sourceEvidence, head: this.head.sourceEvidence },
+    }
+  }
+}
+```
+
+```typescript
+// internal comparison facts (inline-typed like the builder's GraphDiff nested shapes)
+interface ElementRelationship {
+  readonly name: string
+  readonly role: string
+  readonly subdomain: string
+}
+interface ElementState {
+  readonly name: string
+  readonly role: string
+  readonly packageKind: ArchitecturePackageKind
+  readonly externalClient?: string
+  readonly methods: readonly string[]
+  readonly relatedTo: readonly ElementRelationship[]
+  readonly associatedSubdomains: readonly string[]
+  readonly sourceEvidence: SourceLocation
+}
+interface AggregateState {
+  readonly name: string
+  readonly packageKind: ArchitecturePackageKind
+  readonly entities: readonly ElementState[]
+  readonly methods: readonly string[]
+  readonly sourceEvidence: SourceLocation
+}
+interface ArchitectureLayerState {
+  readonly aggregates: readonly AggregateState[]
+  readonly items: readonly ElementState[]
+}
+interface SubdomainFacts {
+  readonly layers: {
+    readonly entrypoints: ArchitectureLayerState
+    readonly useCases: ArchitectureLayerState
+    readonly domain: ArchitectureLayerState
+  }
+}
+
+// --- value-object: projects one fine-grained-role-graph into comparison facts ---
+/** @riviere-role value-object */
+export class ArchitectureSource {
+  declare private readonly brand: 'ArchitectureSource'
+
+  private constructor(
+    private readonly subdomains: ReadonlyMap<string, SubdomainFacts>,
+    private readonly application: ArchitectureElementCollection,
+  ) {}
+
+  static fromGraph(graph: RiviereGraph): ArchitectureSource {
+    const componentsById = new Map(graph.components.map((component) => [component.id, component]))
+    const primariesBySupportingId = supportingPrimaries(graph, componentsById)
+    const subdomains = new Map<string, SubdomainFacts>()
+    const application: ElementState[] = []
+    for (const component of graph.components) {
+      if (component.type !== 'Custom' || component.customTypeName !== 'architecture-review-element') {
+        continue
+      }
+      const packageKind = typeof component.packageKind === 'string' ? component.packageKind : 'domain-model'
+      const relationships = primariesBySupportingId.get(component.id) ?? []
+      const state: ElementState = {
+        name: component.name,
+        role: typeof component.architectureRole === 'string' ? component.architectureRole : '',
+        packageKind,
+        externalClient: typeof component.externalClient === 'string' ? component.externalClient : undefined,
+        methods: stringArray(component.methods),
+        relatedTo: relationships,
+        associatedSubdomains: uniqueSorted(relationships.map(({ subdomain }) => subdomain)),
+        sourceEvidence: component.sourceLocation,
+      }
+      if (packageKind === 'application') {
+        application.push(state) // application-owned elements never join subdomain layers (PRD ownership rule)
+        continue
+      }
+      // aggregateOwnerId mirrors the aggregate-owns-entity link for entity elements
+      const ownerName =
+        typeof component.aggregateOwnerId === 'string'
+          ? componentsById.get(component.aggregateOwnerId)?.name
+          : undefined
+      subdomains.set(component.domain, withElement(subdomains.get(component.domain), state, ownerName))
+    }
+    return new ArchitectureSource(subdomains, ArchitectureElementCollection.fromStates(application))
+  }
+
+  subdomain(name: string): SubdomainFacts | undefined {
+    return this.subdomains.get(name)
+  }
+
+  subdomainNames(): readonly string[] {
+    return [...this.subdomains.keys()].sort()
+  }
+
+  applicationElements(): ArchitectureElementCollection {
+    return this.application
+  }
+}
+
+/** link resolution: supports-primary-element points from primary to supporting element; EVERY link
+ *  is collected so multi-relationship elements keep all facts (POC canonicalRelationships parity) */
+function supportingPrimaries(
+  graph: RiviereGraph,
+  componentsById: ReadonlyMap<string, RiviereGraph['components'][number]>,
+): ReadonlyMap<string, readonly ElementRelationship[]> {
+  const bySupportingId = new Map<string, ElementRelationship[]>()
+  for (const link of graph.links) {
+    if (link.relationshipType !== 'supports-primary-element') continue
+    const primary = componentsById.get(link.source)
+    if (primary === undefined) continue
+    const relationship: ElementRelationship = {
+      name: primary.name,
+      role: typeof primary.architectureRole === 'string' ? primary.architectureRole : '',
+      subdomain: primary.domain,
+    }
+    const existing = bySupportingId.get(link.target) ?? []
+    bySupportingId.set(link.target, canonicalRelationships([...existing, relationship]))
+  }
+  return bySupportingId
+}
+
+/** canonicalisation: unique by role+name, sorted — preserves every relationship */
+function canonicalRelationships(
+  relationships: readonly ElementRelationship[],
+): readonly ElementRelationship[] {
+  const unique = new Map(
+    relationships.map((relationship) => [`${relationship.role}:${relationship.name}`, relationship]),
+  )
+  return [...unique.values()].sort((left, right) => left.name.localeCompare(right.name, 'en'))
+}
+
+function uniqueSorted(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right, 'en'))
+}
+
+function stringArray(value: unknown): readonly string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string') ? value : []
+}
+
+/** layer mapping and aggregate split: one element joins exactly one layer of one subdomain */
+function withElement(
+  subdomain: SubdomainFacts | undefined,
+  element: ElementState,
+  ownerName: string | undefined,
+): SubdomainFacts {
+  const layers =
+    subdomain?.layers ??
+    ({
+      entrypoints: { aggregates: [], items: [] },
+      useCases: { aggregates: [], items: [] },
+      domain: { aggregates: [], items: [] },
+    } satisfies SubdomainFacts['layers'])
+  if (element.packageKind === 'use-cases') {
+    return { layers: { ...layers, useCases: { ...layers.useCases, items: [...layers.useCases.items, element] } } }
+  }
+  if (element.packageKind === 'domain-model' || element.packageKind === 'published-language') {
+    return { layers: { ...layers, domain: withDomainElement(layers.domain, element, ownerName) } }
+  }
+  return { layers: { ...layers, entrypoints: { ...layers.entrypoints, items: [...layers.entrypoints.items, element] } } }
+}
+
+function withDomainElement(
+  domain: ArchitectureLayerState,
+  element: ElementState,
+  ownerName: string | undefined,
+): ArchitectureLayerState {
+  if (ownerName !== undefined) {
+    // entity: attaches to its aggregate through aggregateOwnerId (create-or-attach handles link order)
+    const exists = domain.aggregates.some((aggregate) => aggregate.name === ownerName)
+    const aggregates = exists
+      ? domain.aggregates.map((aggregate) =>
+          aggregate.name === ownerName ? { ...aggregate, entities: [...aggregate.entities, element] } : aggregate,
+        )
+      : [
+          ...domain.aggregates,
+          { name: ownerName, packageKind: element.packageKind, entities: [element], methods: [], sourceEvidence: element.sourceEvidence },
+        ]
+    return { ...domain, aggregates }
+  }
+  if (element.role === 'aggregate') {
+    const exists = domain.aggregates.some((aggregate) => aggregate.name === element.name)
+    const aggregates = exists
+      ? domain.aggregates.map((aggregate) =>
+          aggregate.name === element.name
+            ? { ...aggregate, packageKind: element.packageKind, methods: element.methods, sourceEvidence: element.sourceEvidence }
+            : aggregate,
+        )
+      : [
+          ...domain.aggregates,
+          { name: element.name, packageKind: element.packageKind, entities: [], methods: element.methods, sourceEvidence: element.sourceEvidence },
+        ]
+    return { ...domain, aggregates }
+  }
+  return { ...domain, items: [...domain.items, element] }
+}
+```
+
+##### New dependencies
+
+| Dependency | Status | Used by | Purpose |
+|---|---|---|---|
+| `@living-architecture/riviere-schema-published-language` | Existing | `domain-model` (`ArchitectureComparison`, `ArchitectureSource`) | Reuse `RiviereGraph`, `CustomComponent`, `Link`, `SourceLocation`, `parseRiviereGraph` to validate and project graph input into comparison facts. |
+| `@living-architecture/riviere-schema-published-language` | Existing | `published-language` | Reuse `SourceLocation` in `SourceEvidence`. |
+| `@living-architecture/riviere-architecture-published-language` | New | `riviere-architecture-domain-model`, `riviere-architecture-use-cases` | The shared `ArchitectureDiff` contract and `parseArchitectureDiff`; apps consume the types through the use-cases query exports (envelope, results), never directly. |
+| `@living-architecture/riviere-architecture-use-cases` | New | `apps/cli` | The two query use cases, query models, envelope types, failure unions, and loaders; apps may only import subdomain queries. |
+
+##### Code shape
+
+```text
+packages/riviere-architecture/
+├── published-language/src/published-language/
+│   ├── architecture-diff.ts                 contract incl. AggregateDiff.status, affectedAggregates,
+│   │                                        ArchitectureRelationship collection
+│   └── parse-architecture-diff.ts           published-language-parser
+├── domain-model/src/domain/
+│   ├── architecture-source.ts               ArchitectureSource + fact shapes + projection helpers
+│   ├── architecture-element-collection.ts
+│   ├── association-move.ts
+│   ├── architecture-comparison.ts           facade
+│   ├── invalid-architecture-graph-error.ts
+│   ├── entrypoint-layer-comparison.ts
+│   ├── use-case-layer-comparison.ts
+│   ├── domain-layer-comparison.ts           + memberDiff + removedAggregateDiff + aggregateKey
+│   └── subdomain-grouper.ts
+├── use-cases/src/features/architecture-comparison/
+│   ├── queries/{compare-architectures,compare-architectures-input,compare-architectures-result,
+│   │           architecture-diff-result,architecture-graph-load-failure,
+│   │           load-architecture-diff-envelope,load-architecture-diff-envelope-input,
+│   │           load-architecture-diff-envelope-result,architecture-diff-envelope,
+│   │           architecture-diff-envelope-metadata}.ts
+│   └── data-access/
+│       ├── architecture-diff/{architecture-diff-loader,graph-not-found-error,graph-corrupted-error}.ts
+│       └── architecture-diff-envelope/{architecture-diff-envelope-loader,
+│           architecture-diff-envelope-not-found-error,architecture-diff-envelope-corrupted-error}.ts
+apps/cli/src/features/architecture-diff/entrypoint/
+├── generate-pr-architecture-diff/
+│   ├── entrypoint.ts                        commit-hook command; graph + git-context flags from the hook
+│   ├── compose-commit-architecture-diff-envelope.ts
+│   ├── write-architecture-diff-envelope.ts
+│   └── format-architecture-graph-load-failure.ts
+└── publish-pr-architecture-diff/
+    ├── entrypoint.ts                        PR-time Action command
+    ├── with-pull-request-metadata.ts
+    ├── format-architecture-diff-report.ts   + section formatters
+    ├── format-architecture-diff-envelope-load-failure.ts
+    ├── write-published-architecture-diff-envelope.ts
+    └── write-architecture-diff-report.ts
+apps/eclair/src/features/pr-diff/...         boundary only; feature design deferred
+.githooks/ + .github/workflows/               hook script and PR workflow steps (outside enforced packages)
+```
+
+No file of this feature remains in `apps/cli/src/infra/cli/presentation/`: the complete-diff and load-failure formatters consume the subdomain queries contract, which root infra cannot import.
+
+##### Runtime call outline
+
+```text
+createGeneratePrArchitectureDiffCommand  (commit-hook phase)
+  ├─ compareArchitectures.execute({ baseGraphPath, headGraphPath })   input built directly from parsed flags
+  │  ├─ architectureDiffLoader.load(input.baseGraphPath, input.headGraphPath)
+  │  │  ├─ readGraphJson(baseGraphPath)                      node:fs existsSync, readFileSync, JSON.parse
+  │  │  ├─ readGraphJson(headGraphPath)                      throws GraphNotFoundError or GraphCorruptedError
+  │  │  └─ architectureDiffResult.parse(baseJson, headJson)
+  │  │     └─ architectureComparison.fromRevisions(baseJson, headJson).compare()
+  │  │        ├─ architectureSource.fromGraph(baseGraph)
+  │  │        ├─ architectureSource.fromGraph(headGraph)
+  │  │        └─ architectureComparison.compare()
+  │  │           ├─ base.applicationElements()
+  │  │           ├─ baseCollection.applicationAssociationChanges(headCollection)
+  │  │           │  └─ associationMove.fromStates(baseState, headState)
+  │  │           ├─ groupSubdomainDiff(base, head)
+  │  │           │  ├─ base.subdomainNames()
+  │  │           │  ├─ head.subdomainNames()
+  │  │           │  ├─ base.subdomain(name)
+  │  │           │  └─ head.subdomain(name)
+  │  │           ├─ compareEntrypointLayer(pair.base, pair.head)      per compared subdomain pair
+  │  │           │  ├─ architectureElementCollection.fromStates(items)
+  │  │           │  ├─ baseCollection.addedIn(headCollection)
+  │  │           │  └─ baseCollection.removedIn(headCollection)
+  │  │           ├─ compareUseCaseLayer(pair.base, pair.head)         per compared subdomain pair
+  │  │           │  ├─ architectureElementCollection.fromStates(items)
+  │  │           │  ├─ baseCollection.addedIn(headCollection)
+  │  │           │  └─ baseCollection.removedIn(headCollection)
+  │  │           └─ compareDomainLayer(pair.base, pair.head)          per compared subdomain pair
+  │  │              ├─ architectureElementCollection.fromStates(items)
+  │  │              ├─ baseCollection.addedIn(headCollection)
+  │  │              ├─ baseCollection.removedIn(headCollection)
+  │  │              ├─ memberDiff(baseAggregate, headAggregate)       sets status created or affected
+  │  │              └─ removedAggregateDiff(baseAggregate)            sets status removed
+  │  └─ toArchitectureGraphLoadFailure(error)                when load threw a data-access error
+  ├─ formatArchitectureGraphLoadFailure(failure)             failure path
+  ├─ composeCommitArchitectureDiffEnvelope(result, commitContext)     success path
+  └─ writeArchitectureDiffEnvelope(envelope, outputPath)     writes .riviere/pr-diffs/riviere-architecture-diff.json
+
+createPublishPrArchitectureDiffCommand  (PR-time Action phase)
+  ├─ loadArchitectureDiffEnvelope.execute({ envelopePathOption })
+  │  ├─ architectureDiffEnvelopeLoader.load(input.envelopePathOption)
+  │  │  ├─ existsSync(envelopePath)                          default .riviere/pr-diffs/riviere-architecture-diff.json
+  │  │  ├─ readFileSync(envelopePath), JSON.parse            throws ArchitectureDiffEnvelopeNotFoundError
+  │  │  │                                                    or ArchitectureDiffEnvelopeCorruptedError
+  │  │  └─ parseArchitectureDiff(envelopeJson.diff)          published-language validation of diff
+  │  └─ toArchitectureDiffEnvelopeLoadFailure(error)         when load threw a data-access error
+  ├─ formatArchitectureDiffEnvelopeLoadFailure(failure)      failure path
+  ├─ withPullRequestMetadata(envelope, pullRequestMetadata)  adds metadata.pullRequest.* only
+  ├─ writePublishedArchitectureDiffEnvelope(publishedEnvelope, envelopePath)
+  ├─ formatArchitectureDiffReport(publishedEnvelope)         GitHub markdown from the envelope
+  └─ writeArchitectureDiffReport(markdown, reportOutput)     report file the workflow posts as the comment
+```
+
+##### Design validation
+
+- Domain terminology: pass — reuses established Rivière terms (`Component`, `Domain`, `Entry Point`, source evidence) and the proof-of-concept comparison vocabulary (`subdomain`, `layer`, `aggregate`, `added`/`removed`, `relatedTo` relationships); `affected`/`created` match the PRD's own wording for the both-sides aggregate rule; `AssociationMove` names the PRD's application association change, and `ArchitectureElementCollection` is flagged above as a proposed term.
+- Application/domain separation: pass — both use cases are try/catch load delegation plus failure mapping only; loaders only read + parse JSON (and validate through the published-language parser); the query models only wrap the facade result; every comparison rule lives in the domain value objects and services; envelope composition, PR-metadata merge, and report formatting are presentation-side. Closed unions are matched exhaustively and domain code uses no TypeScript `in` operator.
+- Role and location fit: pass — every `domain-service` declaration carries a per-declaration `@riviere-role-justification` answering the configured aggregate-first/value-object-second question; shared element diffing lives once on a `value-object`; the facade is consumed by a `query-model`; domain-model imports only published-language; use-cases own file reading/parsing in data-access; both cli-entrypoints build their query inputs directly per the canonical query pattern; all formatters and writers live in feature entrypoint folders where consuming the subdomain queries contract is legal (root infra cannot); envelope writers take a `query-model` input, satisfying `cli-response-writer.allowedInputs`.
+- Implementability: pass — mirrors the existing `ListDomains`/`DomainListLoader`/`query-loaders`/`writeFinalizedGraph` patterns and the POC `generate-pr-architecture-diff` entrypoint/formatter/writer placement; respects ADR-002 and `.riviere/role-enforcement.config.ts` template paths (`packages/{subdomain}/...`), so the new package needs no enforcement-config change; no package imports an app; the PR-time phase implements the approved ARCH.md §2 convention exactly (load the tracked JSON, write `metadata.pullRequest.*`, build the report without recalculating the diff).
+
+##### Open decisions
+
+- `ArchitectureComparison` is a new `domain-facade` instance; `.riviere/roles.ts` lists approved instances (currently only `RiviereQuery`), so this facade requires explicit user approval.
+- The Éclair review page feature design (public PR link resolution, upload-envelope parsing, the approved page) is deliberately deferred, as in earlier rounds: `apps/eclair` is in `unassignedPackages`, and the envelope plus `ArchitectureDiff` published here already fix the contract it must consume.
+- How the commit hook materialises the retained `main` graph before invoking the command (worktree, checkout, or cached artifact) is a delivery-planning decision outside this component design; the command takes explicit `--base-graph`/`--head-graph` paths and invents no path convention.
+
+##### Rejected alternative sub-ideas
+
+- Deferring the PR-time publication phase as an open decision (rejected: approved ARCH.md §2 fully specifies the phase — load the tracked JSON, write `metadata.pullRequest.*`, build the report without recalculating — so a complete implementable design must include it; this correction adds the envelope query, merge formatter, and report writer/writers).
+- The complete-diff formatter in root `infra/cli/presentation` (rejected: ADR-002 states root infra cannot import application or domain code, and `app.ts` gives `/infra` own-subtree-only imports; formatting the complete `ArchitectureDiff` needs the full subdomain contract; the POC keeps its formatter in the feature entrypoint folder).
+- Registering no metadata flags and letting the writer receive only the query result (rejected: nothing would compose the approved `{ metadata, diff }` envelope; the composer with explicit field origins and the `query-model` writer input make every field's provenance named and consistent across prose, table, outline, and stress test).
+- Publishing affected aggregates inside `added.aggregates` with no discriminator (rejected: the PRD requires an aggregate changed on both sides to be named as affected while remaining distinguishable from a newly created aggregate; `AggregateDiff.status` plus the layer's `affectedAggregates` list makes the rule machine-checkable for the GitHub and Éclair summaries).
+- `relatedTo` as a single optional string built from a link map keyed by target (rejected: the POC models `relatedTo` as a canonicalised relationship collection — `canonicalRelationships(item.relatedTo ?? [])` — and a single-valued map keeps only the last link, silently dropping multi-relationship facts and breaking complete-output parity).
+- A single monolithic `Architecture` value object holding all comparison logic (rejected: it grows past a clean single-responsibility boundary and hides the layer-specific rules; the direction requires fine-grained decomposition).
+- Separate `classifyChange` and `resolveSourceEvidence` domain services (rejected per the `look-for-missing-value-objects-before-domain-services` memory: presence labelling is a three-branch check absorbed into `groupSubdomainDiff`, and evidence pairing moved onto `ArchitectureElementCollection`/`AssociationMove` where both revision states meet — value objects own the state they label).
+- `addedItems`/`itemKey` duplicated per layer-comparison file (rejected: sharing across files needs an exported role; a `domain-service` home would create a forbidden domain-service→domain-service dependency — the collection value object is the one legal home).
+- Handling application association moves inside per-subdomain entrypoint layers (rejected: a move pairs an application element across the whole revision pair, so per-layer pairing cannot see it; moves are recorded once in the diff's application section with dual evidence, per the PRD ownership rule).
+- A `command-input-factory` for either query input (rejected: that role may only produce `command-use-case-input`; the canonical "CLI Invoking Query Model Use Case" pattern constructs query inputs in the cli-entrypoint).
+- `ArchitectureSource` wrapping a use-cases `query-model` via `fromState` (rejected: domain-model cannot import use-cases; projection now lives on the value object from the published-language graph, resolving the single-home requirement).
+- `CompareArchitectures` returning an alias of the published-language `ArchitectureDiff` (rejected as an unresolved `forbiddenSupertypes` risk; the use case returns a concrete `query-model` result union wrapping the schema).
+- Letting the app supply already-parsed graphs (rejected: approved ownership assigns loading its inputs to use-cases; the loader now owns the two graph files' read + parse).
+- An `ArchitectureDiffAggregate` + `ArchitectureDiffRepository` (rejected: comparison never mutates persisted state and owns no lifecycle invariant, so aggregate/repository would be a forced fit violating the query-side rule).
+- Resolving source evidence inside the use case (rejected: evidence resolution is domain logic and must stay out of orchestration).
+- Modelling the PR-time merge as a command use case (rejected: the merge adds presentation metadata to an already-generated file at the CLI output boundary; no domain state changes, so the formatter + writer pair is sufficient and matches the `writeFinalizedGraph` precedent).
+
+<!-- component-design-option-3:end -->
+
+#### Approval
+
+Options have been written to this file. Which option should be approved, rejected, or combined?
 
 ## 4. Feasibility confirmations
 

--- a/docs/project/PRD/pull-request-diffs/PRD.md
+++ b/docs/project/PRD/pull-request-diffs/PRD.md
@@ -1,0 +1,131 @@
+# PRD: Pull Request Architecture Diffs
+
+**Status:** Approved
+
+**PRD approval:** Approved
+
+**Approval note:** The approved review experience remains unchanged. Reapproval confirms two independently generated Rivière graph outputs, the `fine-grained-role-graph` as the architecture diff source, retained outputs, and performance validation in the first delivery ticket.
+
+---
+
+## 1. Problem Summary
+
+AI agents are doing much of the implementation work, while key architecture and domain model changes can remain hidden among hundreds of lines of code. Developers and maintainers reviewing pull requests may therefore miss important decisions before merge, allowing architecture mistakes to pass unnoticed and become difficult to correct later.
+
+The same visibility problem affects principal engineers and architects who need to understand how architecture evolved across a longer period. A working architecture diff proof of concept exists, but it is an isolated TypeScript-specific script which nobody except its creator can use.
+
+## 2. Product Decision
+
+Create a reusable Rivière pull request architecture comparison which keeps the complete generated GitHub architecture diff and supplements it with an Éclair review page.
+
+Repositories generate two retained Rivière graphs through independently named workflows:
+
+- the **high-level graph**, which selectively shows flows and key concepts for exploration in Éclair or any other purpose;
+- the **fine-grained-role-graph**, which maps every role annotated class and method together with the ownership, relationships, package information, and source evidence required by the architecture diff.
+
+The architecture diff compares base and head `fine-grained-role-graph` states. GitHub and Éclair consume the same generated `ArchitectureDiff`; they may present it differently while preserving complete and consistent facts. The pull request does not show a second diff of the `high-level graph`.
+
+The experience helps a reviewer answer three questions:
+
+1. What architecture changed?
+2. Has the change damaged the domain model?
+3. What code proves it?
+
+Rivière exposes changes and evidence. It does not judge whether the architecture is good or bad. The reviewer owns that decision.
+
+## 3. Users and Use Cases
+
+- Developers and maintainers reviewing changes made by AI agents: identify important architecture and domain model changes before deciding whether a pull request should be merged.
+- Principal engineers and architects: compare Rivière graph states to understand how architecture evolved across a longer period.
+- Pull request reviewers: move from a concise summary to the relevant application, subdomain, package, use case, aggregate, element, and exact source evidence without losing access to the complete diff.
+
+## 4. Product Requirements
+
+- A repository must be able to run two independently named workflows which generate and retain separate valid Rivière graph outputs.
+- The `high-level graph` must remain selective. It shows flows and key concepts for exploration in Éclair or any other purpose rather than including every role annotated declaration.
+- The `fine-grained-role-graph` must include every role annotated class and method, plus the ownership, relationships, package information, and source evidence required to preserve the complete existing architecture diff.
+- “Fine grained” does not mean every source symbol. Unannotated implementation details which provide no required architecture diff fact are not part of this requirement.
+- The architecture diff must compare base and head `fine-grained-role-graph` states without making the product model TypeScript specific.
+- The pull request must continue to present one architecture diff. It must not add a separate diff of the `high-level graph`.
+- GitHub and Éclair must consume the same generated `ArchitectureDiff`, while retaining their approved presentation differences.
+- The `fine-grained-role-graph` must be retained as a normal workflow output for now. Future direct exploration of it in Éclair remains possible but is not required by this PRD.
+- Architecture diff generation approaches must be compared using exact output equivalence, elapsed time, peak memory, and generated input size. The selected approach must preserve the complete existing diff output and avoid unnecessary graph generation work.
+- A pull request comparison must retain the complete generated GitHub architecture diff and provide access to a focused Éclair review page.
+- GitHub architecture diff generation must not depend on the Éclair page being available.
+- The Éclair page must show the repository and pull request link, the real pull request title, and a pull request description which is collapsed by default.
+- The page must show concise totals for changed subdomains, changed packages, and affected aggregates.
+- A summary table must group changes by subdomain and show status, named affected aggregates, additions, removals, and changes within `use-cases`, `domain-model`, and `published-language` packages where present.
+- Published language changes must be visible in the initial subdomain summary because they expose contracts to other subdomains.
+- Application-owned elements must remain under their application owner. Changes in their association with subdomains must not be presented as subdomain package ownership.
+- Entry points which the Rivière model identifies as genuinely owned by a subdomain must be allowed to appear within that subdomain.
+- Detailed evidence must follow this hierarchy where applicable: subdomain, architecture layer, change direction, then package, use case, aggregate, or supporting element group.
+- Command and query use cases must be distinct. Each named use case must be independently collapsible with its related inputs, results, models, loaders, repositories, errors, and other supporting elements. Changes outside a named use case must remain in a clearly named supporting group.
+- Domain changes must be grouped by package. Each package must be independently collapsible, closed by default, and show its change count before expansion.
+- Aggregates must clearly separate Name, Role, Package, and Code. Their entity and method collections must be collapsed by default. Expanded methods must appear as one readable, non-wrapping method per line.
+- Every architecture element in the generated diff must remain reviewable. Important application, use case, aggregate, entity, method, published language, and domain model elements must link to exact source lines at the relevant base or head revision.
+- Application association changes must provide both base and head source evidence.
+- An aggregate changed on both sides of a comparison must be named as affected in the summary, while its detailed view distinguishes added and removed members without presenting the aggregate itself as both created and deleted.
+- Large comparisons must remain navigable through independent progressive disclosure for subdomains, layers, packages, use cases, aggregates, and method groups.
+- The page must use the Éclair Stream visual language and teal product identity, with restrained surfaces, visible carets, monospace code, and conventional red and green change colours.
+- Information-heavy sections must remain vertically stacked and responsive rather than being compressed into competing horizontal panels.
+- The complete GitHub representation and Éclair representation must remain consistent as Rivière graph concepts evolve.
+- Each repository must retain control over whether architecture diff generation failures block merging.
+- The approved visual baseline is `prototypes/architecture-diff-visual-mockups.html`. Its content hierarchy, ownership distinctions, evidence completeness, and review readability must be preserved unless later product discovery changes them.
+
+## 5. Non-Goals
+
+- Replacing the complete GitHub code diff or generated architecture diff.
+- Making Éclair availability a prerequisite for GitHub architecture diff generation.
+- Imposing one central merge policy on every repository.
+- Creating a TypeScript-specific product model.
+- Dropping, summarising away, or hiding facts from the authoritative generated diff.
+- Producing an AI verdict, architecture score, speculative warning, or claim that a change is safe or unsafe.
+- Presenting application-owned CLI entry points as packages inside a subdomain, or assuming every entry point belongs to an application.
+- Using a package-global summary which loses subdomain context or burying published language several disclosure levels below the summary.
+- Using flat use case tables, permanently expanded package bodies, long package sections which obscure later packages, or ambiguous and compressed aggregate method presentations.
+- Turning the review into a graph-first or dashboard-first exploration experience.
+- Imitating GitHub at the expense of Éclair's visual conventions, or using dominant purple styling, decorative card grids, gradient-filled diff bodies, tiny text, or excessive pills.
+- Providing fake controls, dead links, repeated equivalent views, or actions which do not work.
+- Treating implementation or formatting mechanics as proof that the review experience is usable.
+- Expanding the `high-level graph` to include every role annotated declaration.
+- Including every unannotated source symbol in the `fine-grained-role-graph`.
+- Showing a second pull request diff for the `high-level graph`.
+- Requiring direct exploration of the `fine-grained-role-graph` in Éclair in the current scope.
+
+Possible future exploration of the `fine-grained-role-graph` in Éclair does not add a current product requirement.
+
+## 6. Success Criteria
+
+- In a real pull request review, reviewers can identify what architecture changed, assess whether the change damaged the domain model, and reach the exact code evidence.
+- Key package, aggregate, published language, application association, use case, and domain model changes are visible without scanning the complete raw architecture inventory.
+- Every architecture fact in the generated diff remains available for review in both the complete GitHub baseline and the consistent Éclair representation.
+- Reviewers can navigate a large generated comparison by opening only the relevant levels and groups.
+- If the Éclair page is unavailable, reviewers can still use the complete generated GitHub architecture diff.
+- Dogfooding with the real pull request #478 generated diff confirms that the approved hierarchy remains readable and usable with a substantial domain model change.
+- A `fine-grained-role-graph` generated for the base and head of pull request #478 reproduces the existing architecture diff facts and published output.
+- The first delivery validation directly generates the `fine-grained-role-graph` through a Rivière workflow, reproduces pull request #478 exactly, and records elapsed time, peak memory, and generated input size before later delivery work relies on that path.
+- The retained `high-level graph` remains selective and useful independently of the architecture diff.
+
+## 7. Open Product Questions
+
+No open product questions. Direct exploration of the `fine-grained-role-graph` in Éclair may be considered later, but it is not required now.
+
+## 8. Architecture Questions
+
+- How should the two independently named workflows generate and retain the `high-level graph` and `fine-grained-role-graph`?
+- How should the first delivery ticket validate direct `fine-grained-role-graph` workflow extraction, exact pull request #478 parity, and performance before later delivery work relies on that path?
+- How should the reusable Rivière graph comparison represent application ownership, subdomain ownership, and changes in associations without inventing containment?
+- What repository and revision metadata must the comparison carry so base and head evidence can link to exact source lines?
+- How should the complete GitHub representation and Éclair representation be generated from consistent comparison facts?
+- How should generated comparison pages be deployed, accessed, retained, and operationally owned?
+- How should Éclair failures be isolated so they cannot prevent generation of the complete GitHub architecture diff?
+
+## 9. Source Traceability
+
+- Problem definition: `problem-definition.md`
+- Solution exploration: `solution-exploration.md`
+- Graph representation and performance evidence: `prototypes/README.md` and `prototypes/results/`
+- Key source sections:
+  - Problem definition: Approved inputs; Problem statement
+  - Solution exploration: Existing solution research; Selected product concept; Product paths; No-gos and exclusions; Risk review; Risky assumptions; Open discovery questions
+  - Approved visual baseline: `prototypes/architecture-diff-visual-mockups.html`

--- a/docs/project/PRD/pull-request-diffs/PRD.md
+++ b/docs/project/PRD/pull-request-diffs/PRD.md
@@ -4,7 +4,7 @@
 
 **PRD approval:** Approved
 
-**Approval note:** The approved review experience remains unchanged. Reapproval confirms two independently generated Rivière graph outputs, the `fine-grained-role-graph` as the architecture diff source, retained outputs, and performance validation in the first delivery ticket.
+**Approval note:** Product discovery is complete enough for architecture drafting. This PRD records the approved product decision and intentionally excludes delivery milestones. Reapproval confirms public GitHub loading and private repository file upload containing the GitHub metadata unavailable in upload mode. The remaining approved review experience is unchanged, including two independently generated Rivière graph outputs, the `fine-grained-role-graph` as the architecture diff source, retained outputs, and performance validation. Ticket sequencing is left to delivery planning.
 
 ---
 
@@ -51,6 +51,9 @@ Rivière exposes changes and evidence. It does not judge whether the architectur
 - The `fine-grained-role-graph` must be retained as a normal workflow output for now. Future direct exploration of it in Éclair remains possible but is not required by this PRD.
 - Architecture diff generation approaches must be compared using exact output equivalence, elapsed time, peak memory, and generated input size. The selected approach must preserve the complete existing diff output and avoid unnecessary graph generation work.
 - A pull request comparison must retain the complete generated GitHub architecture diff and provide access to a focused Éclair review page.
+- Public repositories must support opening the review through a link identifying the repository and pull request ID. Éclair retrieves the generated diff through GitHub using the agreed file convention.
+- Private repositories must support reviewing a generated diff through file upload rather than authenticated GitHub loading. Éclair has no backend; uploaded files are processed in the browser.
+- The uploaded file must contain the extra GitHub metadata unavailable in upload mode: repository and pull request identity and link, pull request title and description, and revision-specific source links. Displaying the review must not depend on fetching private GitHub metadata.
 - GitHub architecture diff generation must not depend on the Éclair page being available.
 - The Éclair page must show the repository and pull request link, the real pull request title, and a pull request description which is collapsed by default.
 - The page must show concise totals for changed subdomains, changed packages, and affected aggregates.
@@ -76,6 +79,7 @@ Rivière exposes changes and evidence. It does not judge whether the architectur
 
 - Replacing the complete GitHub code diff or generated architecture diff.
 - Making Éclair availability a prerequisite for GitHub architecture diff generation.
+- Authenticated loading of private repository diffs through GitHub. Private repository review is supported through file upload instead.
 - Imposing one central merge policy on every repository.
 - Creating a TypeScript-specific product model.
 - Dropping, summarising away, or hiding facts from the authoritative generated diff.
@@ -101,9 +105,11 @@ Possible future exploration of the `fine-grained-role-graph` in Éclair does not
 - Every architecture fact in the generated diff remains available for review in both the complete GitHub baseline and the consistent Éclair representation.
 - Reviewers can navigate a large generated comparison by opening only the relevant levels and groups.
 - If the Éclair page is unavailable, reviewers can still use the complete generated GitHub architecture diff.
+- A public repository reviewer can open the generated diff from a repository and pull request link without selecting a file.
+- A private repository reviewer can upload a generated diff and see the approved review, including pull request context and revision-specific source links, without Éclair fetching private GitHub metadata.
 - Dogfooding with the real pull request #478 generated diff confirms that the approved hierarchy remains readable and usable with a substantial domain model change.
 - A `fine-grained-role-graph` generated for the base and head of pull request #478 reproduces the existing architecture diff facts and published output.
-- The first delivery validation directly generates the `fine-grained-role-graph` through a Rivière workflow, reproduces pull request #478 exactly, and records elapsed time, peak memory, and generated input size before later delivery work relies on that path.
+- Validation directly generates the `fine-grained-role-graph` through a Rivière workflow, reproduces pull request #478 exactly, and records elapsed time, peak memory, and generated input size.
 - The retained `high-level graph` remains selective and useful independently of the architecture diff.
 
 ## 7. Open Product Questions
@@ -113,10 +119,11 @@ No open product questions. Direct exploration of the `fine-grained-role-graph` i
 ## 8. Architecture Questions
 
 - How should the two independently named workflows generate and retain the `high-level graph` and `fine-grained-role-graph`?
-- How should the first delivery ticket validate direct `fine-grained-role-graph` workflow extraction, exact pull request #478 parity, and performance before later delivery work relies on that path?
+- How should direct `fine-grained-role-graph` workflow extraction be validated for exact pull request #478 parity and performance?
 - How should the reusable Rivière graph comparison represent application ownership, subdomain ownership, and changes in associations without inventing containment?
 - What repository and revision metadata must the comparison carry so base and head evidence can link to exact source lines?
 - How should the complete GitHub representation and Éclair representation be generated from consistent comparison facts?
+- How should the upload file contract carry the required GitHub metadata, and how is that metadata supplied during generation?
 - How should generated comparison pages be deployed, accessed, retained, and operationally owned?
 - How should Éclair failures be isolated so they cannot prevent generation of the complete GitHub architecture diff?
 

--- a/docs/project/PRD/pull-request-diffs/component-design-option-1.md
+++ b/docs/project/PRD/pull-request-diffs/component-design-option-1.md
@@ -1,0 +1,454 @@
+<!-- component-design-option-1:start -->
+#### Option 1: DDD value objects and domain-facade comparison exposed as a query model
+
+This option makes architecture comparison a read-side domain capability inside `riviere-architecture`. The comparison input is a pair of file paths; the `riviere-architecture` use-cases package owns loading its inputs (the two `fine-grained-role-graph` files) exactly like the canonical riviere-builder query loaders; the comparison rules (diffing, grouping, association detection, affected-aggregate resolution, totals) live in explicit `domain-service` functions coordinated by a `domain-facade`; and the capability is exposed to callers as a `query-model` loaded by a `query-model-loader` and orchestrated by a `query-model-use-case`. The shared `ArchitectureDiff` serialization contract lives in a published-language package; the tracked `.riviere/pr-diffs/riviere-architecture-diff.json` envelope is modelled as a second query so the PR-time GitHub Action merges its fields and formats the report from already-generated state without recalculating. `apps/cli` passes only options and formats/writes output; every comparison rule sits in the domain.
+
+##### Domain model change
+
+```mermaid
+flowchart LR
+  fineGrainedRoleGraph["FineGrainedRoleGraph<br/>(role graph state)"]
+  roleElement["RoleElement<br/>(role-annotated element)"]
+  diffFacade["ArchitectureDiffFacade<br/>(coordinates services)"]
+  architectureDiff["ArchitectureDiff<br/>(published contract)"]
+
+  fineGrainedRoleGraph --"indexes"--> roleElement
+  diffFacade --"compares base and head"--> fineGrainedRoleGraph
+  diffFacade --"produces"--> architectureDiff
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+  class fineGrainedRoleGraph statusNew
+  class roleElement statusNew
+  class diffFacade statusOpen
+  class architectureDiff statusNew
+```
+
+Legend: green = new, red = open decision (domain-facade instance awaiting `approvedInstances` approval), gray = existing, yellow = changed.
+
+No aggregate here: the comparison only reads `base`/`head` and derives a result, so the owning class is a query model, and the behaviour is domain services plus a facade. `ArchitectureDiff` (green) is the published-language contract shown as a domain output, not a consumer-API mapping. The tracked-file envelope (`ArchitectureDiffEnvelope`) is deliberately **not** in this diagram: it is an app-facing read shape (query model), not a domain concept. There is no existing `riviere-architecture` subdomain, so all concepts are new.
+
+##### Runtime call diagram
+
+```mermaid
+flowchart LR
+  compareEntrypoint["createCompareArchitectureCommand<br/>(apps/cli feature entrypoint)"]
+  compareUseCase["CompareArchitecture<br/>(query-model-use-case)"]
+  comparisonLoader["ArchitectureComparisonLoader<br/>(query-model-loader)"]
+  roleGraph["FineGrainedRoleGraph<br/>(value-object)"]
+  comparisonModel["ArchitectureComparison<br/>(query-model)"]
+  diffFacade["ArchitectureDiffFacade<br/>(domain-facade)"]
+  commitFormatter["composeCommitArchitectureDiffEnvelope<br/>(cli-output-formatter)"]
+  commitWriter["writeCommitArchitectureDiffEnvelope<br/>(cli-response-writer)"]
+  publishEntrypoint["createPublishPullRequestArchitectureDiffCommand<br/>(apps/cli feature entrypoint)"]
+  envelopeUseCase["LoadGeneratedArchitectureDiff<br/>(query-model-use-case)"]
+  envelopeLoader["GeneratedArchitectureDiffLoader<br/>(query-model-loader)"]
+  diffParser["parseArchitectureDiff<br/>(published-language-parser)"]
+  mergeFormatter["composePullRequestArchitectureDiffEnvelope<br/>(cli-output-formatter)"]
+  githubFormatter["formatGitHubArchitectureDiff<br/>(cli-output-formatter)"]
+  mergeWriter["writeMergedArchitectureDiffEnvelope<br/>(cli-response-writer)"]
+  reportWriter["writeGitHubArchitectureDiffReport<br/>(cli-response-writer)"]
+
+  compareEntrypoint --"execute"--> compareUseCase
+  compareUseCase --"load"--> comparisonLoader
+  comparisonLoader --"parse"--> roleGraph
+  comparisonLoader --"from"--> comparisonModel
+  compareEntrypoint --"compare"--> comparisonModel
+  comparisonModel --"build"--> diffFacade
+  compareEntrypoint --"compose envelope"--> commitFormatter
+  compareEntrypoint --"write envelope file"--> commitWriter
+  publishEntrypoint --"execute"--> envelopeUseCase
+  envelopeUseCase --"load"--> envelopeLoader
+  envelopeLoader --"parse diff"--> diffParser
+  publishEntrypoint --"merge pull request metadata"--> mergeFormatter
+  publishEntrypoint --"write merged envelope"--> mergeWriter
+  publishEntrypoint --"format markdown"--> githubFormatter
+  publishEntrypoint --"write report"--> reportWriter
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+  class compareEntrypoint statusNew
+  class compareUseCase statusNew
+  class comparisonLoader statusNew
+  class roleGraph statusNew
+  class comparisonModel statusNew
+  class diffFacade statusOpen
+  class commitFormatter statusNew
+  class commitWriter statusNew
+  class publishEntrypoint statusNew
+  class envelopeUseCase statusNew
+  class envelopeLoader statusNew
+  class diffParser statusNew
+  class mergeFormatter statusNew
+  class githubFormatter statusNew
+  class mergeWriter statusNew
+  class reportWriter statusNew
+```
+
+Legend: green = new, red = open decision (facade instance approval), gray = existing, yellow = changed. Left cluster = commit-hook phase; right cluster = PR-time Action phase.
+
+##### State loading and persistence description
+
+**Load 1 — comparison inputs (commit-hook phase):**
+
+- **Loaded state:** exactly two `fine-grained-role-graph` files — `base` (the `main` revision) and `head` (the current commit). These are retained outputs of the two independently named Rivière workflows.
+- **Owning component and role:** `ArchitectureComparisonLoader` (`query-model-loader`) in `packages/riviere-architecture/use-cases/src/features/architecture-diff/data-access/architecture-comparison/`. This honours the approved ownership "Expose architecture comparison to callers, including loading its inputs"; the CLI passes only paths and never reads files.
+- **Exact load call:** `load(baseGraphPath, headGraphPath)`; per path it resolves the path against the working directory, checks `existsSync`, reads with `readFileSync`, `JSON.parse`s, then parses via `FineGrainedRoleGraph.parse` — mirroring `packages/riviere-builder/use-cases/src/features/query/data-access/graph/query-loaders.ts` (`loadQueryModel`/`resolveGraphPath`). Both paths are required; there is no default-path convention.
+- **Load inputs and origins:** `CompareArchitectureInput = { baseGraphPath: string; headGraphPath: string }` ← CLI options `--base-graph` / `--head-graph` supplied by the commit-hook script. How the hook generates and materialises the base (`main`) and head graph files (retained output paths, worktree, or checkout) is **deferred to the approved first delivery ticket** (ARCH.md §6); the loader therefore takes explicit required paths and invents no path convention.
+- **Loaded output:** `ArchitectureComparison` query model. `base` ← success value of `FineGrainedRoleGraph.parse(base file JSON)`; `head` ← success value of `FineGrainedRoleGraph.parse(head file JSON)`; combined via `ArchitectureComparison.from(base, head)`. Missing file → `FineGrainedRoleGraphNotFoundError`; unreadable/invalid JSON or failed parse → `FineGrainedRoleGraphCorruptedError` (both `data-access-error`).
+- **Invoked by:** `CompareArchitecture.execute` only. Never invoked by an entrypoint.
+- **Owning object after loading:** `ArchitectureComparison` holds both `FineGrainedRoleGraph` values as private read-only data members. Source location lives on each `RoleElement` (from `riviere-schema` `SourceLocation`); revision-specific URLs are composed at the app boundary inside the envelope metadata.
+
+**Load 2 — tracked diff envelope (PR-time Action phase):**
+
+- **Loaded state:** the tracked file `.riviere/pr-diffs/riviere-architecture-diff.json` (approved convention; used as the `envelopePathOption` default).
+- **Owning component and role:** `GeneratedArchitectureDiffLoader` (`query-model-loader`) in `.../data-access/architecture-diff-envelope/`.
+- **Exact load call:** `load(envelopePathOption)` → `readFileSync` → `JSON.parse` → `parseArchitectureDiff(envelope.diff)` (published-language parser, explicit success/failure result, no throwing validation).
+- **Load inputs and origins:** `LoadGeneratedArchitectureDiffInput = { envelopePathOption: string | undefined }` ← CLI option `--envelope` (default `.riviere/pr-diffs/riviere-architecture-diff.json`) supplied by the workflow step.
+- **Loaded output:** `ArchitectureDiffEnvelope`. `metadata` ← passthrough of the file's metadata object (`repository`, `baseRevision`, `headRevision`, `sourceLinks`, optional `pullRequest`); `diff` ← `parseArchitectureDiff` success value. Missing file → `ArchitectureDiffEnvelopeNotFoundError`; corrupt metadata or failed diff validation → `ArchitectureDiffEnvelopeCorruptedError` (`data-access-error`).
+- **Invoked by:** `LoadGeneratedArchitectureDiff.execute` only.
+
+**Persistence — tracked envelope writes (field-level ownership per ARCH.md):**
+
+- **Commit-hook write:** `writeCommitArchitectureDiffEnvelope(envelope, outputPath)` (`cli-response-writer`) writes `{ metadata: { repository, baseRevision, headRevision, sourceLinks }, diff }`. Field origins: `repository` ← `git remote get-url origin`; `baseRevision` ← `git rev-parse main`; `headRevision` ← `git rev-parse HEAD` — each passed by the commit-hook script as `--repository` / `--base-revision` / `--head-revision` options (the CLI performs no git subprocess calls; no `external-client-service` role is allowed in `apps/cli`). `sourceLinks` ← composed by `composeCommitArchitectureDiffEnvelope` from repository + revisions as base/head blob-URL prefixes (`https://github.com/{repository}/blob/{revision}/`) used by both GitHub and Éclair to build element source-line links from `SourceLocation`. `diff` ← `architectureComparison.compare()`. `outputPath` ← `--output`, default `.riviere/pr-diffs/riviere-architecture-diff.json`.
+- **PR-time write-back:** `writeMergedArchitectureDiffEnvelope(mergedEnvelope, envelopePath)` (`cli-response-writer`) writes the same file with only `metadata.pullRequest.{ number, title, description, url }` added by `composePullRequestArchitectureDiffEnvelope`. Field origins: GitHub Actions pull-request event context (`github.event.pull_request.number`, `.title`, `.body`, `.html_url`) passed as options by the workflow step. These fields do not exist at commit time.
+- **Report write:** `writeGitHubArchitectureDiffReport(markdown, reportPath)` (`cli-response-writer`) writes the markdown file the workflow posts as the pull-request comment; the report is built from the parsed envelope, never recalculated.
+
+##### Components
+
+Subdomain packages (`packages/riviere-architecture/`):
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `ArchitectureDiff` | `published-language/src/published-language` | New | `published-language-schema` | Root `diff` contract: subdomains, elements, associations, affected aggregates, totals. | Medium |
+| `ArchitectureSubdomainChange` | published-language | New | `published-language-data-structure` | Subdomain change with status, affected aggregates, per-package-kind additions/removals. | Medium |
+| `ArchitectureElementChange` | published-language | New | `published-language-data-structure` | Element change: direction, layer, group, before/after element reference, source evidence. | Large |
+| `ApplicationAssociationChange` | published-language | New | `published-language-data-structure` | Application↔subdomain association change with base and head source evidence. | Small |
+| `AffectedAggregate` | published-language | New | `published-language-data-structure` | Aggregate named as affected with separated added/removed members. | Small |
+| `ArchitectureDiffTotals` | published-language | New | `published-language-data-structure` | changedSubdomains, changedPackages, affectedAggregates. | Small |
+| `ARCHITECTURE_CHANGE_DIRECTION` / `ArchitectureChangeDirection` | published-language | New | `published-language-enumeration` / `published-language-enumeration-type` | `added` / `removed` / `modified`. | Small |
+| `ARCHITECTURE_PACKAGE_KIND` / `ArchitecturePackageKind` | published-language | New | `published-language-enumeration` / `published-language-enumeration-type` | `use-cases` / `domain-model` / `published-language` / `application`. | Small |
+| `ARCHITECTURE_LAYER_NAME` / `ArchitectureLayerName` | published-language | New | `published-language-enumeration` / `published-language-enumeration-type` | `entrypoints` / `use-cases` / `domain`. | Small |
+| `architecture-diff-field-names` | published-language | New | `published-language-field-name` | String-literal field-name constants. | Small |
+| `parseArchitectureDiff` | published-language | New | `published-language-parser` | Parse `unknown` → `ArchitectureDiff` or a declared failure shape; used by the envelope loader and by Éclair readers. | Medium |
+| `FineGrainedRoleGraph` | `domain-model/src/domain/comparison` | New | `value-object` | Owns a validated `RiviereGraph`; exposes `elements()` as `RoleElement[]`. | Medium |
+| `RoleElement` | domain-model | New | `value-object` | One role-annotated element: identity, `architectureRole`, `packageKind`, `aggregateOwnerId`, methods, source location; `sameAs`. | Medium |
+| `diffRoleElements` | domain-model `domain/comparison` | New | `domain-service` | Produce `ArchitectureElementChange[]` (added/removed/modified) via `RoleElement` identity. | Medium |
+| `groupChangesBySubdomainAndLayer` | domain-model | New | `domain-service` | Group element changes by subdomain → layer → direction → package/use-case/aggregate group. | Medium |
+| `detectApplicationAssociationChanges` | domain-model | New | `domain-service` | Detect application↔subdomain reassignment with base and head evidence. | Medium |
+| `resolveAffectedAggregates` | domain-model | New | `domain-service` | Enforce "changed on both sides ⇒ affected, not created+deleted". | Small |
+| `summarizeDiffTotals` | domain-model | New | `domain-service` | Compute `ArchitectureDiffTotals` from changes, grouping, associations. | Small |
+| `ArchitectureDiffFacade` | domain-model | New | `domain-facade` *(open decision)* | One stable `build(base, head)` interface coordinating the five comparison services held as private readonly members. | Small |
+| `CompareArchitecture` | `use-cases/src/features/architecture-diff/queries` | New | `query-model-use-case` | Translate input into loader criteria; load and return the comparison query model. | Small |
+| `CompareArchitectureInput` | use-cases `queries` | New | `query-model-use-case-input` | `{ baseGraphPath: string; headGraphPath: string }` — paths only, no file content. | Small |
+| `ArchitectureComparison` | use-cases `queries` | New | `query-model` | Read model holding base+head; exposes `compare(): ArchitectureDiff` via the facade. | Small |
+| `ArchitectureComparisonLoader` | use-cases `data-access/architecture-comparison` | New | `query-model-loader` | `load(baseGraphPath, headGraphPath)`: read both graph files via `node:fs`, parse value objects, construct the query model. Owns "loading its inputs". | Medium |
+| `FineGrainedRoleGraphNotFoundError` / `FineGrainedRoleGraphCorruptedError` | use-cases `data-access/architecture-comparison` | New | `data-access-error` | Missing or corrupt/unparseable graph file (not a domain violation). | Small |
+| `LoadGeneratedArchitectureDiff` | use-cases `queries` | New | `query-model-use-case` | Load and return the tracked envelope as a query model. | Small |
+| `LoadGeneratedArchitectureDiffInput` | use-cases `queries` | New | `query-model-use-case-input` | `{ envelopePathOption: string \| undefined }`. | Small |
+| `ArchitectureDiffEnvelope` | use-cases `queries` | New | `query-model` | `{ metadata, diff }` interface — the tracked-file read shape and app write target. | Small |
+| `ArchitectureDiffEnvelopeMetadata` / `ArchitectureDiffPullRequestMetadata` | use-cases `queries` | New | `query-model-value` | Commit-time metadata (repository, revisions, sourceLinks, optional pullRequest) and PR-time metadata (number, title, description, url). | Small |
+| `GeneratedArchitectureDiffLoader` | use-cases `data-access/architecture-diff-envelope` | New | `query-model-loader` | `load(envelopePathOption)`: read tracked file, validate `diff` via `parseArchitectureDiff`, return the envelope. | Medium |
+| `ArchitectureDiffEnvelopeNotFoundError` / `ArchitectureDiffEnvelopeCorruptedError` | use-cases `data-access/architecture-diff-envelope` | New | `data-access-error` | Missing tracked file or invalid envelope/diff. | Small |
+
+Consumer boundaries:
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `createCompareArchitectureCommand` + `CompareArchitectureEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/compare-architecture` | New | `cli-entrypoint` + `cli-entrypoint-dependencies` | Register `--base-graph`/`--head-graph`/`--repository`/`--base-revision`/`--head-revision`/`--output` options; translate options into `CompareArchitectureInput` inline (canonical query pattern; **no input factory**); invoke query; call `compare()`; compose and write the commit-time envelope. | Small |
+| `composeCommitArchitectureDiffEnvelope` | `apps/cli` `entrypoint/compare-architecture` | New | `cli-output-formatter` | Compose `{ metadata: { repository, baseRevision, headRevision, sourceLinks }, diff }` from the diff and git-context options; derive sourceLinks URL prefixes. | Small |
+| `writeCommitArchitectureDiffEnvelope` | `apps/cli` `entrypoint/compare-architecture` | New | `cli-response-writer` | Write the envelope JSON to the tracked output path. | Small |
+| `createPublishPullRequestArchitectureDiffCommand` + `PublishPullRequestArchitectureDiffEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/publish-pr-architecture-diff` | New | `cli-entrypoint` + `cli-entrypoint-dependencies` | Register `--envelope`/`--pull-request-number`/`--pull-request-title`/`--pull-request-description`/`--pull-request-url`/`--report-output` options; translate into `LoadGeneratedArchitectureDiffInput`; invoke query; merge, write back, format, and write the report. | Small |
+| `composePullRequestArchitectureDiffEnvelope` | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-output-formatter` | Add only `metadata.pullRequest.*` to the loaded envelope (approved PR-time field ownership). | Small |
+| `formatGitHubArchitectureDiff` (+ sibling section formatters) | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-output-formatter` | Format the parsed envelope (diff + sourceLinks) as the complete GitHub markdown report; decomposes into section formatter functions like the existing proof of concept. | Large |
+| `writeMergedArchitectureDiffEnvelope` | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-response-writer` | Write the merged envelope back to the tracked file. | Small |
+| `writeGitHubArchitectureDiffReport` | `apps/cli` `entrypoint/publish-pr-architecture-diff` | New | `cli-response-writer` | Write the markdown report file the workflow posts as the pull-request comment. | Small |
+| `pr-diff` review page | `apps/eclair/src/features/pr-diff` | New | (Éclair is unassigned) | Public link load and private upload both validate `diff` via `parseArchitectureDiff`; presents metadata from the envelope. | — |
+| Commit-hook script + PR workflow steps | `.githooks/` + `.github/workflows/` | Changed | (outside enforced packages) | Supply git context and GitHub event context as CLI options; invoke the two commands; post the report comment. | — |
+
+### .riviere role options
+
+| Element | Kind | Sublocation | Candidate roles | Preferred role | Reason | Open decision |
+|---|---|---|---|---|---|---|
+| `ArchitectureDiff` | interface | `riviere-architecture/published-language` | `published-language-schema`, `published-language-data-structure` | `published-language-schema` | Root cross-boundary contract, not a nested member shape. | none |
+| `ArchitectureSubdomainChange`, `ArchitectureElementChange`, `ApplicationAssociationChange`, `AffectedAggregate`, `ArchitectureDiffTotals` | interfaces | published-language | `published-language-data-structure` | `published-language-data-structure` | Member shapes of the schema; must be data structures. | none |
+| `ARCHITECTURE_CHANGE_DIRECTION`/`ArchitectureChangeDirection` (and package-kind, layer-name pairs) | variable + type alias | published-language | `published-language-enumeration` + `-enumeration-type` | same | Closed string unions follow the repo enumeration pair convention. | none |
+| `architecture-diff-field-names` | const | published-language | `published-language-field-name` | `published-language-field-name` | Unchecked string-literal duplication is forbidden repo-wide. | none |
+| `parseArchitectureDiff` | function | published-language | `published-language-parser` | `published-language-parser` | Parses the complete schema with an explicit failure branch; used by the envelope loader and Éclair. | none |
+| `FineGrainedRoleGraph`, `RoleElement` | classes | `riviere-architecture/domain-model` `domain/comparison` | `value-object` | `value-object` | Immutable parsed graph state with `parse`/`from` factories and brand members; no invariants beyond integrity. | `RoleElement` terminology confirmation |
+| `diffRoleElements`, `groupChangesBySubdomainAndLayer`, `detectApplicationAssociationChanges`, `resolveAffectedAggregates`, `summarizeDiffTotals` | functions | domain-model `domain/comparison` | `domain-service` | `domain-service` | Operate on two value-object states (base and head) that no single object owns; each carries the required justification ("comparison of two states has no single owning aggregate/value object"). | none |
+| `ArchitectureDiffFacade` | class | domain-model `domain/comparison` | `domain-facade`, `domain-service` | `domain-facade` | Consumer (`ArchitectureComparison` query model) needs one stable interface over five services with sequencing; `domain-service` forbids depending on other domain services. Requires `approvedInstances` entry with justification answering the configured question. | **yes** — user approval required |
+| `CompareArchitecture`, `LoadGeneratedArchitectureDiff` | classes | `riviere-architecture/use-cases` `features/architecture-diff/queries` | `query-model-use-case` | `query-model-use-case` | Read-only load-and-return orchestration. | none |
+| `CompareArchitectureInput`, `LoadGeneratedArchitectureDiffInput` | interfaces | use-cases `queries` | `query-model-use-case-input` | `query-model-use-case-input` | Name matches `.*(Input\|Options)$`; paths/options only. | none |
+| `ArchitectureComparison` | class | use-cases `queries` | `query-model` | `query-model` | Read model for the concrete compare read; depends on the facade (allowed dependent role). | none |
+| `ArchitectureDiffEnvelope` | interface | use-cases `queries` | `query-model`, `query-model-value` | `query-model` | The tracked-file read shape returned by the query; `query-model` (interface target) is also accepted by `cli-response-writer.allowedInputs`. | none |
+| `ArchitectureDiffEnvelopeMetadata`, `ArchitectureDiffPullRequestMetadata` | interfaces | use-cases `queries` | `query-model-value` | `query-model-value` | Result shapes flowing out of the envelope query model. | none |
+| `ArchitectureComparisonLoader`, `GeneratedArchitectureDiffLoader` | classes | use-cases `data-access/{architecture-comparison, architecture-diff-envelope}` | `query-model-loader` | `query-model-loader` | Load concrete query models from persisted files; canonical `query-loaders.ts` shape; no save. | none |
+| `FineGrainedRoleGraphNotFoundError`/`…CorruptedError`, `ArchitectureDiffEnvelopeNotFoundError`/`…CorruptedError` | classes | use-cases `data-access/*` | `data-access-error` | `data-access-error` | File-level failures, mirroring `GraphNotFoundError`/`GraphCorruptedError`. | none |
+| `createCompareArchitectureCommand`, `createPublishPullRequestArchitectureDiffCommand` | functions | `apps/cli` `features/architecture-diff/entrypoint/*` | `cli-entrypoint` | `cli-entrypoint` | Register command, translate options into query input inline, invoke query, delegate formatting/writing. | none |
+| `CompareArchitectureEntrypointDependencies`, `PublishPullRequestArchitectureDiffEntrypointDependencies` | interfaces | apps/cli entrypoints | `cli-entrypoint-dependencies` | `cli-entrypoint-dependencies` | Name matches `.*EntrypointDependencies$`; collaborator roles all allowed. | none |
+| `composeCommitArchitectureDiffEnvelope`, `composePullRequestArchitectureDiffEnvelope`, `formatGitHubArchitectureDiff` (+ section formatters) | functions | apps/cli entrypoints | `cli-output-formatter` | `cli-output-formatter` | Decide envelope/report presentation from a typed result; no file I/O, no loading. | none |
+| `writeCommitArchitectureDiffEnvelope`, `writeMergedArchitectureDiffEnvelope`, `writeGitHubArchitectureDiffReport` | functions | apps/cli entrypoints | `cli-response-writer` | `cli-response-writer` | Perform the output side effect (file writes); envelope input is a `query-model`. | none |
+
+No `command-input-factory` appears on the query path: its `allowedOutputs`/`allowedDependencyRoles` only permit `command-use-case-input`, and the canonical "CLI Invoking Query Model Use Case" pattern has no factory — the `cli-entrypoint` translates options inline, matching `apps/cli/src/features/query/entrypoint/components/entrypoint.ts`.
+
+### Canonical role pattern
+
+Pattern: `CLI Invoking Query Model Use Case` and `Query Model Use Case loading and querying a query model` (from `.riviere/canonical-role-configurations.md`), applied twice. The commit-hook command invokes `CompareArchitecture` and formats/writes the envelope; the PR-time Action invokes `LoadGeneratedArchitectureDiff` and formats/writes the merged envelope plus report. Both loaders follow the canonical `query-loaders.ts` data-access shape (path option in, file read via `node:fs`, `data-access-error` on failure, concrete query model out).
+
+### Tangled responsibility findings
+
+- **Resolved:** the previous draft had the app-side entrypoint/factory read graph files and pass raw content — an "entrypoint directly imports persistence" tangle, plus a `command-input-factory` producing a `query-model-use-case-input` (incompatible role). Corrected: all file reading lives in `ArchitectureComparisonLoader`/`GeneratedArchitectureDiffLoader` (use-cases data-access); the factory is dropped.
+- **Checked, not tangled:** the PR-time merge is presentation-side composition (`cli-output-formatter`) plus a `cli-response-writer` file write at the CLI output boundary — the same precedent as `writeFinalizedGraph`/`writePullRequestArchitectureDiff`. No write behaviour exists on a query model or loader, so the "write behind a query model" check passes.
+
+No tangled responsibilities identified beyond the resolved finding above.
+
+#### Output contract reconciliation
+
+`CompareArchitecture.execute` returns `ArchitectureComparison` (role `query-model`), satisfying `allowedOutputs = ['query-model', 'query-model-value']`. Its `compare()` returns the published-language `ArchitectureDiff` via the facade. `LoadGeneratedArchitectureDiff.execute` returns `ArchitectureDiffEnvelope` (interface annotated `query-model`) whose `diff` member is the validated `ArchitectureDiff` and whose `metadata` members are `query-model-value` shapes. `apps/cli` never imports published-language directly (features may only import subdomain `queries`/`commands`): it consumes the `ArchitectureDiff` type via the query package's exported types and the envelope, and `parseArchitectureDiff` is invoked inside `GeneratedArchitectureDiffLoader` (data-access may import any subdomain published-language) and by Éclair. The envelope keeps GitHub-specific identity fields out of the language-agnostic `ArchitectureDiff` schema, per the approved rejection. Conformance between query results and the schema is asserted in use-cases tests by round-tripping through `parseArchitectureDiff`. The approved field-level write ownership is visible in the two composers: commit-time writes `repository`/`baseRevision`/`headRevision`/`sourceLinks`/`diff`; PR-time adds only `pullRequest.number`/`.title`/`.description`/`.url`.
+
+##### Runtime call outline
+
+```text
+createCompareArchitectureCommand  (commit-hook phase)
+  ├─ compareArchitecture.execute({ baseGraphPath, headGraphPath })
+  │  └─ architectureComparisonLoader.load(baseGraphPath, headGraphPath)
+  │     ├─ readFileSync(baseGraphPath)
+  │     ├─ FineGrainedRoleGraph.parse(baseGraphJson)
+  │     ├─ readFileSync(headGraphPath)
+  │     ├─ FineGrainedRoleGraph.parse(headGraphJson)
+  │     └─ ArchitectureComparison.from(base, head)
+  ├─ architectureComparison.compare()
+  │  └─ architectureDiffFacade.build(base, head)
+  │     ├─ diffRoleElements(base.elements(), head.elements())
+  │     ├─ groupChangesBySubdomainAndLayer(elementChanges, base, head)
+  │     ├─ detectApplicationAssociationChanges(base.elements(), head.elements())
+  │     ├─ resolveAffectedAggregates(elementChanges)
+  │     └─ summarizeDiffTotals(elementChanges, grouping, associationChanges)
+  ├─ composeCommitArchitectureDiffEnvelope(architectureDiff, commitContext)
+  └─ writeCommitArchitectureDiffEnvelope(envelope, outputPath)
+
+createPublishPullRequestArchitectureDiffCommand  (PR-time Action phase)
+  ├─ loadGeneratedArchitectureDiff.execute({ envelopePathOption })
+  │  └─ generatedArchitectureDiffLoader.load(envelopePathOption)
+  │     ├─ readFileSync(envelopePath)
+  │     └─ parseArchitectureDiff(envelopeJson.diff)
+  ├─ composePullRequestArchitectureDiffEnvelope(envelope, pullRequestMetadata)
+  ├─ writeMergedArchitectureDiffEnvelope(mergedEnvelope, envelopePath)
+  ├─ formatGitHubArchitectureDiff(mergedEnvelope)
+  └─ writeGitHubArchitectureDiffReport(markdown, reportPath)
+```
+
+##### Code stress test
+
+```typescript
+// ── riviere-architecture/use-cases: queries ──────────────────────────────
+/** @riviere-role query-model-use-case */
+export class CompareArchitecture {
+  constructor(private readonly loader: ArchitectureComparisonLoader) {}
+  execute(input: CompareArchitectureInput): ArchitectureComparison {
+    return this.loader.load(input.baseGraphPath, input.headGraphPath)
+  }
+}
+
+// ── riviere-architecture/use-cases: data-access (owns loading its inputs) ─
+/** @riviere-role query-model-loader */
+export class ArchitectureComparisonLoader {
+  load(baseGraphPath: string, headGraphPath: string): ArchitectureComparison {
+    const base = loadFineGrainedRoleGraph(baseGraphPath)
+    const head = loadFineGrainedRoleGraph(headGraphPath)
+    return ArchitectureComparison.from(base, head)
+  }
+}
+
+function loadFineGrainedRoleGraph(graphPath: string): FineGrainedRoleGraph {
+  if (!existsSync(graphPath)) {
+    throw new FineGrainedRoleGraphNotFoundError(graphPath)
+  }
+  let json: unknown
+  try {
+    json = JSON.parse(readFileSync(graphPath, 'utf-8'))
+  } catch (error) {
+    throw new FineGrainedRoleGraphCorruptedError(graphPath, { cause: error })
+  }
+  const parsed = FineGrainedRoleGraph.parse(json)
+  if (!parsed.success) {
+    throw new FineGrainedRoleGraphCorruptedError(graphPath)
+  }
+  return parsed.graph
+}
+
+/** @riviere-role query-model */
+export class ArchitectureComparison {
+  private readonly facade = new ArchitectureDiffFacade()
+  private constructor(
+    private readonly base: FineGrainedRoleGraph,
+    private readonly head: FineGrainedRoleGraph,
+  ) {}
+  static from(base: FineGrainedRoleGraph, head: FineGrainedRoleGraph): ArchitectureComparison {
+    return new ArchitectureComparison(base, head)
+  }
+  compare(): ArchitectureDiff {
+    return this.facade.build(this.base, this.head)
+  }
+}
+
+// ── riviere-architecture/domain-model: facade holds its services ─────────
+/** @riviere-role domain-facade */
+export class ArchitectureDiffFacade {
+  private readonly diffElements = diffRoleElements
+  private readonly groupChanges = groupChangesBySubdomainAndLayer
+  private readonly detectAssociationChanges = detectApplicationAssociationChanges
+  private readonly resolveAffected = resolveAffectedAggregates
+  private readonly summarizeTotals = summarizeDiffTotals
+
+  build(base: FineGrainedRoleGraph, head: FineGrainedRoleGraph): ArchitectureDiff {
+    const elements = this.diffElements(base.elements(), head.elements())
+    const grouping = this.groupChanges(elements, base, head)
+    const associations = this.detectAssociationChanges(base.elements(), head.elements())
+    const affectedAggregates = this.resolveAffected(elements)
+    const totals = this.summarizeTotals(elements, grouping, associations)
+    return { subdomains: grouping.subdomains, elements, associations, affectedAggregates, totals }
+  }
+}
+
+// ── domain service: element diff by stable identity (added/removed/modified)
+/** @riviere-role domain-service */
+export function diffRoleElements(
+  base: readonly RoleElement[],
+  head: readonly RoleElement[],
+): readonly ArchitectureElementChange[] {
+  const baseById = new Map(base.map((element) => [element.id, element]))
+  const headById = new Map(head.map((element) => [element.id, element]))
+  const added = [...headById.values()]
+    .filter((element) => !baseById.has(element.id))
+    .map((after) => ({ direction: 'added', after }) as ArchitectureElementChange)
+  const removed = [...baseById.values()]
+    .filter((element) => !headById.has(element.id))
+    .map((before) => ({ direction: 'removed', before }) as ArchitectureElementChange)
+  const modified = [...headById.values()]
+    .filter((element) => baseById.has(element.id) && !baseById.get(element.id)!.sameAs(element))
+    .map((after) => ({ direction: 'modified', before: baseById.get(after.id)!, after }) as ArchitectureElementChange)
+  return [...added, ...removed, ...modified]
+}
+
+// ── apps/cli: approved field-level envelope ownership ────────────────────
+/** @riviere-role cli-output-formatter */
+export function composeCommitArchitectureDiffEnvelope(
+  architectureDiff: ArchitectureDiff,
+  commitContext: { repository: string; baseRevision: string; headRevision: string },
+): ArchitectureDiffEnvelope {
+  return {
+    metadata: {
+      repository: commitContext.repository,
+      baseRevision: commitContext.baseRevision,
+      headRevision: commitContext.headRevision,
+      sourceLinks: {
+        base: `https://github.com/${commitContext.repository}/blob/${commitContext.baseRevision}/`,
+        head: `https://github.com/${commitContext.repository}/blob/${commitContext.headRevision}/`,
+      },
+    },
+    diff: architectureDiff,
+  }
+}
+
+/** @riviere-role cli-output-formatter */
+export function composePullRequestArchitectureDiffEnvelope(
+  envelope: ArchitectureDiffEnvelope,
+  pullRequest: ArchitectureDiffPullRequestMetadata,
+): ArchitectureDiffEnvelope {
+  return { metadata: { ...envelope.metadata, pullRequest }, diff: envelope.diff }
+}
+```
+
+`groupChangesBySubdomainAndLayer`, `detectApplicationAssociationChanges`, `resolveAffectedAggregates`, and `summarizeDiffTotals` keep the previous option's domain-service shapes (grouping by `RoleElement.domain`/`.layer`/`.packageKind`; association reassignment with base+head evidence; "changed on both sides ⇒ affected"; three totals). `RoleElement.sameAs(other)` implements structural equality over `architectureRole`, `packageKind`, `aggregateOwnerId`, `methods`, and `sourceLocation`, ignoring `id`.
+
+##### New dependencies
+
+| Dependency | Status | Used by | Purpose |
+|---|---|---|---|
+| `@living-architecture/riviere-schema-published-language` | Existing | `riviere-architecture-published-language`, `riviere-architecture-domain-model` | Reuse `Component`, `Link`, `SourceLocation`, `RiviereGraph` for element references and graph parsing. |
+| `@living-architecture/riviere-architecture-published-language` | New | `riviere-architecture-domain-model`, `riviere-architecture-use-cases`, `apps/eclair` | The single shared `ArchitectureDiff` contract and `parseArchitectureDiff` for readers. |
+| `@living-architecture/riviere-architecture-use-cases` | New | `apps/cli` | The two query use cases, query models, envelope types, and loaders; apps may only import subdomain queries/commands. |
+| None | — | — | No runtime/adapter libraries; comparison is pure domain logic over parsed graphs; file access is `node:fs` in data-access and CLI writers only. |
+
+##### Code shape
+
+```text
+packages/riviere-architecture/
+  published-language/src/published-language/
+    architecture-diff.ts                    (root schema)
+    architecture-element-change.ts          (data structure)
+    architecture-subdomain-change.ts
+    application-association-change.ts
+    affected-aggregate.ts
+    architecture-diff-totals.ts
+    architecture-change-direction.ts        (enumeration + type)
+    architecture-package-kind.ts
+    architecture-layer-name.ts
+    architecture-diff-field-names.ts
+    parse-architecture-diff.ts              (parser)
+    index.ts
+  domain-model/src/domain/comparison/
+    fine-grained-role-graph.ts              (value-object)
+    role-element.ts                         (value-object)
+    diff-role-elements.ts                   (domain-service)
+    group-changes-by-subdomain-and-layer.ts (domain-service)
+    detect-application-association-changes.ts (domain-service)
+    resolve-affected-aggregates.ts          (domain-service)
+    summarize-diff-totals.ts                (domain-service)
+    architecture-diff-facade.ts             (domain-facade)
+  use-cases/src/features/architecture-diff/
+    queries/compare-architecture.ts               (query-model-use-case)
+    queries/compare-architecture-input.ts
+    queries/architecture-comparison.ts            (query-model)
+    queries/load-generated-architecture-diff.ts   (query-model-use-case)
+    queries/load-generated-architecture-diff-input.ts
+    queries/architecture-diff-envelope.ts         (query-model)
+    queries/architecture-diff-envelope-metadata.ts        (query-model-value)
+    queries/architecture-diff-pull-request-metadata.ts    (query-model-value)
+    data-access/architecture-comparison/architecture-comparison-loader.ts
+    data-access/architecture-comparison/fine-grained-role-graph-not-found-error.ts
+    data-access/architecture-comparison/fine-grained-role-graph-corrupted-error.ts
+    data-access/architecture-diff-envelope/generated-architecture-diff-loader.ts
+    data-access/architecture-diff-envelope/architecture-diff-envelope-not-found-error.ts
+    data-access/architecture-diff-envelope/architecture-diff-envelope-corrupted-error.ts
+apps/cli/src/features/architecture-diff/entrypoint/
+  compare-architecture/entrypoint.ts
+  compare-architecture/compose-commit-architecture-diff-envelope.ts
+  compare-architecture/write-commit-architecture-diff-envelope.ts
+  publish-pr-architecture-diff/entrypoint.ts
+  publish-pr-architecture-diff/compose-pull-request-architecture-diff-envelope.ts
+  publish-pr-architecture-diff/format-github-architecture-diff.ts   (+ section formatters)
+  publish-pr-architecture-diff/write-merged-architecture-diff-envelope.ts
+  publish-pr-architecture-diff/write-github-architecture-diff-report.ts
+apps/eclair/src/features/pr-diff/             (minimal review page)
+```
+
+##### Design validation
+
+- **Domain terminology:** pass. `FineGrainedRoleGraph`, `ArchitectureDiff`, `ArchitectureComparison`, `ArchitectureDiffEnvelope`, `metadata`/`diff` envelope keys, `sourceLinks`, commit hook, and PR-time Action reuse PRD/ARCH terms. `RoleElement` is proposed for a single role-annotated element (no existing shared term).
+- **Application/domain separation:** pass. Both use cases only translate-and-load-and-return; the comparison query model delegates computation to the facade; every comparison rule is a domain service; envelope merge and report formatting are presentation-side; no loops or private logic in use cases.
+- **Role and location fit:** pass, with one open decision. Every element maps to a real role and an allowed sublocation; loading lives in use-cases data-access per the approved "including loading its inputs" ownership; no `command-input-factory` on the query path; writers take a `query-model`/strings. `ArchitectureDiffFacade` is a new `domain-facade` instance needing `approvedInstances` approval.
+- **Implementability:** pass. ADR-002 allows domain-model→any published-language, use-cases→own domain + any published-language, and apps→subdomain queries only; the envelope query makes `parseArchitectureDiff` reachable without apps importing published-language; both file reads mirror the canonical `query-loaders.ts` pattern.
+
+##### Rejected sub-ideas
+
+- **Aggregate + aggregate-repository + command-use-case:** rejected — the comparison is read-only over immutable inputs and derives a result without mutating or persisting domain state, so the write-side roles are wrong.
+- **App-side generic JSON reader passing raw content:** rejected — ARCH.md assigns input loading to `riviere-architecture/use-cases`, the canonical query loaders read files by path in data-access, and no reader role exists in `apps/cli`.
+- **`command-input-factory` on the query path:** rejected — its role constraints only allow producing `command-use-case-input`; the canonical query pattern translates options in the `cli-entrypoint` with no factory.
+- **Returning the published-language `ArchitectureDiff` directly from the use case:** rejected — `query-model-use-case` `allowedOutputs` are `query-model`/`query-model-value`; the query models own the read and the published-language package owns serialization.
+- **A single monolithic `buildArchitectureDiff` domain-service:** rejected — it hides the grouping, association, affected-aggregate, and totals rules behind one entry point; the per-capability services make each rule reviewable.
+- **Sequencing services inside the query model:** rejected — that would leak comparison orchestration into the query layer; the facade keeps it in the domain.
+- **Moving grouping into the CLI formatter:** rejected — grouping and association detection are comparison rules, not presentation, and must stay consistent across GitHub and Éclair.
+- **Modelling the PR-time merge as a command use case:** rejected — the merge adds presentation metadata to an already-generated file at the CLI output boundary; no domain state changes, so the writer/formatter pair is sufficient and matches `writeFinalizedGraph` precedent.
+
+##### Open decisions
+
+- **New domain-facade instance `ArchitectureDiffFacade`.** Requires approval to be added to `approvedInstances` in `.riviere/roles.ts`. Justification answering the configured question: the consumer is the `ArchitectureComparison` query model (plus any future query needing the same read); it needs one stable domain interface because correctly assembling the comparison requires five services in a fixed sequence (diff → group + detect associations → resolve affected aggregates → totals), a discovery and assembly burden that must not leak into the query layer.
+- **`RoleElement` terminology.** Proposed domain term for a single role-annotated element in the fine-grained-role-graph; confirm before it becomes shared vocabulary.
+<!-- component-design-option-1:end -->

--- a/docs/project/PRD/pull-request-diffs/component-design-option-2.md
+++ b/docs/project/PRD/pull-request-diffs/component-design-option-2.md
@@ -1,0 +1,585 @@
+<!-- component-design-option-2:start -->
+#### Option 2: Lean query-model-only comparison
+
+Comparing two `fine-grained-role-graph` states is a **read-only** operation: a pure function over two immutable inputs producing one immutable result, so `riviere-architecture` stays **query-only** — one comparison query (`CompareArchitecture`) and one envelope-loading query (`LoadArchitectureDiffEnvelope`), with no aggregate, repository, or command use case in the subdomain. The graph-to-architecture projection — selecting review elements, resolving ownership links, grouping into subdomains and layers — is `ArchitectureGraph.from(riviereGraph)` in the domain-model, the architectural interpretation ARCH §2 assigns to `packages/riviere-architecture/domain-model`; the use-cases loaders own only reading and validating inputs. The retained file convention is delivered by two named `apps/cli` writers: the commit hook records the `ArchitectureDiff` plus commit-time metadata into `.riviere/pr-diffs/riviere-architecture-diff.json`, and the PR-time Action loads that same file, records `metadata.pullRequest`, and formats the GitHub report **from the file — never from a live comparison**. The envelope contract (`metadata` + `diff`, commit-time vs PR-time field split) is owned by `riviere-architecture/published-language`, and Éclair consumes the same envelope through its parser.
+
+##### Domain model change
+
+The comparison rules move from the dead `living-documentation` proof of concept into `riviere-architecture`, expressed **in Rivière graph concepts, not TypeScript symbols**. No aggregate is introduced: comparison has no lifecycle, protected state, or invariant beyond validity of inputs and output, and validity is owned by published-language parsing and value-object construction.
+
+```mermaid
+flowchart LR
+    graphArchitecture["ArchitectureGraph<br/>(value-object)"]
+    item["ArchitectureElement<br/>(value-object)"]
+    aggregateView["AggregateView<br/>(value-object)"]
+    comparison["ArchitectureComparison<br/>(domain-service)"]
+    diff["ArchitectureDiff<br/>(published output)"]
+
+    graphArchitecture -->|"selects and normalises"| item
+    graphArchitecture -->|"resolves ownership links into"| aggregateView
+    aggregateView -->|"owns members"| item
+    comparison -->|"accepts two graphs"| graphArchitecture
+    comparison -->|"emits"| diff
+    diff -->|"reports changes of"| item
+    diff -->|"reports changes of"| aggregateView
+
+    classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+    classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+    classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+    classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+    class graphArchitecture statusNew
+    class item statusNew
+    class aggregateView statusNew
+    class comparison statusNew
+    class diff statusNew
+```
+
+Legend: green = new domain concept. There are no changed or open-decision domain concepts in this option.
+
+##### Runtime call diagram
+
+```mermaid
+flowchart LR
+    subgraph appsCli["apps/cli"]
+        recordEntrypoint["createRecordArchitectureDiffCommand<br/>(apps/cli entrypoint)"]
+        recordPrEntrypoint["createRecordPullRequestMetadataCommand<br/>(apps/cli entrypoint)"]
+        formatReviewEntrypoint["createFormatArchitectureDiffReviewCommand<br/>(apps/cli entrypoint)"]
+        writeEnvelope["writeArchitectureDiffEnvelope<br/>(apps/cli cli-response-writer)"]
+        writeEnvelopePr["writeArchitectureDiffEnvelopePullRequest<br/>(apps/cli cli-response-writer)"]
+        formatReview["formatArchitectureDiffReview<br/>(apps/cli cli-output-formatter)"]
+        sourceLinks["githubSourceLinkTemplate<br/>(apps/cli cli-output-formatter)"]
+    end
+    subgraph useCases["riviere-architecture / use-cases"]
+        compare["CompareArchitecture<br/>(query-model-use-case)"]
+        loadEnvelope["LoadArchitectureDiffEnvelope<br/>(query-model-use-case)"]
+        graphLoader["FineGrainedRoleGraphLoader<br/>(query-model-loader)"]
+        envelopeLoader["ArchitectureDiffEnvelopeLoader<br/>(query-model-loader)"]
+    end
+    subgraph domainModel["riviere-architecture / domain-model"]
+        projection["ArchitectureGraph<br/>(value-object)"]
+        element["ArchitectureElement<br/>(value-object)"]
+        aggregateView["AggregateView<br/>(value-object)"]
+        comparison["ArchitectureComparison<br/>(domain-service)"]
+    end
+    subgraph parsers["shared published-language parsers"]
+        parseEnvelope["parseArchitectureDiffEnvelope<br/>(riviere-architecture published-language)"]
+        parseGraph["parseRiviereGraph<br/>(riviere-schema published-language)"]
+    end
+    eclairPage["PrDiffReviewPage<br/>(apps/eclair)"]
+
+    recordEntrypoint -->|"execute comparison input"| compare
+    recordEntrypoint -->|"write envelope file"| writeEnvelope
+    compare -->|"load base and head graph"| graphLoader
+    graphLoader -->|"validate graph json"| parseGraph
+    graphLoader -->|"project graph into architecture view"| projection
+    projection -->|"normalise review element fields"| element
+    projection -->|"resolve aggregate owned entities"| aggregateView
+    compare -->|"compare base and head graphs"| comparison
+    recordPrEntrypoint -->|"execute envelope load input"| loadEnvelope
+    recordPrEntrypoint -->|"write pull request metadata"| writeEnvelopePr
+    formatReviewEntrypoint -->|"execute envelope load input"| loadEnvelope
+    formatReviewEntrypoint -->|"format github report markdown"| formatReview
+    loadEnvelope -->|"load retained envelope file"| envelopeLoader
+    envelopeLoader -->|"validate envelope json"| parseEnvelope
+    writeEnvelope -->|"compose revision source link"| sourceLinks
+    eclairPage -->|"validate fetched or uploaded envelope"| parseEnvelope
+
+    classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+    classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+    classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+    classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+    class recordEntrypoint statusChanged
+    class recordPrEntrypoint statusChanged
+    class formatReviewEntrypoint statusChanged
+    class writeEnvelope statusChanged
+    class writeEnvelopePr statusChanged
+    class formatReview statusChanged
+    class sourceLinks statusChanged
+    class compare statusNew
+    class loadEnvelope statusNew
+    class graphLoader statusNew
+    class envelopeLoader statusNew
+    class projection statusNew
+    class element statusNew
+    class aggregateView statusNew
+    class comparison statusNew
+    class parseEnvelope statusNew
+    class parseGraph statusExisting
+    class eclairPage statusOpen
+```
+
+Legend: green = new (the three `riviere-architecture` packages are new); yellow = changed (new commands added to the existing `apps/cli`); gray = existing (`parseRiviereGraph` in `riviere-schema-published-language`); red = open decision (`PrDiffReviewPage`, Éclair is explicitly unassigned).
+
+##### Components
+
+All three `packages/riviere-architecture/*` packages are new; `apps/cli` and `apps/eclair` are changed.
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `ArchitectureGraph` | `packages/riviere-architecture/domain-model/src/domain/architecture-graph.ts` | New | `value-object` | Owns the architectural interpretation (ARCH §2): `from(riviereGraph)` selects `architecture-review-element` components, resolves `aggregate-owns-entity` and `supports-primary-element` links, groups members into subdomains/layers, splits application-owned elements out, canonicalises ordering. | Medium |
+| `ArchitectureElement` | `packages/riviere-architecture/domain-model/src/domain/architecture-element.ts` | New | `value-object` | One role-annotated element; `fromReviewElementComponent` owns field normalisation: name, subdomain, `architectureRole`, `packageKind` into the closed union, `externalClient`, `methods`, related-to references, source evidence. | Small |
+| `AggregateView` | `packages/riviere-architecture/domain-model/src/domain/aggregate-view.ts` | New | `value-object` | Read view of one aggregate; `fromAggregateComponent` owns field normalisation plus resolved owned-entity names: name, packageKind, methods, entities, source evidence. | Small |
+| `InvalidArchitectureGraphError` | `packages/riviere-architecture/domain-model/src/domain/invalid-architecture-graph-error.ts` | New | `domain-error` | Thrown by the projection when a review element's required custom properties are missing or outside the closed unions (schema-valid graph, untrustworthy custom values). | Small |
+| `ArchitectureComparison` | `packages/riviere-architecture/domain-model/src/domain/architecture-comparison.ts` | New | `domain-service` | Pure `compare(base, head) → ArchitectureDiff`; owns change direction, layer-change composition, aggregate member grouping, association-change detection. | Medium |
+| `ArchitectureDiff` (+ nested change data structures, `ARCHITECTURE_PACKAGE_KIND`/`ArchitecturePackageKind` and `ARCHITECTURE_LAYER_NAME`/`ArchitectureLayerName` enumeration pairs) | `packages/riviere-architecture/published-language/src/published-language/architecture-diff.ts` | New | `published-language-schema`, `published-language-data-structure`, `published-language-enumeration`/`-enumeration-type` | Stable language-agnostic comparison contract (subdomain → layer → added/removed change sets); method-free. | Medium |
+| `ArchitectureDiffEnvelope` (+ `ArchitectureDiffEnvelopeMetadata`, `RevisionReference`, source-link and pull-request structures) | `packages/riviere-architecture/published-language/src/published-language/architecture-diff-envelope.ts` | New | `published-language-schema`, `published-language-data-structure` | The retained-file contract: both top-level keys, with the commit-time (`repository`, `baseRevision`, `headRevision`, `sourceLinks`, `diff`) vs PR-time (`pullRequest`) field split. | Small |
+| `parseArchitectureDiffEnvelope` | `packages/riviere-architecture/published-language/src/published-language/architecture-diff-envelope-parser.ts` | New | `published-language-parser` | Validates an unknown JSON value into an `ArchitectureDiffEnvelope`; commit-time fields required, `pullRequest` optional; browser-safe (no Node built-ins). | Small |
+| `CompareArchitecture` (+ `CompareArchitectureInput`) | `packages/riviere-architecture/use-cases/src/features/comparison/queries/compare-architecture.ts` | New | `query-model-use-case` (+ `query-model-use-case-input`) | Load base → load head → compare → return `ArchitectureDiffView`; no domain decisions. | Small |
+| `LoadArchitectureDiffEnvelope` (+ `LoadArchitectureDiffEnvelopeInput`) | `packages/riviere-architecture/use-cases/src/features/comparison/queries/load-architecture-diff-envelope.ts` | New | `query-model-use-case` (+ `query-model-use-case-input`) | Loads and validates the retained envelope file; returns `ArchitectureDiffEnvelopeView`. | Small |
+| `ArchitectureDiffView` | `packages/riviere-architecture/use-cases/src/features/comparison/queries/architecture-diff-view.ts` | New | `query-model` | App-facing read shape: validated `ArchitectureDiff` plus base and head `RevisionReference`s. | Small |
+| `ArchitectureDiffEnvelopeView` | `packages/riviere-architecture/use-cases/src/features/comparison/queries/architecture-diff-envelope-view.ts` | New | `query-model` | App-facing read shape wrapping the validated envelope. | Small |
+| `FineGrainedRoleGraphView` | `packages/riviere-architecture/use-cases/src/features/comparison/queries/fine-grained-role-graph-view.ts` | New | `query-model` | One loaded `ArchitectureGraph` plus its `RevisionReference`. | Small |
+| `FineGrainedRoleGraphLoader` (+ `ArchitectureGraphLoadError`) | `packages/riviere-architecture/use-cases/src/features/comparison/data-access/fine-grained-role-graph/` | New | `query-model-loader` (+ `data-access-error`) | Reads a retained graph file by required path, validates with `parseRiviereGraph`, invokes the domain factory `ArchitectureGraph.from`, attaches the `RevisionReference`. Contains no interpretation logic. | Small |
+| `ArchitectureDiffEnvelopeLoader` (+ `ArchitectureDiffEnvelopeLoadError`) | `packages/riviere-architecture/use-cases/src/features/comparison/data-access/architecture-diff-envelope/` | New | `query-model-loader` (+ `data-access-error`) | Reads `.riviere/pr-diffs/riviere-architecture-diff.json` (default) by path and validates it with `parseArchitectureDiffEnvelope`. | Small |
+| `createRecordArchitectureDiffCommand` + `RecordArchitectureDiffEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/record-architecture-diff/entrypoint.ts` | Changed | `cli-entrypoint` + `cli-entrypoint-dependencies` | Commit-hook command: receives exactly one dependencies interface (composition-root assembled) holding `compareArchitecture` and `writeArchitectureDiffEnvelope`; translates options into `CompareArchitectureInput` inline; executes the query; calls the writer through dependencies. | Small |
+| `writeArchitectureDiffEnvelope` | `apps/cli/src/features/architecture-diff/entrypoint/record-architecture-diff/write-architecture-diff-envelope.ts` | Changed | `cli-response-writer` | Serialises the `ArchitectureDiff` plus commit-time metadata into the envelope and writes the retained file; composes `sourceLinks` via `githubSourceLinkTemplate`. | Small |
+| `createRecordPullRequestMetadataCommand` + `RecordPullRequestMetadataEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/record-pull-request-metadata/entrypoint.ts` | Changed | `cli-entrypoint` + `cli-entrypoint-dependencies` | PR-time Action command: dependencies interface holding `loadArchitectureDiffEnvelope` and `writeArchitectureDiffEnvelopePullRequest`. | Small |
+| `writeArchitectureDiffEnvelopePullRequest` | `apps/cli/src/features/architecture-diff/entrypoint/record-pull-request-metadata/write-architecture-diff-envelope-pull-request.ts` | Changed | `cli-response-writer` | Merges `metadata.pullRequest` into the loaded envelope and rewrites the retained file. | Small |
+| `createFormatArchitectureDiffReviewCommand` + `FormatArchitectureDiffReviewEntrypointDependencies` | `apps/cli/src/features/architecture-diff/entrypoint/format-architecture-diff-review/entrypoint.ts` | Changed | `cli-entrypoint` + `cli-entrypoint-dependencies` | PR-time Action command: dependencies interface holding `loadArchitectureDiffEnvelope` and `formatArchitectureDiffReview`. | Small |
+| `formatArchitectureDiffReview` | `apps/cli/src/features/architecture-diff/entrypoint/format-architecture-diff-review/format-architecture-diff-review.ts` | Changed | `cli-output-formatter` | Formats the complete GitHub Markdown report from the loaded envelope; builds evidence links from `metadata.sourceLinks`. | Medium |
+| `githubSourceLinkTemplate` | `apps/cli/src/features/architecture-diff/entrypoint/_platform/cli/github-source-link-template.ts` | Changed | `cli-output-formatter` | Per-revision GitHub blob-link template; invoked inside `writeArchitectureDiffEnvelope` (not an entrypoint dependency — no `cli-entrypoint` calls it, and only `cli-entrypoint` forbids imported function calls). | Small |
+| `PrDiffReviewPage` | `apps/eclair/src/features/comparison/...` | Changed | open role decision (Éclair unassigned) | Presents the approved review page from the validated envelope; public resolution and upload processing owned by Éclair (see Open decisions). | Medium |
+
+##### .riviere role options
+
+| Component(s) | Kind | Chosen role | Alternative considered and why not |
+|---|---|---|---|
+| `ArchitectureGraph`, `ArchitectureElement`, `AggregateView` | class | `value-object` | Projection inside `FineGrainedRoleGraphLoader` — rejected: ARCH §2 assigns "Architectural interpretation" to the domain-model, and the `value-object` static-factory contract (`from*`) is the natural owner of parsing/normalisation (per the look-for-missing-value-objects memory). `aggregate` — rejected: comparison state has no lifecycle or invariant to protect. |
+| `ArchitectureComparison` | class | `domain-service` (with `@riviere-role-justification`) | Method on `ArchitectureGraph` — rejected: a change set spans two graphs; neither graph owns behaviour between revisions. |
+| `InvalidArchitectureGraphError` | class | `domain-error` | `data-access-error` — rejected: it reports an invalid domain value (custom-property normalisation failure), not a file-access failure. |
+| `ArchitectureDiff`, `ArchitectureDiffEnvelope` + nested structures and enumeration pairs | interface / variable / type-alias | `published-language-schema` / `published-language-data-structure` / `published-language-enumeration` + `-enumeration-type` | Domain-model value objects — rejected: the contract crosses package boundaries to `apps/cli` and `apps/eclair`. |
+| `parseArchitectureDiffEnvelope` | function | `published-language-parser` | Validation inside a use-cases loader only — rejected: Éclair (browser) must validate envelopes without importing Node-dependent packages. |
+| `CompareArchitecture`, `LoadArchitectureDiffEnvelope` | class | `query-model-use-case` | `command-use-case` — rejected: the subdomain performs no writes; the retained file is application delivery. |
+| Query inputs, views | interface / class | `query-model-use-case-input`, `query-model` | — |
+| `FineGrainedRoleGraphLoader`, `ArchitectureDiffEnvelopeLoader` | class | `query-model-loader` | `aggregate-repository` — rejected: there is no aggregate to reconstruct or persist. Loader-owned interpretation — rejected: the projection is domain behaviour and lives in `ArchitectureGraph.from`; the enforcement config permits data-access to import own-subdomain value objects, so the loader invokes the factory without containing interpretation logic. |
+| `ArchitectureGraphLoadError`, `ArchitectureDiffEnvelopeLoadError` | class | `data-access-error` | `domain-error` — rejected: load failures are not domain failures (ADR-002). |
+| `create*Command` functions | function | `cli-entrypoint` | Statically imported use case/writer calls — rejected: `cli-entrypoint` sets `forbiddenImportedFunctionCalls: true`; every callable arrives through the one dependencies interface. |
+| `RecordArchitectureDiffEntrypointDependencies`, `RecordPullRequestMetadataEntrypointDependencies`, `FormatArchitectureDiffReviewEntrypointDependencies` | interface | `cli-entrypoint-dependencies` | Separate dependency parameters — rejected: the role contract requires exactly one dependencies interface (name `.*EntrypointDependencies$`) assembled by the composition root. `githubSourceLinkTemplate` is deliberately not a member: no entrypoint calls it; it is invoked inside the writer. |
+| `writeArchitectureDiffEnvelope`, `writeArchitectureDiffEnvelopePullRequest` | function | `cli-response-writer` | Subdomain command use cases — rejected: ARCH §2 leaves how/when the diff is generated and committed to each application. |
+| `formatArchitectureDiffReview`, `githubSourceLinkTemplate` | function | `cli-output-formatter` | — |
+| `PrDiffReviewPage` | React component | open role decision | Éclair is explicitly unassigned in `.riviere/role-enforcement.config.ts`; no role may be invented for it. |
+
+##### Canonical role pattern
+
+Both CLI flows follow **CLI Invoking Query Model Use Case** from `.riviere/canonical-role-configurations.md`: each `cli-entrypoint` receives exactly one `*EntrypointDependencies` interface assembled by the composition root (the `createComponentsCommand`/`CreateComponentsCommandEntrypointDependencies` precedent), translates options into the `query-model-use-case-input` inline (no factory on the query path), executes the `query-model-use-case` through dependencies, and passes the returned `query-model` to the `cli-response-writer` / `cli-output-formatter`, also through dependencies. There is no command use case and no save step inside the subdomain; the app-level writer step matches the existing `finalize` → `writeFinalizedGraph` precedent in `apps/cli`. `githubSourceLinkTemplate` is invoked inside the writer because only the `cli-entrypoint` role forbids imported function calls. Éclair follows its own unassigned configuration (Dependency Cruiser rules remain active).
+
+##### Tangled responsibility findings
+
+- The existing POC query `GeneratePullRequestArchitectureDiff` (`living-documentation`) tangles comparison with delivery: it receives an `outputPath` and the app formats and writes the diff. This design splits them — the comparison query is delivery-free, and both envelope writes are named single-purpose app writers.
+- Formatting the GitHub report from a live in-memory comparison (the tangle the review caught) would duplicate the diff pipeline at PR time and break the retained-file convention. Resolution: `formatArchitectureDiffReview` accepts only an `ArchitectureDiffEnvelopeView` loaded from the file.
+- Projection buried in a data-access loader (an earlier draft of this option described it as loader-internal prose): resolved — the interpretation rules are `ArchitectureGraph.from(riviereGraph)` in the domain-model, exactly where ARCH §2 places "Architectural interpretation"; `FineGrainedRoleGraphLoader` reads, validates, invokes the factory, and attaches the revision.
+
+No further tangled responsibilities identified.
+
+##### State loading and persistence
+
+**Loaded state 1 — base graph:** `FineGrainedRoleGraphLoader.load(graphPath: string, revision: RevisionReference): FineGrainedRoleGraphView` (role `query-model-loader`, `riviere-architecture/use-cases` data-access — ARCH §2 assigns use-cases "loading its inputs"). Inputs: `graphPath` ← **required** CLI option `--base-graph` with **no default** — this design invents no retained-graph path convention; how the hook materialises the base graph (retained output path, worktree, checkout) is deferred to the approved first delivery ticket (ARCH §1). `revision` ← CLI options `--repository` + `--base-commit`; the commit-hook script resolves the commit with `git rev-parse main` and the CLI runs no git subprocess. Exact internals: `existsSync`/`readFileSync` → `parseRiviereGraph` (missing file or schema-invalid JSON → `ArchitectureGraphLoadError`) → `ArchitectureGraph.from(riviereGraph)` — the architectural interpretation owned by the domain-model: it selects `Custom` components with `customTypeName === 'architecture-review-element'` (single named constant), resolves `aggregate-owns-entity` and `supports-primary-element` links, reads `architectureRole`, `packageKind`, `externalClient`, and `methods` custom properties (invalid values → `InvalidArchitectureGraphError`), and groups into subdomains/layers — the projection proven by the representation prototype → `FineGrainedRoleGraphView.from(graph, revision)`. Output: the `ArchitectureGraph` plus its `RevisionReference`. Element fields come from component `name`, `domain`, and custom properties; aggregate entities from `aggregate-owns-entity` link targets; source evidence from `metadata.sources[].repository`/`commit` plus each component's `sourceLocation`.
+
+**Loaded state 2 — head graph:** the same loader call with `--head-graph` and `--head-commit` (the hook resolves it with `git rev-parse HEAD`); identical internals and output shape.
+
+**Loaded state 3 — retained envelope (PR-time and review reads):** `ArchitectureDiffEnvelopeLoader.load(envelopePathOption: string | undefined): ArchitectureDiffEnvelopeView`. `envelopePathOption` ← CLI option `--envelope`, default `.riviere/pr-diffs/riviere-architecture-diff.json` (the approved convention; the `DEFAULT_GRAPH_PATH` precedent). Internals: `readFileSync` → `parseArchitectureDiffEnvelope` (throws `ArchitectureDiffEnvelopeLoadError`).
+
+**Persisted state 1 — commit-time envelope write:** `writeArchitectureDiffEnvelope(view: ArchitectureDiffView, outputPath: string): void` (`apps/cli`, `cli-response-writer`), invoked by the entrypoint through `RecordArchitectureDiffEntrypointDependencies`. `outputPath` ← CLI option `--output`, default `.riviere/pr-diffs/riviere-architecture-diff.json`. Field origins: `diff` ← `view.diff`; `metadata.repository` and `metadata.baseRevision`/`headRevision` ← the view's revision references (hook-resolved options); `metadata.sourceLinks` ← `githubSourceLinkTemplate(repository, commit)` per revision (imported by the writer from `_platform/cli`). Writes the file with `writeFileSync` + `JSON.stringify`; the Action/commit hook then commits it to the branch (workflow mechanics, not CLI code). Output is validated by `parseArchitectureDiffEnvelope` on every read.
+
+**Persisted state 2 — PR-time metadata write:** `writeArchitectureDiffEnvelopePullRequest(view: ArchitectureDiffEnvelopeView, pullRequest: { number; title; description; url }, outputPath: string): void`, invoked through `RecordPullRequestMetadataEntrypointDependencies`. Fields come from the Action environment (`github.event.pull_request.*`) via CLI options; `outputPath` is the loaded envelope path, so the writer merges into `metadata` by spread, leaves `diff` untouched, and rewrites the same file.
+
+##### Runtime call outline
+
+```text
+createRecordArchitectureDiffCommand(dependencies)                 // commit hook — apps/cli
+  ├─ dependencies.compareArchitecture.execute(input)              // input translated inline from options
+  │  ├─ fineGrainedRoleGraphLoader.load(baseGraphPath, baseRevision)
+  │  │  ├─ readFileSync(baseGraphPath)                            // retained fine-grained-role-graph, required option
+  │  │  ├─ parseRiviereGraph(json)                                // riviere-schema parser
+  │  │  ├─ ArchitectureGraph.from(riviereGraph)                   // domain-model interpretation (ARCH §2)
+  │  │  │  ├─ ArchitectureElement.fromReviewElementComponent(component, relatedTo, revision)
+  │  │  │  └─ AggregateView.fromAggregateComponent(component, ownedEntityNames, revision)
+  │  │  └─ FineGrainedRoleGraphView.from(graph, baseRevision)
+  │  ├─ fineGrainedRoleGraphLoader.load(headGraphPath, headRevision)
+  │  │  ├─ readFileSync(headGraphPath)
+  │  │  ├─ parseRiviereGraph(json)
+  │  │  ├─ ArchitectureGraph.from(riviereGraph)
+  │  │  │  ├─ ArchitectureElement.fromReviewElementComponent(component, relatedTo, revision)
+  │  │  │  └─ AggregateView.fromAggregateComponent(component, ownedEntityNames, revision)
+  │  │  └─ FineGrainedRoleGraphView.from(graph, headRevision)
+  │  ├─ architectureComparison.compare(base.graph, head.graph)    // domain-service → ArchitectureDiff
+  │  └─ ArchitectureDiffView.from(diff, base.revision, head.revision)
+  └─ dependencies.writeArchitectureDiffEnvelope(diffView, outputPath)
+     ├─ githubSourceLinkTemplate(repository, commit)              // per revision
+     └─ writeFileSync(outputPath)                                 // default .riviere/pr-diffs/riviere-architecture-diff.json
+createRecordPullRequestMetadataCommand(dependencies)              // PR-time Action — apps/cli
+  ├─ dependencies.loadArchitectureDiffEnvelope.execute({ envelopePathOption })
+  │  └─ architectureDiffEnvelopeLoader.load(envelopePathOption)
+  │     ├─ readFileSync(envelopePath)                             // retained envelope, default path
+  │     └─ parseArchitectureDiffEnvelope(json)                    // published-language-parser
+  └─ dependencies.writeArchitectureDiffEnvelopePullRequest(view, pullRequest, envelopePath)
+     └─ writeFileSync(envelopePath)
+createFormatArchitectureDiffReviewCommand(dependencies)           // PR-time Action — apps/cli
+  ├─ dependencies.loadArchitectureDiffEnvelope.execute({ envelopePathOption })
+  │  └─ architectureDiffEnvelopeLoader.load(envelopePathOption)
+  └─ dependencies.formatArchitectureDiffReview(view)              // cli-output-formatter → GitHub Markdown
+PrDiffReviewPage(route, upload)                                   // apps/eclair — Éclair-owned, open
+  ├─ fetch('api.github.com/repos/{owner}/{repository}/pulls/{id}')   // public mode — Éclair-owned
+  ├─ fetch(rawEnvelopeUrl pinned to head.sha)                        // public mode — Éclair-owned
+  └─ parseArchitectureDiffEnvelope(envelopeJson)                     // upload mode and public mode
+```
+
+##### Code stress test
+
+```typescript
+// --- domain-model: ArchitectureGraph.from owns the architectural interpretation ---
+// ARCH §2 assigns "Architectural interpretation and comparison rules" to this package.
+const ARCHITECTURE_REVIEW_ELEMENT_TYPE_NAME = 'architecture-review-element'
+const AGGREGATE_OWNS_ENTITY_RELATIONSHIP = 'aggregate-owns-entity'
+const SUPPORTS_PRIMARY_ELEMENT_RELATIONSHIP = 'supports-primary-element'
+const AGGREGATE_ARCHITECTURE_ROLE = 'aggregate'
+
+type LayerName = 'entrypoints' | 'use-cases' | 'domain'
+type ArchitectureMember = ArchitectureElement | AggregateView // discriminated by the `kind` member; matched exhaustively, never with `in`
+type SubdomainPackageKind = Exclude<ArchitecturePackageKind, 'application'>
+
+/** @riviere-role value-object */
+export class ArchitectureGraph {
+  declare private readonly brand: 'ArchitectureGraph'
+
+  private constructor(
+    readonly subdomains: ReadonlyMap<string, SubdomainLayers>,
+    readonly applicationElements: readonly ArchitectureElement[],
+  ) {}
+
+  static from(riviereGraph: RiviereGraph): ArchitectureGraph {
+    const revision = revisionSourceOf(riviereGraph) // metadata.sources → { repository, commit }
+    const reviewComponents = riviereGraph.components.filter(isArchitectureReviewElement)
+    const elements = reviewComponents.map((component) =>
+      ArchitectureElement.fromReviewElementComponent(
+        component,
+        supportedPrimaryNames(riviereGraph, component.id), // supports-primary-element link targets
+        revision,
+      ))
+    const aggregates = reviewComponents
+      .filter((component) => architectureRoleOf(component) === AGGREGATE_ARCHITECTURE_ROLE)
+      .map((component) =>
+        AggregateView.fromAggregateComponent(
+          component,
+          ownedEntityNames(riviereGraph, component.id),
+          revision,
+        ))
+    return new ArchitectureGraph(
+      groupIntoSubdomains(elements, aggregates), // subdomain ← element.domain; canonical sorted ordering
+      elements.filter((element) => element.packageKind === 'application'),
+    )
+  }
+}
+
+// Element selection: schema-validated component union narrowed by type, no `in` operator.
+function isArchitectureReviewElement(component: Component): component is CustomComponent {
+  return component.type === 'Custom'
+    && component.customTypeName === ARCHITECTURE_REVIEW_ELEMENT_TYPE_NAME
+}
+
+// aggregate-owns-entity resolution: aggregate source → owned entity target names.
+function ownedEntityNames(riviereGraph: RiviereGraph, aggregateId: string): readonly string[] {
+  return riviereGraph.links
+    .filter((link) =>
+      link.source === aggregateId
+      && link.relationshipType === AGGREGATE_OWNS_ENTITY_RELATIONSHIP)
+    .map((link) => componentName(riviereGraph, link.target))
+}
+
+// Subdomain/layer grouping rule (PRD lines 60–63): layer ← packageKind, exhaustive match;
+// 'application' elements never enter a subdomain (they stay under their application owner).
+function subdomainLayerOf(packageKind: SubdomainPackageKind): LayerName {
+  switch (packageKind) {
+    case 'use-cases': return 'use-cases'
+    case 'entrypoints': return 'entrypoints'
+    case 'domain-model': return 'domain'
+    case 'published-language': return 'domain'
+  }
+}
+
+// ArchitectureElement.fromReviewElementComponent normalises name, domain, architectureRole,
+// packageKind (validated into the closed ARCHITECTURE_PACKAGE_KIND union), externalClient,
+// methods, and combines component.sourceLocation with the revision into source evidence;
+// AggregateView.fromAggregateComponent normalises the same fields plus the resolved
+// owned-entity names. Both are private-constructor value objects; invalid custom-property
+// values throw InvalidArchitectureGraphError (domain-error).
+```
+
+```typescript
+// --- use-cases: load → invoke → return. No save step exists in the subdomain ---
+/** @riviere-role query-model-use-case */
+export class CompareArchitecture {
+  constructor(
+    private readonly graphs: FineGrainedRoleGraphLoader,
+    private readonly comparison: ArchitectureComparison,
+  ) {}
+
+  execute(input: CompareArchitectureInput): ArchitectureDiffView {
+    const base = this.graphs.load(input.baseGraphPath, input.baseRevision)
+    const head = this.graphs.load(input.headGraphPath, input.headRevision)
+    return ArchitectureDiffView.from(
+      this.comparison.compare(base.graph, head.graph),
+      base.revision,
+      head.revision,
+    )
+  }
+}
+
+/** @riviere-role query-model-use-case-input */
+export interface CompareArchitectureInput {
+  readonly baseGraphPath: string          // required --base-graph option, no default
+  readonly headGraphPath: string          // required --head-graph option, no default
+  readonly baseRevision: RevisionReference // --repository + --base-commit (hook: git rev-parse main)
+  readonly headRevision: RevisionReference // --repository + --head-commit (hook: git rev-parse HEAD)
+}
+
+/** @riviere-role query-model-loader */
+export class FineGrainedRoleGraphLoader {
+  load(graphPath: string, revision: RevisionReference): FineGrainedRoleGraphView {
+    const riviereGraph = readValidatedGraph(graphPath)
+    return FineGrainedRoleGraphView.from(ArchitectureGraph.from(riviereGraph), revision)
+  }
+}
+
+function readValidatedGraph(graphPath: string): RiviereGraph {
+  if (!existsSync(graphPath)) throw new ArchitectureGraphLoadError(graphPath)
+  const parsed = parseRiviereGraph(JSON.parse(readFileSync(graphPath, 'utf8')))
+  if (!parsed.success) throw new ArchitectureGraphLoadError(graphPath, parsed.issues)
+  return parsed.graph
+}
+
+/** @riviere-role query-model-loader */
+export class ArchitectureDiffEnvelopeLoader {
+  load(envelopePathOption: string | undefined): ArchitectureDiffEnvelopeView {
+    const path = envelopePathOption ?? '.riviere/pr-diffs/riviere-architecture-diff.json'
+    const parsed = parseArchitectureDiffEnvelope(JSON.parse(readFileSync(path, 'utf8')))
+    if (!parsed.success) throw new ArchitectureDiffEnvelopeLoadError(path)
+    return ArchitectureDiffEnvelopeView.from(parsed.value)
+  }
+}
+```
+
+```typescript
+// --- domain-model: ArchitectureComparison (domain-service) owns every comparison rule ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification A change set spans two whole ArchitectureGraph
+ *  states; no single graph, element, or aggregate view owns behaviour between
+ *  two revisions, and no aggregate exists to hold it. */
+export class ArchitectureComparison {
+  compare(base: ArchitectureGraph, head: ArchitectureGraph): ArchitectureDiff {
+    return buildDiff(base.subdomains, head.subdomains)
+  }
+}
+
+// Layer-change composition: one added/removed change-set pair per layer for both sides.
+function composite(
+  base: Layers | undefined,
+  head: Layers | undefined,
+): Record<LayerName, ArchitectureLayerChange>
+
+function subdomainChange(
+  base: SubdomainArchitecture | undefined,
+  head: SubdomainArchitecture | undefined,
+): 'added' | 'changed' | 'removed'
+
+function hasChanges(layers: Record<LayerName, ArchitectureLayerChange>): boolean
+function emptyLayers(): Layers
+function sourceEvidence(element: ArchitectureElement): ArchitectureSourceEvidence
+
+function buildDiff(base: SubdomainMap, head: SubdomainMap): ArchitectureDiff {
+  const names = new Set([...base.keys(), ...head.keys()])
+  return { subdomains: [...names].sort().flatMap((name) => {
+    const b = base.get(name); const h = head.get(name)
+    const layers = composite(b?.layers ?? emptyLayers(), h?.layers ?? emptyLayers())
+    return hasChanges(layers) ? [{ name, change: subdomainChange(b, h), layers }] : []
+  }) }
+}
+
+// Association rule (PRD §4, lines 62–63): base/head application elements matched by
+// (packageKind, role, name) that moved subdomain emit ONE association change carrying
+// BOTH revisions' evidence — never a create + delete pair.
+function associateApplicationElements(
+  base: readonly ArchitectureElement[],
+  head: readonly ArchitectureElement[],
+): ArchitectureAssociationChange[] {
+  const headByKey = new Map(head.map((element) => [element.key(), element]))
+  return base.flatMap((baseElement) => {
+    const headElement = headByKey.get(baseElement.key())
+    return headElement !== undefined && headElement.subdomain !== baseElement.subdomain
+      ? [{ from: sourceEvidence(baseElement), to: sourceEvidence(headElement) }]
+      : []
+  })
+}
+```
+
+```typescript
+// --- apps/cli: the entrypoint receives exactly one dependencies interface ---
+/** @riviere-role cli-entrypoint-dependencies */
+export interface RecordArchitectureDiffEntrypointDependencies {
+  readonly compareArchitecture: CompareArchitecture
+  readonly writeArchitectureDiffEnvelope: typeof writeArchitectureDiffEnvelope
+}
+
+/** @riviere-role cli-entrypoint */
+export function createRecordArchitectureDiffCommand(
+  dependencies: RecordArchitectureDiffEntrypointDependencies,
+): Command {
+  return new Command('record-architecture-diff')
+    .description('Record the architecture diff envelope for the commit hook')
+    .requiredOption('--base-graph <path>', 'Retained base fine-grained-role-graph path')
+    .requiredOption('--head-graph <path>', 'Retained head fine-grained-role-graph path')
+    .requiredOption('--repository <name>', 'Repository owner/name')
+    .requiredOption('--base-commit <sha>', 'Base revision (hook: git rev-parse main)')
+    .requiredOption('--head-commit <sha>', 'Head revision (hook: git rev-parse HEAD)')
+    .option('--output <path>', 'Envelope output path', '.riviere/pr-diffs/riviere-architecture-diff.json')
+    .action((options) => {
+      const diffView = dependencies.compareArchitecture.execute({
+        baseGraphPath: options.baseGraph,
+        headGraphPath: options.headGraph,
+        baseRevision: { repository: options.repository, commit: options.baseCommit },
+        headRevision: { repository: options.repository, commit: options.headCommit },
+      })
+      dependencies.writeArchitectureDiffEnvelope(diffView, options.output)
+    })
+}
+
+/** @riviere-role cli-response-writer */
+export function writeArchitectureDiffEnvelope(
+  view: ArchitectureDiffView, // query model returned by CompareArchitecture
+  outputPath: string,
+): void {
+  const envelope = { // structural match of ArchitectureDiffEnvelope; parser-gated on every read
+    metadata: {
+      repository: view.baseRevision.repository,
+      baseRevision: view.baseRevision,
+      headRevision: view.headRevision,
+      sourceLinks: {
+        base: githubSourceLinkTemplate(view.baseRevision.repository, view.baseRevision.commit),
+        head: githubSourceLinkTemplate(view.headRevision.repository, view.headRevision.commit),
+      },
+    },
+    diff: view.diff,
+  }
+  writeFileSync(outputPath, JSON.stringify(envelope, null, 2), 'utf8')
+}
+
+/** @riviere-role cli-response-writer */
+export function writeArchitectureDiffEnvelopePullRequest(
+  view: ArchitectureDiffEnvelopeView, // query model returned by LoadArchitectureDiffEnvelope
+  pullRequest: { number: number; title: string; description: string; url: string },
+  outputPath: string,
+): void {
+  writeFileSync(outputPath, JSON.stringify({
+    metadata: { ...view.envelope.metadata, pullRequest },
+    diff: view.envelope.diff,
+  }, null, 2), 'utf8')
+}
+```
+
+```typescript
+// --- published-language: the retained-file contract with the approved field split ---
+/** @riviere-role published-language-schema */
+export interface ArchitectureDiffEnvelope {
+  readonly metadata: ArchitectureDiffEnvelopeMetadata
+  readonly diff: ArchitectureDiff
+}
+
+/** @riviere-role published-language-data-structure */
+export interface ArchitectureDiffEnvelopeMetadata {
+  readonly repository: string                          // commit hook
+  readonly baseRevision: RevisionReference             // commit hook
+  readonly headRevision: RevisionReference             // commit hook
+  readonly sourceLinks: { base: string; head: string } // commit hook — per-revision blob-link templates
+  readonly pullRequest?: {                             // PR-time Action only
+    readonly number: number; readonly title: string
+    readonly description: string; readonly url: string
+  }
+}
+
+/** @riviere-role published-language-data-structure */
+export interface RevisionReference { readonly repository: string; readonly commit: string }
+
+/** @riviere-role published-language-parser */
+export function parseArchitectureDiffEnvelope(
+  value: unknown,
+): { success: true; value: ArchitectureDiffEnvelope } | { success: false; error: string }
+```
+
+The remaining grouping rule — an aggregate present on both sides is named once as affected while its added/removed members are distinguished (PRD line 70) — follows the same shape: `subdomainChange` derives the direction from presence, and the layer change sets group members by `AggregateView.key()`.
+
+##### New dependencies
+
+| Dependency | Status | Used by | Purpose |
+|---|---|---|---|
+| `@living-architecture/riviere-schema-published-language` | Existing | domain-model, use-cases | `RiviereGraph`/`Component`/`CustomComponent` types for the projection; `parseRiviereGraph` for input validation. |
+| `@living-architecture/riviere-architecture-published-language` | New | domain-model, use-cases, apps/eclair | `ArchitectureDiff`, envelope contract, kind/layer enumerations, and `parseArchitectureDiffEnvelope`. |
+| `@living-architecture/riviere-architecture-domain-model` | New | use-cases | Graph projection value objects and `ArchitectureComparison`. |
+| `@living-architecture/riviere-architecture-use-cases` | New | apps/cli | The compare and envelope-loading queries. |
+
+Enforced app packages (`apps/cli`) import only subdomain queries — the app import rule allows `anySubdomain: ['commands','queries','external-clients']` and forbids published-language, which is why the writers and formatter take query models and primitives. `apps/eclair` is explicitly unassigned; it imports `parseArchitectureDiffEnvelope` from the published-language package directly, mirroring its existing direct imports of `riviere-schema-published-language`. The published-language package must therefore stay browser-safe (schemas and parser only, no Node built-ins). The domain-model imports only schema **types** (plus nothing else); `parseRiviereGraph` is invoked by the use-cases loader, keeping file I/O out of the domain.
+
+##### Code shape
+
+```text
+packages/riviere-architecture/                    (new subdomain packages)
+  domain-model/src/domain/
+    architecture-graph.ts                         ArchitectureGraph.from + selection/link/grouping helpers
+    architecture-element.ts                       ArchitectureElement
+    aggregate-view.ts                             AggregateView
+    invalid-architecture-graph-error.ts           InvalidArchitectureGraphError
+    architecture-comparison.ts                    ArchitectureComparison + helpers
+  published-language/src/published-language/
+    architecture-diff.ts                          ArchitectureDiff + change structures + kind/layer enumerations
+    architecture-diff-envelope.ts                 envelope + metadata + RevisionReference
+    architecture-diff-envelope-parser.ts          parseArchitectureDiffEnvelope
+  use-cases/src/features/comparison/
+    queries/
+      compare-architecture.ts + compare-architecture-input.ts
+      load-architecture-diff-envelope.ts + load-architecture-diff-envelope-input.ts
+      architecture-diff-view.ts                   ArchitectureDiffView
+      architecture-diff-envelope-view.ts          ArchitectureDiffEnvelopeView
+      fine-grained-role-graph-view.ts             FineGrainedRoleGraphView
+    data-access/fine-grained-role-graph/
+      fine-grained-role-graph-loader.ts           + architecture-graph-load-error.ts
+    data-access/architecture-diff-envelope/
+      architecture-diff-envelope-loader.ts        + architecture-diff-envelope-load-error.ts
+apps/cli/src/features/architecture-diff/entrypoint/
+  record-architecture-diff/
+    entrypoint.ts                                 createRecordArchitectureDiffCommand + RecordArchitectureDiffEntrypointDependencies
+    write-architecture-diff-envelope.ts           writeArchitectureDiffEnvelope
+  record-pull-request-metadata/
+    entrypoint.ts                                 createRecordPullRequestMetadataCommand + RecordPullRequestMetadataEntrypointDependencies
+    write-architecture-diff-envelope-pull-request.ts
+  format-architecture-diff-review/
+    entrypoint.ts                                 createFormatArchitectureDiffReviewCommand + FormatArchitectureDiffReviewEntrypointDependencies
+    format-architecture-diff-review.ts            formatArchitectureDiffReview
+  _platform/cli/
+    github-source-link-template.ts                githubSourceLinkTemplate
+.github/workflows/pr-architecture-review.yml      (rewritten to run the PR-time commands)
+apps/eclair/src/features/comparison/...           (PrDiffReviewPage — Éclair-owned)
+```
+
+##### Design validation
+
+- Domain terminology: **pass** — uses Rivière terms (`Component`, `Link`, `Domain`, `fine-grained-role-graph`, `ArchitectureDiff`); proposes `ArchitectureComparison`, `ArchitectureGraph`, `ArchitectureDiffEnvelope`, and `RevisionReference` as named new contract concepts rather than pretending they exist.
+- Application/domain separation: **pass** — queries do load → invoke → return only; the architectural interpretation is `ArchitectureGraph.from` in the domain-model (ARCH §2) and the loaders contain no interpretation logic; both file writes are named app writers following the `finalize`/`writeFinalizedGraph` precedent; every comparison rule lives in `ArchitectureComparison`.
+- Role and location fit: **pass** — every `riviere-architecture` and `apps/cli` element maps to a real role and allowed sublocation (data-access may import own-subdomain value objects per the enforcement config, so the loader invoking the domain factory is legal); each `cli-entrypoint` receives exactly one `*EntrypointDependencies` interface (composition-root assembled, no imported function calls); `PrDiffReviewPage` is the only open role decision because Éclair is explicitly unassigned; the `domain-service` carries a `@riviere-role-justification`.
+- Implementability: **pass** — import rules hold (apps/cli → queries only; use-cases → own domain + any published-language; domain-model → published-language types; published-language imports no workspace package); base/head graph paths are required options so the load contract is total; envelope writes are structural at the app layer and parser-gated on every read; no `in`-operator use, exhaustive union matching, and no consumer-shaped method names on domain objects.
+
+##### Open decisions
+
+- `PrDiffReviewPage` is an open role decision because `apps/eclair` is explicitly unassigned in `.riviere/role-enforcement.config.ts`. Éclair's own architecture owns the approved public resolution steps (GitHub API pull request metadata → raw file URL pinned to the returned head SHA → load and validate) and the browser upload processing, consuming the envelope through `parseArchitectureDiffEnvelope`. Only the page's existence, its envelope-validation boundary, and its presentation responsibility are fixed here; its internal decomposition is deferred to Éclair's approved configuration.
+- If `architecture-comparison.ts` approaches the 400-line limit as more layer rules land, the growth is a modelling signal about a missing domain concept, not a file-splitting decision. The role-valid responses are: identify missing value objects that own part of the composition (for example a `LayerChanges` value object owning per-layer added/removed composition, which removes the layer logic from the service), or — only if several capabilities genuinely need one stable interface — propose a `domain-facade` coordinator, which requires explicit user approval and an `approvedInstances` entry. Splitting into layer-scoped domain services is role-invalid because a `domain-service` may not depend on another `domain-service`. No decomposition is proposed now.
+- Whether `ArchitectureGraph` should later expose a public query interface for direct Éclair exploration of the `fine-grained-role-graph` (PRD §4 line 51) is out of scope; the projection is comparison-only for now.
+
+##### Rejected alternative sub-ideas
+
+- **An `ArchitectureDiff` aggregate with an `ArchitectureDiffRepository`:** rejected — a diff has no lifecycle, invariant, or persistence need; an aggregate would invent state and a save step the product does not have.
+- **The graph-to-architecture projection inside `FineGrainedRoleGraphLoader` (use-cases data-access):** rejected — ARCH §2 assigns "Architectural interpretation and comparison rules" to `packages/riviere-architecture/domain-model`; element selection, ownership-link resolution, and subdomain/layer grouping are domain behaviour, and the `value-object` static-factory contract makes `ArchitectureGraph.from(riviereGraph)` (with `ArchitectureElement`/`AggregateView` owning their field normalisation) the natural owner. The loader reads, validates, invokes the factory, and attaches the revision.
+- **Envelope-writing command use cases in `riviere-architecture`:** rejected — ARCH §2 leaves how and when the diff is generated and committed to each application; write behaviour stays behind named app writers (`cli-response-writer`), keeping the subdomain query-only.
+- **Enforced apps importing `riviere-architecture-published-language` directly:** rejected — the app import rule forbids it, so `apps/cli` receives everything through query-model outputs and primitives. Éclair is the explicit, already-established exception as an unassigned browser app, not an instance of this rejected alternative.
+- **Comparison rules in the use case (loops/conditionals over change sets):** rejected — the transaction-script anti-pattern and the exact failure in `rejected-workflow-use-case-dumping-case-study.md`; grouping and direction belong in the domain service.
+- **A `domain-facade` wrapper around comparison:** rejected — `domain-facade` is for several related capabilities with a common consumer; the comparison is one capability, so the query use case talks to the domain service directly.
+<!-- component-design-option-2:end -->

--- a/docs/project/PRD/pull-request-diffs/component-design-option-3.md
+++ b/docs/project/PRD/pull-request-diffs/component-design-option-3.md
@@ -1,0 +1,1174 @@
+<!-- component-design-option-3:start -->
+#### Option 3: Fine-grained comparison decomposition
+
+This option decomposes the comparison into small, single-responsibility domain components: four `domain-service` comparisons that each span two revision snapshots (subdomain grouping, entrypoint layer, use-case layer, domain layer), three value objects that own behaviour over state a single object does hold (`ArchitectureSource` projection, `ArchitectureElementCollection` element diffing and evidence resolution, `AssociationMove` dual-evidence pairing), and one `domain-facade` composing them. It designs **both approved phases**: the **commit-hook command** compares two retained `fine-grained-role-graph` revisions, composes the commit-time metadata, and writes the tracked `{ metadata, diff }` envelope to `.riviere/pr-diffs/riviere-architecture-diff.json`; the **PR-time Action command** loads that tracked envelope, adds only `metadata.pullRequest.*`, writes the merged envelope back, and formats the GitHub report from the loaded JSON without recalculating the diff. Both commands follow the codebase's established query pattern exactly: the **query-model** consumes the facade, the **query-model-loader** owns file read + JSON parse, and the **query-model-use-case** only delegates and maps load failures. There is **no aggregate and no repository**: comparison and publication are read-only computations over already-persisted files, no method mutates state, and every rule stays in `domain-model`. Application-owned elements never enter subdomain layers; their association changes are paired into one recorded move with dual base/head evidence; an aggregate changed on both sides is published with machine-distinguishable `status: 'affected'`, never as created-plus-deleted.
+
+##### Domain model change
+
+No new aggregate. Comparison and publication mutate nothing and own no lifecycle invariant, so an `ArchitectureDiffAggregate` + repository would be a forced fit. The proof-of-concept's monolithic `Architecture` value object is replaced by: one per-revision facts value object, one element-collection value object that is the single shared home of element diffing and evidence resolution, one association-move value object, four justified cross-snapshot comparison services, and one facade. Published-contract changes this correction adds: `AggregateDiff.status` (`created` / `affected` / `removed`) so an aggregate affected on both sides is machine-distinguishable from a newly created one (the PRD summary rule), domain layer diffs carry a named `affectedAggregates` list, and element relationships are published as the POC-modelled `ArchitectureRelationship` collection (`relatedTo`) with `associatedSubdomains` rather than a single optional string. `ArchitectureElementCollection` and `AssociationMove` are proposed terms — there is no existing domain vocabulary for "one layer's element list at one revision" or for the PRD's "application association change" as a first-class concept.
+
+```mermaid
+flowchart LR
+  architectureSource["ArchitectureSource<br/>(per revision facts)"]
+  elementCollection["ArchitectureElementCollection<br/>(layer element list)"]
+  associationMove["AssociationMove<br/>(changed association)"]
+  architectureComparison["ArchitectureComparison"]
+  groupSubdomainDiff["groupSubdomainDiff"]
+  compareEntrypointLayer["compareEntrypointLayer"]
+  compareUseCaseLayer["compareUseCaseLayer"]
+  compareDomainLayer["compareDomainLayer"]
+  aggregateDiff["AggregateDiff<br/>(status created affected removed)"]
+  architectureDiff["ArchitectureDiff<br/>(compared facts)"]
+
+  architectureComparison -->|"compares two"| architectureSource
+  architectureSource -->|"contains per layer"| elementCollection
+  elementCollection -->|"pairs both sides into"| associationMove
+  architectureComparison -->|"pairs subdomains through"| groupSubdomainDiff
+  groupSubdomainDiff -->|"labels presence of"| architectureSource
+  architectureComparison -->|"compares entrypoint layer through"| compareEntrypointLayer
+  compareEntrypointLayer -->|"diffs element lists through"| elementCollection
+  architectureComparison -->|"compares use case layer through"| compareUseCaseLayer
+  compareUseCaseLayer -->|"diffs element lists through"| elementCollection
+  architectureComparison -->|"compares domain layer through"| compareDomainLayer
+  compareDomainLayer -->|"diffs element lists through"| elementCollection
+  compareDomainLayer -->|"labels each aggregate"| aggregateDiff
+  architectureComparison -->|"diffs application associations through"| elementCollection
+  associationMove -->|"carries dual evidence into"| architectureDiff
+  aggregateDiff -->|"fills affectedAggregates of"| architectureDiff
+  architectureComparison -->|"exposes result as"| architectureDiff
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+  class architectureSource statusNew
+  class elementCollection statusNew
+  class associationMove statusNew
+  class architectureComparison statusOpen
+  class groupSubdomainDiff statusNew
+  class compareEntrypointLayer statusNew
+  class compareUseCaseLayer statusNew
+  class compareDomainLayer statusNew
+  class aggregateDiff statusNew
+  class architectureDiff statusNew
+```
+
+Legend: gray = existing, yellow = changed, green = new, red = unclear/open decision. All concepts are new to the `riviere-architecture` subdomain, though `ArchitectureSource`, `ArchitectureDiff`, and the relationship vocabulary carry over the comparison-facts vocabulary validated in the `living-documentation` proof of concept. `ArchitectureComparison` is red because the new `domain-facade` instance awaits user approval (see Open decisions).
+
+##### Runtime call diagram
+
+```mermaid
+flowchart LR
+  generateEntrypoint["createGeneratePrArchitectureDiffCommand<br/>(apps/cli feature entrypoint)"]
+  compareUseCase["CompareArchitectures<br/>(use-cases queries)"]
+  graphLoader["ArchitectureDiffLoader<br/>(use-cases data-access)"]
+  diffResult["ArchitectureDiffResult<br/>(use-cases queries)"]
+  failureMapper["toArchitectureGraphLoadFailure<br/>(use-cases queries)"]
+  facade["ArchitectureComparison<br/>(domain-model)"]
+  architectureSource["ArchitectureSource<br/>(domain-model)"]
+  groupSubdomainDiff["groupSubdomainDiff<br/>(domain-model)"]
+  compareEntrypointLayer["compareEntrypointLayer<br/>(domain-model)"]
+  compareUseCaseLayer["compareUseCaseLayer<br/>(domain-model)"]
+  compareDomainLayer["compareDomainLayer<br/>(domain-model)"]
+  elementCollection["ArchitectureElementCollection<br/>(domain-model)"]
+  associationMove["AssociationMove<br/>(domain-model)"]
+  commitComposer["composeCommitArchitectureDiffEnvelope<br/>(apps/cli feature entrypoint)"]
+  envelopeWriter["writeArchitectureDiffEnvelope<br/>(apps/cli feature entrypoint)"]
+  loadFailureFormatter["formatArchitectureGraphLoadFailure<br/>(apps/cli feature entrypoint)"]
+  publishEntrypoint["createPublishPrArchitectureDiffCommand<br/>(apps/cli feature entrypoint)"]
+  envelopeUseCase["LoadArchitectureDiffEnvelope<br/>(use-cases queries)"]
+  envelopeLoader["ArchitectureDiffEnvelopeLoader<br/>(use-cases data-access)"]
+  diffParser["parseArchitectureDiff<br/>(riviere-architecture published-language)"]
+  envelopeFailureMapper["toArchitectureDiffEnvelopeLoadFailure<br/>(use-cases queries)"]
+  envelopeFailureFormatter["formatArchitectureDiffEnvelopeLoadFailure<br/>(apps/cli feature entrypoint)"]
+  prMetadataFormatter["withPullRequestMetadata<br/>(apps/cli feature entrypoint)"]
+  envelopeWriteBack["writePublishedArchitectureDiffEnvelope<br/>(apps/cli feature entrypoint)"]
+  reportFormatter["formatArchitectureDiffReport<br/>(apps/cli feature entrypoint)"]
+  reportWriter["writeArchitectureDiffReport<br/>(apps/cli feature entrypoint)"]
+
+  generateEntrypoint -->|execute| compareUseCase
+  compareUseCase -->|load| graphLoader
+  compareUseCase -->|toArchitectureGraphLoadFailure| failureMapper
+  graphLoader -->|parse| diffResult
+  diffResult -->|fromRevisions| facade
+  diffResult -->|compare| facade
+  facade -->|fromGraph| architectureSource
+  facade -->|applicationElements| architectureSource
+  facade -->|groupSubdomainDiff| groupSubdomainDiff
+  groupSubdomainDiff -->|subdomainNames, subdomain| architectureSource
+  facade -->|compareEntrypointLayer| compareEntrypointLayer
+  compareEntrypointLayer -->|fromStates, addedIn, removedIn| elementCollection
+  facade -->|compareUseCaseLayer| compareUseCaseLayer
+  compareUseCaseLayer -->|fromStates, addedIn, removedIn| elementCollection
+  facade -->|compareDomainLayer| compareDomainLayer
+  compareDomainLayer -->|fromStates, addedIn, removedIn| elementCollection
+  facade -->|applicationAssociationChanges| elementCollection
+  elementCollection -->|fromStates| associationMove
+  generateEntrypoint -->|formatArchitectureGraphLoadFailure| loadFailureFormatter
+  generateEntrypoint -->|composeCommitArchitectureDiffEnvelope| commitComposer
+  generateEntrypoint -->|writeArchitectureDiffEnvelope| envelopeWriter
+  publishEntrypoint -->|execute| envelopeUseCase
+  envelopeUseCase -->|load| envelopeLoader
+  envelopeUseCase -->|toArchitectureDiffEnvelopeLoadFailure| envelopeFailureMapper
+  envelopeLoader -->|parseArchitectureDiff| diffParser
+  publishEntrypoint -->|formatArchitectureDiffEnvelopeLoadFailure| envelopeFailureFormatter
+  publishEntrypoint -->|withPullRequestMetadata| prMetadataFormatter
+  publishEntrypoint -->|writePublishedArchitectureDiffEnvelope| envelopeWriteBack
+  publishEntrypoint -->|formatArchitectureDiffReport| reportFormatter
+  publishEntrypoint -->|writeArchitectureDiffReport| reportWriter
+
+  classDef statusExisting fill:#e5e7eb,stroke:#374151,color:#111827
+  classDef statusChanged fill:#fef3c7,stroke:#92400e,color:#111827
+  classDef statusNew fill:#dcfce7,stroke:#166534,color:#111827
+  classDef statusOpen fill:#fee2e2,stroke:#991b1b,color:#111827
+
+  class generateEntrypoint statusNew
+  class compareUseCase statusNew
+  class graphLoader statusNew
+  class diffResult statusNew
+  class failureMapper statusNew
+  class facade statusOpen
+  class architectureSource statusNew
+  class groupSubdomainDiff statusNew
+  class compareEntrypointLayer statusNew
+  class compareUseCaseLayer statusNew
+  class compareDomainLayer statusNew
+  class elementCollection statusNew
+  class associationMove statusNew
+  class commitComposer statusNew
+  class envelopeWriter statusNew
+  class loadFailureFormatter statusNew
+  class publishEntrypoint statusNew
+  class envelopeUseCase statusNew
+  class envelopeLoader statusNew
+  class diffParser statusNew
+  class envelopeFailureMapper statusNew
+  class envelopeFailureFormatter statusNew
+  class prMetadataFormatter statusNew
+  class envelopeWriteBack statusNew
+  class reportFormatter statusNew
+  class reportWriter statusNew
+```
+
+Legend: gray = existing, yellow = changed, green = new, red = unclear ownership / open decision. `ArchitectureComparison` is red because the new `domain-facade` instance awaits user approval. Left cluster = commit-hook phase; right cluster = PR-time Action phase.
+
+##### Components
+
+| Component | Layer / path | Status | .riviere role | Responsibilities | Estimated size |
+|---|---|---|---|---|---|
+| `ArchitectureDiff` (+ `ApplicationDiff`, `SubdomainDiff`, `ArchitectureLayerDiff`, `ArchitectureChangeSet`, `UseCaseChangeGroup`, `ArchitectureElement`, `AggregateDiff`, `ArchitectureRelationship`, `SourceEvidence`) | `packages/riviere-architecture/published-language/src/published-language/architecture-diff.ts` | New | `published-language-schema` / `published-language-data-structure` | Minimal stable wire contract consumed by GitHub and Éclair. `SourceEvidence = { base?, head? }` reusing `SourceLocation`. `AggregateDiff.status: 'created' \| 'affected' \| 'removed'` makes an aggregate affected on both sides machine-distinguishable from a newly created one; domain layer diffs carry `affectedAggregates` only when non-empty. `ArchitectureElement.relatedTo` is an `ArchitectureRelationship[]` collection (`{ name, role }`, POC vocabulary) plus `associatedSubdomains: string[]`. `application.associationChanges` holds dual-evidence association moves recorded once. No application behaviour. | Medium |
+| `SubdomainChange` / `ArchitecturePackageKind` / `ElementChangeDirection` / `AggregateChangeStatus` | same package | New | `published-language-union` | Closed unions: `added\|changed\|removed`, `application\|use-cases\|domain-model\|published-language`, `added\|removed`, `created\|affected\|removed`. | Small |
+| `parseArchitectureDiff` | `.../published-language/parse-architecture-diff.ts` | New | `published-language-parser` | Parses `unknown` into `{ success: true, diff } \| { success: false, issues }`; consumed by the envelope loader (data-access may import any subdomain published-language) and later by Éclair. | Medium |
+| `ArchitectureSource` | `packages/riviere-architecture/domain-model/src/domain/architecture-source.ts` | New | `value-object` | Projects one `RiviereGraph` into comparison facts via `static fromGraph` (custom-component filter, application/subdomain ownership split, layer mapping by `packageKind`, aggregate split, `aggregateOwnerId` resolution, **all** `supports-primary-element` links collected into a canonicalised relationship collection, source evidence); exposes `subdomain(name)`, `subdomainNames()`, `applicationElements()`. Internal fact shapes (`ElementState`, `ElementRelationship`, `AggregateState`, `ArchitectureLayerState`, `SubdomainFacts`) are inline-typed like the builder's `GraphDiff` nested shapes. | Medium |
+| `ArchitectureElementCollection` | `.../domain/architecture-element-collection.ts` | New | `value-object` | The one shared home of element-list diffing: `fromStates`, `addedIn`, `removedIn` (single-side evidence resolved here), `applicationAssociationChanges` (identity pairing over the relationship collection, move/add/remove split). Owns the element identity key and the association identity. | Medium |
+| `AssociationMove` | `.../domain/association-move.ts` | New | `value-object` | One application-owned element present on both sides whose association changed; `toElement()` records it once with dual base/head evidence. | Small |
+| `InvalidArchitectureGraphError` | `.../domain/invalid-architecture-graph-error.ts` | New | `domain-error` | Thrown by the facade when a graph fails published-language validation; the loader surfaces it as `GraphCorruptedError`. | Small |
+| `ArchitectureComparison` | `.../domain/architecture-comparison.ts` | New | `domain-facade` *(open decision)* | One stable interface over the four comparisons: `static fromRevisions(baseJson, headJson)` + `compare(): ArchitectureDiff`. Consumed by the query-model, not the use case. | Medium |
+| `groupSubdomainDiff` | `.../domain/subdomain-grouper.ts` | New | `domain-service` (justified) | Pairs subdomain facts from the union of both snapshots' names and labels each pair's presence `added\|changed\|removed` (absorbs the former `classifyChange`). | Small |
+| `compareEntrypointLayer` | `.../domain/entrypoint-layer-comparison.ts` | New | `domain-service` (justified) | Compares subdomain-owned entrypoint-layer items; returns `undefined` when unchanged. Application-owned entry points never reach it. | Small |
+| `compareUseCaseLayer` | `.../domain/use-case-layer-comparison.ts` | New | `domain-service` (justified) | Compares use-case-layer items and groups changed supporting elements under each named use case from the element's `relatedTo` relationships (an element supporting several use cases appears in each named group, POC parity); unattached changes stay in `items` as the supporting group. | Small |
+| `compareDomainLayer` | `.../domain/domain-layer-comparison.ts` | New | `domain-service` (justified) | Compares domain-layer aggregates and items; owns the both-sides rule: an aggregate present on both sides with member changes is published once with `status: 'affected'` in `affectedAggregates`, head-only aggregates get `status: 'created'` in `added.aggregates`, vanished ones `status: 'removed'` in `removed.aggregates` — never created-plus-deleted. | Medium |
+| `CompareArchitectures` | `packages/riviere-architecture/use-cases/src/features/architecture-comparison/queries/compare-architectures.ts` | New | `query-model-use-case` | `execute(input)` → `loader.load(...)` in a try/catch that maps thrown data-access errors via `toArchitectureGraphLoadFailure` (mirrors `ListDomains`). One method, no domain logic. | Small |
+| `CompareArchitecturesInput` | `.../queries/compare-architectures-input.ts` | New | `query-model-use-case-input` | `{ baseGraphPath: string; headGraphPath: string }` — the two retained graph file paths. | Small |
+| `ArchitectureDiffResult` | `.../queries/architecture-diff-result.ts` | New | `query-model` | Concrete result class (private constructor + `static parse(baseJson, headJson)`) that consumes the facade: `ArchitectureComparison.fromRevisions(...).compare()`. | Small |
+| `CompareArchitecturesResult` / `ArchitectureGraphLoadFailure` / `toArchitectureGraphLoadFailure` | `.../queries/compare-architectures-result.ts`, `.../queries/architecture-graph-load-failure.ts` | New | `query-model-value` / `query-model` | Result union `ArchitectureDiffResult \| ArchitectureGraphLoadFailure`; the mapper converts thrown `GraphNotFoundError`/`GraphCorruptedError` into the failure union. | Small |
+| `ArchitectureDiffLoader` | `.../data-access/architecture-diff/architecture-diff-loader.ts` | New | `query-model-loader` | `load(baseGraphPath, headGraphPath)` reads both files (`node:fs`), `JSON.parse`s, and calls `ArchitectureDiffResult.parse`; wraps any parse/validation failure in `GraphCorruptedError`. | Small |
+| `GraphNotFoundError` / `GraphCorruptedError` | `.../data-access/architecture-diff/` | New | `data-access-error` | Thrown by the graph loader; mapped onto `ArchitectureGraphLoadFailure` by the use case. | Small |
+| `LoadArchitectureDiffEnvelope` | `.../queries/load-architecture-diff-envelope.ts` | New | `query-model-use-case` | `execute(input)` → `loader.load(...)` in a try/catch that maps thrown data-access errors via `toArchitectureDiffEnvelopeLoadFailure`. One method, no domain logic. | Small |
+| `LoadArchitectureDiffEnvelopeInput` | `.../queries/load-architecture-diff-envelope-input.ts` | New | `query-model-use-case-input` | `{ envelopePathOption: string \| undefined }` — undefined means the tracked default path. | Small |
+| `ArchitectureDiffEnvelope` | `.../queries/architecture-diff-envelope.ts` | New | `query-model` | `{ metadata, diff }` interface — the tracked-file read shape and the CLI write target; `diff` is the validated `ArchitectureDiff`, so apps consume the schema through this query export without importing published-language. | Small |
+| `ArchitectureDiffEnvelopeMetadata` / `ArchitectureDiffSourceLinks` / `ArchitectureDiffPullRequestMetadata` | `.../queries/architecture-diff-envelope-metadata.ts` | New | `query-model-value` | Commit-time metadata (`repository`, `baseRevision`, `headRevision`, `sourceLinks`, optional `pullRequest`) and PR-time metadata (`number`, `title`, `description`, `url`); keeps GitHub-specific identity fields out of the language-agnostic diff schema per the approved rejection. | Small |
+| `LoadArchitectureDiffEnvelopeResult` / `ArchitectureDiffEnvelopeLoadFailure` / `toArchitectureDiffEnvelopeLoadFailure` | `.../queries/load-architecture-diff-envelope-result.ts` | New | `query-model-value` / `query-model` | Result union `ArchitectureDiffEnvelope \| ArchitectureDiffEnvelopeLoadFailure`; the mapper converts thrown envelope data-access errors into the failure union. | Small |
+| `ArchitectureDiffEnvelopeLoader` | `.../data-access/architecture-diff-envelope/architecture-diff-envelope-loader.ts` | New | `query-model-loader` | `load(envelopePathOption)` resolves the tracked default path, `existsSync`/`readFileSync`/`JSON.parse`s the envelope, validates `diff` via `parseArchitectureDiff` and the four commit-time metadata fields, and returns the envelope; failures throw the errors below. | Small |
+| `ArchitectureDiffEnvelopeNotFoundError` / `ArchitectureDiffEnvelopeCorruptedError` | `.../data-access/architecture-diff-envelope/` | New | `data-access-error` | Missing tracked file or invalid envelope JSON/diff/metadata. | Small |
+| `createGeneratePrArchitectureDiffCommand` + options/dependencies interfaces | `apps/cli/src/features/architecture-diff/entrypoint/generate-pr-architecture-diff/entrypoint.ts` | New | `cli-entrypoint` / `cli-entrypoint-dependencies` | Commit-hook command. Builds `CompareArchitecturesInput` directly from parsed `--base-graph`/`--head-graph` flags (canonical query pattern — no input factory), executes the use case, and on success composes the envelope from the result plus `--repository`/`--base-revision`/`--head-revision` and writes it to `--output` (default tracked path); on failure prints the formatted load failure. | Small |
+| `composeCommitArchitectureDiffEnvelope` | `.../generate-pr-architecture-diff/compose-commit-architecture-diff-envelope.ts` | New | `cli-output-formatter` | Composes `{ metadata: { repository, baseRevision, headRevision, sourceLinks }, diff }` with explicit field origins: the three commit-context fields verbatim from the flags (supplied by the hook's git commands — the CLI runs no git subprocess), `sourceLinks` derived as base/head blob-URL prefixes, `diff` from the query result. Writes no `pullRequest` keys. | Small |
+| `writeArchitectureDiffEnvelope` | `.../generate-pr-architecture-diff/write-architecture-diff-envelope.ts` | New | `cli-response-writer` | `writeArchitectureDiffEnvelope(envelope, outputPath)` — one `writeFile` of `JSON.stringify(envelope, null, 2)` to the tracked path (mirrors `writeFinalizedGraph`); input is the `query-model` envelope, satisfying `cli-response-writer.allowedInputs`. | Small |
+| `formatArchitectureGraphLoadFailure` | `.../generate-pr-architecture-diff/format-architecture-graph-load-failure.ts` | New | `cli-output-formatter` | Formats `ArchitectureGraphLoadFailure` for CLI output. Lives in the feature entrypoint folder (not root infra) because it consumes the subdomain queries contract. | Small |
+| `createPublishPrArchitectureDiffCommand` + options/dependencies interfaces | `apps/cli/src/features/architecture-diff/entrypoint/publish-pr-architecture-diff/entrypoint.ts` | New | `cli-entrypoint` / `cli-entrypoint-dependencies` | PR-time Action command. Builds `LoadArchitectureDiffEnvelopeInput` from `--envelope` (default tracked path), executes the envelope query — the diff is **never recalculated** — then merges `--pull-request-number/-title/-description/-url`, writes the merged envelope back, formats the report, and writes it to `--report-output`. | Small |
+| `withPullRequestMetadata` | `.../publish-pr-architecture-diff/with-pull-request-metadata.ts` | New | `cli-output-formatter` | Adds only `metadata.pullRequest.{number,title,description,url}` to the loaded envelope (approved PR-time field ownership); touches no other field. | Small |
+| `formatArchitectureDiffReport` (+ section formatters) | `.../publish-pr-architecture-diff/format-architecture-diff-report.ts` | New | `cli-output-formatter` | Formats the complete GitHub Markdown report from the merged envelope (`diff` facts + `sourceLinks`); selects affected aggregates for the summary via `status === 'affected'`; decomposes into section formatter files like the POC (`architecture-review-*.ts`) before any file reaches 400 lines. | Large |
+| `formatArchitectureDiffEnvelopeLoadFailure` | `.../publish-pr-architecture-diff/format-architecture-diff-envelope-load-failure.ts` | New | `cli-output-formatter` | Formats `ArchitectureDiffEnvelopeLoadFailure` for CLI output. | Small |
+| `writePublishedArchitectureDiffEnvelope` | `.../publish-pr-architecture-diff/write-published-architecture-diff-envelope.ts` | New | `cli-response-writer` | `writePublishedArchitectureDiffEnvelope(envelope, envelopePath)` — writes the merged envelope back to the tracked file; input is the `query-model` envelope. | Small |
+| `writeArchitectureDiffReport` | `.../publish-pr-architecture-diff/write-architecture-diff-report.ts` | New | `cli-response-writer` | `writeArchitectureDiffReport(markdown, reportPath)` — writes the Markdown file the workflow posts as the pull-request comment. | Small |
+| Éclair review page | `apps/eclair/src/features/pr-diff/...` | New | unassigned (`apps/eclair` is in `unassignedPackages`) | Boundary only. The Éclair feature design — public PR link resolution, upload-envelope parsing, the approved review page — is a deferred open decision (see Open decisions); the envelope and `ArchitectureDiff` above already fix the contract it consumes. | — (deferred) |
+| Commit-hook script + PR workflow steps | `.githooks/` + `.github/workflows/` | Changed | outside enforced packages | The hook supplies `--base-graph`/`--head-graph` and the git-context flags (`git remote get-url origin`, `git rev-parse main`, `git rev-parse HEAD`); the PR workflow supplies the GitHub event-context flags and posts the written report as the comment. | — |
+
+### .riviere role options
+
+| Decision | Candidate roles considered | Preferred role | Reason | Open decision |
+|---|---|---|---|---|
+| Cross-revision comparison behaviour (subdomain grouping, three layer comparisons) | aggregate + `aggregate-repository`; methods on one `Architecture` value object; `domain-service` | `domain-service` (per declaration, each justified) | Aggregate rejected: comparison mutates nothing and owns no lifecycle invariant. Monolithic value object rejected: it would have to hold both revisions' facts. Each comparison spans two `ArchitectureSource` snapshots, so no single value object owns the state it reads. | None |
+| Element-list diffing and evidence pairing | `domain-service`; unexported per-file helpers shared across layer files | `value-object` (`ArchitectureElementCollection`) | Identity keys and single-side evidence are behaviour of one layer's element list; two layer services need one shared legal home, and `domain-service`→`domain-service` dependencies are forbidden. | None |
+| Application association change | `domain-service`; `value-object` | `value-object` (`AssociationMove`) | Pairs two states of one application-owned element; dual base/head evidence defines the concept, per the `look-for-missing-value-objects-before-domain-services` memory. | None |
+| Stable compare interface | query-model calling each capability directly; `domain-facade` | `domain-facade` (`ArchitectureComparison`) | Query-model consumers need one stable interface over the grouper and layer comparisons instead of sequencing them (same rationale as approved `RiviereQuery`). | New facade instance requires explicit user approval (`roles.ts` `approvedInstances`). |
+| Tracked-envelope query (load + validate the published JSON) | app-side JSON read; `query-model-loader` + `query-model-use-case` in the subdomain | `query-model-loader` (`ArchitectureDiffEnvelopeLoader`) + `query-model-use-case` (`LoadArchitectureDiffEnvelope`) | Approved ownership assigns loading its inputs to `riviere-architecture/use-cases`; mirrors `ListDomains` + `query-loaders.ts`; keeps the Action's read inside the canonical pattern with no write behaviour on the query side. | None |
+| Envelope composition and PR-metadata merge | inside the writers; a command use case; `cli-output-formatter` | `cli-output-formatter` (`composeCommitArchitectureDiffEnvelope`, `withPullRequestMetadata`) | Pure presentation-side composition of already-generated facts with explicit field origins; no state change, no loading — same precedent as the POC formatter / `writeFinalizedGraph` separation. | None |
+| Complete GitHub report formatting | root `infra/cli/presentation`; feature entrypoint folder | feature entrypoint folder (`cli-output-formatter`) | ADR-002 forbids root infra importing application/domain code and `app.ts` gives `/infra` own-subtree-only imports; the report consumes the full subdomain contract. POC precedent keeps `pull-request-architecture-diff-formatter.ts` in the feature entrypoint folder. | None |
+| Output file writes | formatters writing directly; `cli-response-writer` | `cli-response-writer` (three small writers, one per entrypoint folder) | Writers perform the output side effect only; envelope writers take the `query-model` envelope, satisfying `allowedInputs: ['command-use-case-result', 'query-model']`. | None |
+| Query input translation | `command-input-factory`; direct construction in `cli-entrypoint` | direct construction in `cli-entrypoint` | `command-input-factory` `allowedOutputs` is `command-use-case-input` only; the canonical "CLI Invoking Query Model Use Case" pattern and existing query entrypoints construct the query input in the entrypoint. | None |
+| Load failure handling | loader returns a failure union; loader throws + use case maps | loader throws + use case maps via `query-model` mappers | Mirrors `ListDomains` + `toQueryGraphLoadFailure`; both loaders stay load-or-throw. | None |
+
+### Canonical role pattern
+
+This option follows **"CLI Invoking Query Model Use Case"** and **"Query Model Use Case loading and querying a query model"** from `.riviere/canonical-role-configurations.md`, applied to both commands: each `cli-entrypoint` orchestrates everything and constructs the `query-model-use-case-input` directly from parsed flags (no factory), each `query-model-use-case` injects its `query-model-loader` and maps load failures, each loader reads and parses its input files into a `query-model`, the comparison query model consumes the `domain-facade`, and there is no save step — publication writes happen through `cli-output-formatter` composition and `cli-response-writer` file writes at the CLI output boundary.
+
+### Tangled responsibility findings
+
+No tangled responsibilities identified in existing production code — the design creates the new `riviere-architecture` package rather than modifying existing packages. Tangles present in earlier drafts of this option were resolved: (1) `addedItems`/`itemKey` shared across two layer-comparison files with no legal role home now live once on the `ArchitectureElementCollection` value object; (2) source evidence resolved in a separate pass after layer comparison now resolves inside the collection and `AssociationMove` at the moment presence is decided; (3) the complete-diff formatter previously placed in root `infra/cli/presentation` — which ADR-002 and `app.ts` forbid from importing the subdomain contract — now lives in the feature entrypoint folder, matching the POC precedent, with only genuinely generic formatters left in root infra; (4) the envelope write path previously had no composition component and contradicted its own outline — the commit composer and the `query-model` envelope writer input now make prose, table, outline, and stress test agree; (5) the PR-time publication phase previously dismissed as "outside this command" is now fully designed rather than silently dropped.
+
+#### State loading and persistence (constraint 4)
+
+All file reading and parsing is owned inside `riviere-architecture` — never pushed to the app. Both envelope writes go through `cli-response-writer` functions whose envelope input is the `query-model` `ArchitectureDiffEnvelope`.
+
+**Load 1 — comparison inputs (commit-hook phase).**
+
+- **What is loaded:** two `fine-grained-role-graph` files on disk (base = retained `main` graph, head = current-commit graph), each a JSON-encoded `RiviereGraph` whose `CustomComponent`s have `customTypeName === 'architecture-review-element'` carrying `architectureRole`, `packageKind`, optionally `aggregateOwnerId`/`externalClient`/`methods`, connected by `supports-primary-element` links (`aggregateOwnerId` mirrors the `aggregate-owns-entity` link), each with a `sourceLocation`.
+- **Loader:** `ArchitectureDiffLoader` (`query-model-loader`).
+- **Load method:** `load(baseGraphPath: string, headGraphPath: string): ArchitectureDiffResult`.
+- **Load inputs and provenance:** `input.baseGraphPath` ← CLI flag `--base-graph`; `input.headGraphPath` ← CLI flag `--head-graph`; the commit hook supplies both file paths. Per file, `readGraphJson` runs `existsSync` (missing → throws `GraphNotFoundError`), then `readFileSync` + `JSON.parse` (invalid JSON → throws `GraphCorruptedError`); any error thrown by `ArchitectureDiffResult.parse` (schema-invalid graph) is also wrapped as `GraphCorruptedError`.
+- **Loaded output:** an `ArchitectureDiffResult` (query-model) wrapping the published `ArchitectureDiff`, or — after the use case maps a thrown data-access error via `toArchitectureGraphLoadFailure` — an `ArchitectureGraphLoadFailure`.
+- **Projection into comparison facts (owned by domain):** `ArchitectureDiffResult.parse` calls `ArchitectureComparison.fromRevisions(baseJson, headJson)`, which builds two `ArchitectureSource` value objects via `ArchitectureSource.fromGraph(graph)`. The projection yields per-subdomain facts `layers: { entrypoints, useCases, domain }` (each `{ aggregates, items }`) plus one application-wide element collection.
+- **Field provenance:** subdomain name ← element `domain`; application vs subdomain placement ← `packageKind === 'application'`; layer ← `packageKind`; aggregate-vs-item split ← `role === 'aggregate'`; aggregate `entities` ← element `aggregateOwnerId` resolved through `componentsById`; `relatedTo` ← **every** `supports-primary-element` link collected per supporting element and canonicalised (unique by role+name, sorted — POC `canonicalRelationships` parity, so multi-relationship elements lose no facts); `associatedSubdomains` ← sorted unique domains of those primaries; `name`/`role`/`externalClient`/`methods` ← element fields; `sourceEvidence` ← element `sourceLocation`.
+
+**Persist 1 — commit-time tracked envelope write.**
+
+- **Composer:** `composeCommitArchitectureDiffEnvelope(result: ArchitectureDiffResult, commitContext: ArchitectureDiffCommitContext): ArchitectureDiffEnvelope` (`cli-output-formatter`); `commitContext` is `{ repository, baseRevision, headRevision }` ← CLI flags `--repository`/`--base-revision`/`--head-revision`, each supplied by the commit hook from `git remote get-url origin`, `git rev-parse main`, and `git rev-parse HEAD` (the CLI runs no git subprocess). `metadata.sourceLinks` ← composer-derived base/head blob-URL prefixes `https://github.com/{repository}/blob/{revision}/` used by the GitHub formatter and Éclair to build source-line links from `SourceLocation`. `diff` ← `result.diff`. No `pullRequest` keys exist at commit time.
+- **Writer:** `writeArchitectureDiffEnvelope(envelope: ArchitectureDiffEnvelope, outputPath: string): Promise<void>` (`cli-response-writer`) — one `writeFile(outputPath, JSON.stringify(envelope, null, 2))`; `outputPath` ← `--output`, default `.riviere/pr-diffs/riviere-architecture-diff.json`.
+
+**Load 2 — tracked envelope (PR-time Action phase; the diff is never recalculated).**
+
+- **What is loaded:** the tracked file `.riviere/pr-diffs/riviere-architecture-diff.json` — the `{ metadata, diff }` envelope written by Load/Persist 1 and committed to the head commit.
+- **Loader:** `ArchitectureDiffEnvelopeLoader` (`query-model-loader`).
+- **Load method:** `load(envelopePathOption: string | undefined): ArchitectureDiffEnvelope`.
+- **Load inputs and provenance:** `input.envelopePathOption` ← CLI flag `--envelope` supplied by the workflow step; `undefined` resolves to the tracked default path. `existsSync` (missing → `ArchitectureDiffEnvelopeNotFoundError`), `readFileSync` + `JSON.parse` (invalid → `ArchitectureDiffEnvelopeCorruptedError`), `parseArchitectureDiff(json.diff)` (schema-invalid diff → `ArchitectureDiffEnvelopeCorruptedError`), and required-field validation of `metadata.repository`/`.baseRevision`/`.headRevision`/`.sourceLinks` (invalid → `ArchitectureDiffEnvelopeCorruptedError`).
+- **Loaded output:** `ArchitectureDiffEnvelope` — `metadata` ← typed passthrough of the file's metadata block (including `pullRequest` when a previous publish already added it); `diff` ← the `parseArchitectureDiff` success value. Or, after the use case maps a thrown data-access error via `toArchitectureDiffEnvelopeLoadFailure`, an `ArchitectureDiffEnvelopeLoadFailure`.
+
+**Persist 2 — PR-time write-back and report write.**
+
+- **Merge:** `withPullRequestMetadata(envelope: ArchitectureDiffEnvelope, pullRequest: ArchitectureDiffPullRequestMetadata): ArchitectureDiffEnvelope` (`cli-output-formatter`); `pullRequest.number/.title/.description/.url` ← CLI flags `--pull-request-number/-title/-description/-url` supplied by the workflow step from the GitHub Actions pull-request event context. Only `metadata.pullRequest.*` is added — the approved PR-time field ownership.
+- **Write-back:** `writePublishedArchitectureDiffEnvelope(publishedEnvelope: ArchitectureDiffEnvelope, envelopePath: string): Promise<void>` (`cli-response-writer`) — `writeFile` of the merged envelope to the same tracked path.
+- **Report:** `formatArchitectureDiffReport(publishedEnvelope): string` (`cli-output-formatter`) then `writeArchitectureDiffReport(markdown: string, reportPath: string): Promise<void>` (`cli-response-writer`); `reportPath` ← `--report-output`. The workflow posts this file as the pull-request comment, so the pull request continues to present one architecture diff.
+
+##### Code stress test
+
+```typescript
+// --- query-model-use-case (commit phase): load, map data-access failures, return ---
+/** @riviere-role query-model-use-case */
+export class CompareArchitectures {
+  constructor(private readonly loader: ArchitectureDiffLoader) {}
+
+  execute(input: CompareArchitecturesInput): CompareArchitecturesResult {
+    try {
+      return this.loader.load(input.baseGraphPath, input.headGraphPath)
+    } catch (error) {
+      const failure = toArchitectureGraphLoadFailure(error)
+      if (failure !== undefined) return failure
+      throw error
+    }
+  }
+}
+
+/** @riviere-role query-model-use-case-input */
+export interface CompareArchitecturesInput {
+  readonly baseGraphPath: string
+  readonly headGraphPath: string
+}
+
+// --- query-model-use-case (PR-time phase): same canonical shape ---
+/** @riviere-role query-model-use-case */
+export class LoadArchitectureDiffEnvelope {
+  constructor(private readonly loader: ArchitectureDiffEnvelopeLoader) {}
+
+  execute(input: LoadArchitectureDiffEnvelopeInput): LoadArchitectureDiffEnvelopeResult {
+    try {
+      return this.loader.load(input.envelopePathOption)
+    } catch (error) {
+      const failure = toArchitectureDiffEnvelopeLoadFailure(error)
+      if (failure !== undefined) return failure
+      throw error
+    }
+  }
+}
+
+/** @riviere-role query-model-use-case-input */
+export interface LoadArchitectureDiffEnvelopeInput {
+  readonly envelopePathOption: string | undefined
+}
+
+// --- query-model-loader: owns the envelope file read + JSON parse + schema validation ---
+/** @riviere-role query-model-loader */
+export class ArchitectureDiffEnvelopeLoader {
+  load(envelopePathOption: string | undefined): ArchitectureDiffEnvelope {
+    const envelopePath = envelopePathOption ?? '.riviere/pr-diffs/riviere-architecture-diff.json'
+    if (!existsSync(envelopePath)) throw new ArchitectureDiffEnvelopeNotFoundError(envelopePath)
+    let json: unknown
+    try {
+      json = JSON.parse(readFileSync(envelopePath, 'utf-8'))
+    } catch (error) {
+      throw new ArchitectureDiffEnvelopeCorruptedError(envelopePath, { cause: error })
+    }
+    // validate diff through the published-language parser and the four commit-time metadata
+    // fields; either failure throws ArchitectureDiffEnvelopeCorruptedError
+    return toValidatedEnvelope(json, envelopePath)
+  }
+}
+
+// --- query-model: the tracked-file read shape and the CLI write target ---
+/** @riviere-role query-model */
+export interface ArchitectureDiffEnvelope {
+  readonly metadata: ArchitectureDiffEnvelopeMetadata
+  readonly diff: ArchitectureDiff
+}
+
+/** @riviere-role query-model-value */
+export interface ArchitectureDiffEnvelopeMetadata {
+  readonly repository: string
+  readonly baseRevision: string
+  readonly headRevision: string
+  readonly sourceLinks: ArchitectureDiffSourceLinks
+  readonly pullRequest?: ArchitectureDiffPullRequestMetadata
+}
+
+/** @riviere-role query-model-value */
+export interface ArchitectureDiffSourceLinks {
+  readonly base: string
+  readonly head: string
+}
+
+/** @riviere-role query-model-value */
+export interface ArchitectureDiffPullRequestMetadata {
+  readonly number: number
+  readonly title: string
+  readonly description: string
+  readonly url: string
+}
+
+// --- query-model (commit phase): consumes the domain-facade
+//     (mirrors DomainList.parse -> RiviereQuery.fromJSON) ---
+/** @riviere-role query-model */
+export class ArchitectureDiffResult {
+  private constructor(readonly diff: ArchitectureDiff) {}
+
+  static parse(baseJson: unknown, headJson: unknown): ArchitectureDiffResult {
+    return new ArchitectureDiffResult(ArchitectureComparison.fromRevisions(baseJson, headJson).compare())
+  }
+}
+```
+
+```typescript
+// --- cli-entrypoint (commit-hook phase): query, compose envelope with explicit origins, write ---
+/** @riviere-role cli-entrypoint-dependencies */
+export interface GeneratePrArchitectureDiffEntrypointDependencies {
+  readonly compareArchitectures: CompareArchitectures
+  readonly composeCommitArchitectureDiffEnvelope: typeof composeCommitArchitectureDiffEnvelope
+  readonly writeArchitectureDiffEnvelope: typeof writeArchitectureDiffEnvelope
+  readonly formatArchitectureGraphLoadFailure: typeof formatArchitectureGraphLoadFailure
+}
+
+/** @riviere-role cli-entrypoint */
+export function createGeneratePrArchitectureDiffCommand(
+  dependencies: GeneratePrArchitectureDiffEntrypointDependencies,
+): Command {
+  return new Command('generate-pr-architecture-diff')
+    .requiredOption('--base-graph <path>', 'base fine-grained-role-graph file')
+    .requiredOption('--head-graph <path>', 'head fine-grained-role-graph file')
+    .requiredOption('--repository <ownerAndName>', 'repository owner/name')
+    .requiredOption('--base-revision <sha>', 'base revision sha')
+    .requiredOption('--head-revision <sha>', 'head revision sha')
+    .option('--output <path>', 'tracked envelope output path', '.riviere/pr-diffs/riviere-architecture-diff.json')
+    .action(async (options: GeneratePrArchitectureDiffOptions) => {
+      const result = dependencies.compareArchitectures.execute({
+        baseGraphPath: options.baseGraph,
+        headGraphPath: options.headGraph,
+      })
+      if (!(result instanceof ArchitectureDiffResult)) {
+        console.log(dependencies.formatArchitectureGraphLoadFailure(result))
+        return
+      }
+      const envelope = dependencies.composeCommitArchitectureDiffEnvelope(result, {
+        repository: options.repository,
+        baseRevision: options.baseRevision,
+        headRevision: options.headRevision,
+      })
+      await dependencies.writeArchitectureDiffEnvelope(envelope, options.output)
+    })
+}
+
+// --- cli-output-formatter: composes the commit-time envelope; every field origin explicit ---
+/** @riviere-role cli-output-formatter */
+export function composeCommitArchitectureDiffEnvelope(
+  result: ArchitectureDiffResult,
+  commitContext: ArchitectureDiffCommitContext,
+): ArchitectureDiffEnvelope {
+  return {
+    metadata: {
+      repository: commitContext.repository,     // --repository  (hook: git remote get-url origin)
+      baseRevision: commitContext.baseRevision, // --base-revision (hook: git rev-parse main)
+      headRevision: commitContext.headRevision, // --head-revision (hook: git rev-parse HEAD)
+      sourceLinks: {
+        base: `https://github.com/${commitContext.repository}/blob/${commitContext.baseRevision}/`,
+        head: `https://github.com/${commitContext.repository}/blob/${commitContext.headRevision}/`,
+      },
+    },
+    diff: result.diff,
+  }
+}
+
+// --- cli-response-writer: query-model input satisfies allowedInputs ---
+/** @riviere-role cli-response-writer */
+export async function writeArchitectureDiffEnvelope(
+  envelope: ArchitectureDiffEnvelope,
+  outputPath: string,
+): Promise<void> {
+  await writeFile(outputPath, JSON.stringify(envelope, null, 2), 'utf-8')
+}
+
+// --- cli-entrypoint (PR-time phase): load tracked JSON, add pullRequest metadata, write report ---
+/** @riviere-role cli-entrypoint */
+export function createPublishPrArchitectureDiffCommand(
+  dependencies: PublishPrArchitectureDiffEntrypointDependencies,
+): Command {
+  return new Command('publish-pr-architecture-diff')
+    .option('--envelope <path>', 'tracked diff envelope', '.riviere/pr-diffs/riviere-architecture-diff.json')
+    .requiredOption('--pull-request-number <number>', 'pull request number')
+    .requiredOption('--pull-request-title <title>', 'pull request title')
+    .requiredOption('--pull-request-description <description>', 'pull request description')
+    .requiredOption('--pull-request-url <url>', 'pull request URL')
+    .requiredOption('--report-output <path>', 'GitHub report file to write')
+    .action(async (options: PublishPrArchitectureDiffOptions) => {
+      const loaded = dependencies.loadArchitectureDiffEnvelope.execute({
+        envelopePathOption: options.envelope,
+      })
+      if ('kind' in loaded) {
+        console.log(dependencies.formatArchitectureDiffEnvelopeLoadFailure(loaded))
+        return
+      }
+      const published = dependencies.withPullRequestMetadata(loaded, {
+        number: Number(options.pullRequestNumber),
+        title: options.pullRequestTitle,
+        description: options.pullRequestDescription,
+        url: options.pullRequestUrl,
+      })
+      await dependencies.writePublishedArchitectureDiffEnvelope(
+        published,
+        options.envelope ?? '.riviere/pr-diffs/riviere-architecture-diff.json',
+      )
+      await dependencies.writeArchitectureDiffReport(
+        dependencies.formatArchitectureDiffReport(published),
+        options.reportOutput,
+      )
+    })
+}
+
+// --- cli-output-formatter: adds only the approved PR-time fields ---
+/** @riviere-role cli-output-formatter */
+export function withPullRequestMetadata(
+  envelope: ArchitectureDiffEnvelope,
+  pullRequest: ArchitectureDiffPullRequestMetadata,
+): ArchitectureDiffEnvelope {
+  return { metadata: { ...envelope.metadata, pullRequest }, diff: envelope.diff }
+}
+
+// --- cli-output-formatter: GitHub markdown from the envelope, never recalculated ---
+/** @riviere-role cli-output-formatter */
+export function formatArchitectureDiffReport(envelope: ArchitectureDiffEnvelope): string {
+  // affected aggregates are machine-distinguishable from created ones via status
+  const affectedAggregates = envelope.diff.subdomains.flatMap((subdomain) =>
+    subdomain.layers.domain?.affectedAggregates ?? [],
+  )
+  return [
+    formatReportSummary(envelope, affectedAggregates),
+    ...formatApplicationSections(envelope),
+    ...formatSubdomainSections(envelope),
+  ].join('\n')
+}
+```
+
+```typescript
+// --- domain-facade: one stable compare interface for query-model consumers ---
+/** @riviere-role domain-facade
+ *  @riviere-role-justification Query-model consumers (ArchitectureDiffResult.parse) need one stable
+ *  compare(base, head) interface over the subdomain grouper and the three layer comparisons instead
+ *  of discovering and sequencing each comparison capability themselves. */
+export class ArchitectureComparison {
+  private constructor(
+    private readonly base: ArchitectureSource,
+    private readonly head: ArchitectureSource,
+  ) {}
+
+  static fromRevisions(baseJson: unknown, headJson: unknown): ArchitectureComparison {
+    return new ArchitectureComparison(
+      ArchitectureSource.fromGraph(ArchitectureComparison.requireValidGraph(baseJson)),
+      ArchitectureSource.fromGraph(ArchitectureComparison.requireValidGraph(headJson)),
+    )
+  }
+
+  private static requireValidGraph(json: unknown): RiviereGraph {
+    const parsed = parseRiviereGraph(json)
+    if (parsed.success) return parsed.graph
+    throw new InvalidArchitectureGraphError(parsed.issues) // the loader surfaces this as GraphCorruptedError
+  }
+
+  compare(): ArchitectureDiff {
+    const changes = this.base.applicationElements().applicationAssociationChanges(this.head.applicationElements())
+    const application =
+      changes.moves.length === 0 && changes.added.length === 0 && changes.removed.length === 0
+        ? undefined
+        : {
+            associationChanges: changes.moves.map((move) => move.toElement()),
+            added: changes.added,
+            removed: changes.removed,
+          }
+    const subdomains = groupSubdomainDiff(this.base, this.head).flatMap((subdomain) => {
+      const entrypoints = compareEntrypointLayer(subdomain.base?.layers.entrypoints, subdomain.head?.layers.entrypoints)
+      const useCases = compareUseCaseLayer(subdomain.base?.layers.useCases, subdomain.head?.layers.useCases)
+      const domain = compareDomainLayer(subdomain.base?.layers.domain, subdomain.head?.layers.domain)
+      return entrypoints === undefined && useCases === undefined && domain === undefined
+        ? []
+        : [{ name: subdomain.name, change: subdomain.change, layers: { entrypoints, useCases, domain } }]
+    })
+    return { application, subdomains }
+  }
+}
+
+// --- domain-service: subdomain pairing + presence labelling (absorbs classifyChange) ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Pairs subdomain facts drawn from two different ArchitectureSource
+ *  snapshots and labels each pair's presence. No aggregate exists because comparison mutates no
+ *  state, and no single value object owns both sides of a base/head revision pair. */
+export function groupSubdomainDiff(
+  base: ArchitectureSource,
+  head: ArchitectureSource,
+): readonly {
+  readonly name: string
+  readonly change: SubdomainChange
+  readonly base: SubdomainFacts | undefined
+  readonly head: SubdomainFacts | undefined
+}[] {
+  const names = [...new Set([...base.subdomainNames(), ...head.subdomainNames()])]
+  return names.map((name) => {
+    const baseFacts = base.subdomain(name)
+    const headFacts = head.subdomain(name)
+    return {
+      name,
+      base: baseFacts,
+      head: headFacts,
+      change: baseFacts === undefined ? 'added' : headFacts === undefined ? 'removed' : 'changed',
+    }
+  })
+}
+
+// --- domain-service: subdomain-owned entrypoint layer comparison ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Entrypoint-layer comparison spans layer facts from two
+ *  ArchitectureSource snapshots and owns the ownership boundary: only genuinely subdomain-owned
+ *  entry points appear in a subdomain's entrypoint layer, because application-owned ones are
+ *  compared as application associations. No single value object owns both sides, and no aggregate
+ *  exists because comparison mutates nothing. */
+export function compareEntrypointLayer(
+  base: ArchitectureLayerState | undefined,
+  head: ArchitectureLayerState | undefined,
+): ArchitectureLayerDiff | undefined {
+  const baseElements = ArchitectureElementCollection.fromStates(base?.items ?? [])
+  const headElements = ArchitectureElementCollection.fromStates(head?.items ?? [])
+  const added = baseElements.addedIn(headElements)
+  const removed = baseElements.removedIn(headElements)
+  if (added.length === 0 && removed.length === 0) return undefined
+  return { added: { aggregates: [], items: added }, removed: { aggregates: [], items: removed } }
+}
+
+// --- domain-service: use-case layer comparison with named-use-case grouping ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Use-case-layer grouping spans layer facts from two
+ *  ArchitectureSource snapshots; no single value object owns both sides of a revision pair, and no
+ *  aggregate exists because comparison mutates nothing. */
+export function compareUseCaseLayer(
+  base: ArchitectureLayerState | undefined,
+  head: ArchitectureLayerState | undefined,
+): ArchitectureLayerDiff | undefined {
+  const baseElements = ArchitectureElementCollection.fromStates(base?.items ?? [])
+  const headElements = ArchitectureElementCollection.fromStates(head?.items ?? [])
+  const added = baseElements.addedIn(headElements)
+  const removed = baseElements.removedIn(headElements)
+  if (added.length === 0 && removed.length === 0) return undefined
+  // changed supporting elements group under EACH named use case they support (relatedTo is a
+  // canonicalised collection); changed elements without relationships stay in items
+  const groupsFor = (
+    direction: ElementChangeDirection,
+    elements: readonly ArchitectureElement[],
+  ): readonly UseCaseChangeGroup[] => {
+    const grouped = new Map<string, ArchitectureElement[]>()
+    for (const element of elements) {
+      for (const relationship of element.relatedTo) {
+        const items = grouped.get(relationship.name) ?? []
+        grouped.set(relationship.name, [...items, element])
+      }
+    }
+    return [...grouped].map(([useCaseName, items]) => ({ useCaseName, direction, items }))
+  }
+  return {
+    added: { aggregates: [], items: added },
+    removed: { aggregates: [], items: removed },
+    useCaseGroups: [...groupsFor('added', added), ...groupsFor('removed', removed)],
+  }
+}
+
+// --- domain-service: domain layer with the both-sides-affected rule ---
+/** @riviere-role domain-service
+ *  @riviere-role-justification Aggregate-member comparison spans domain-layer facts from two
+ *  ArchitectureSource snapshots; neither snapshot's value objects own both sides, and no aggregate
+ *  exists because comparison mutates nothing. */
+export function compareDomainLayer(
+  base: ArchitectureLayerState | undefined,
+  head: ArchitectureLayerState | undefined,
+): ArchitectureLayerDiff | undefined {
+  const baseElements = ArchitectureElementCollection.fromStates(base?.items ?? [])
+  const headElements = ArchitectureElementCollection.fromStates(head?.items ?? [])
+  const addedItems = baseElements.addedIn(headElements)
+  const removedItems = baseElements.removedIn(headElements)
+  const baseAggregates = base?.aggregates ?? []
+  const headAggregates = head?.aggregates ?? []
+  const baseByKey = new Map(baseAggregates.map((aggregate) => [aggregateKey(aggregate), aggregate]))
+  const headKeys = new Set(headAggregates.map((aggregate) => aggregateKey(aggregate)))
+  const created: AggregateDiff[] = []
+  const affected: AggregateDiff[] = []
+  const removedAggregates: AggregateDiff[] = []
+  for (const aggregate of headAggregates) {
+    const before = baseByKey.get(aggregateKey(aggregate))
+    const diff = memberDiff(before, aggregate)
+    if (diff === undefined) continue
+    // present on both sides => affected, published once with member changes (PRD rule);
+    // head-only => created; never created-plus-deleted
+    if (before === undefined) created.push(diff)
+    else affected.push(diff)
+  }
+  for (const aggregate of baseAggregates) {
+    if (!headKeys.has(aggregateKey(aggregate))) removedAggregates.push(removedAggregateDiff(aggregate))
+  }
+  if (
+    created.length === 0 && affected.length === 0 && removedAggregates.length === 0 &&
+    addedItems.length === 0 && removedItems.length === 0
+  ) {
+    return undefined
+  }
+  return {
+    added: { aggregates: created, items: addedItems },
+    removed: { aggregates: removedAggregates, items: removedItems },
+    affectedAggregates: affected,
+  }
+}
+
+function memberDiff(base: AggregateState | undefined, head: AggregateState): AggregateDiff | undefined {
+  const baseEntities = ArchitectureElementCollection.fromStates(base?.entities ?? [])
+  const headEntities = ArchitectureElementCollection.fromStates(head.entities)
+  const addedEntities = baseEntities.addedIn(headEntities)
+  const removedEntities = baseEntities.removedIn(headEntities)
+  const baseMethods = base?.methods ?? []
+  const addedMethods = head.methods.filter((method) => !baseMethods.includes(method))
+  const removedMethods = baseMethods.filter((method) => !head.methods.includes(method))
+  // a creation is itself a change even with zero members; a both-sides aggregate with no
+  // member changes is unchanged and not reported
+  if (
+    base !== undefined &&
+    addedEntities.length === 0 && removedEntities.length === 0 &&
+    addedMethods.length === 0 && removedMethods.length === 0
+  ) {
+    return undefined
+  }
+  return {
+    status: base === undefined ? 'created' : 'affected',
+    name: head.name,
+    packageKind: head.packageKind,
+    sourceEvidence:
+      base === undefined
+        ? { head: head.sourceEvidence }
+        : { base: base.sourceEvidence, head: head.sourceEvidence },
+    addedEntities,
+    removedEntities,
+    addedMethods,
+    removedMethods,
+  }
+}
+
+function removedAggregateDiff(aggregate: AggregateState): AggregateDiff {
+  return {
+    status: 'removed',
+    name: aggregate.name,
+    packageKind: aggregate.packageKind,
+    sourceEvidence: { base: aggregate.sourceEvidence },
+    addedEntities: [],
+    removedEntities: ArchitectureElementCollection.fromStates(aggregate.entities).removedIn(
+      ArchitectureElementCollection.fromStates([]),
+    ),
+    addedMethods: [],
+    removedMethods: [...aggregate.methods],
+  }
+}
+
+function aggregateKey(aggregate: { packageKind: string; name: string }): string {
+  return `${aggregate.packageKind}:${aggregate.name}`
+}
+```
+
+```typescript
+// --- value-object: the one legal home for shared element diffing and evidence resolution ---
+/** @riviere-role value-object */
+export class ArchitectureElementCollection {
+  declare private readonly brand: 'ArchitectureElementCollection'
+
+  private constructor(private readonly items: readonly ElementState[]) {}
+
+  static fromStates(items: readonly ElementState[]): ArchitectureElementCollection {
+    return new ArchitectureElementCollection(items)
+  }
+
+  /** head elements whose full identity is absent here; evidence resolves to the head revision */
+  addedIn(head: ArchitectureElementCollection): readonly ArchitectureElement[] {
+    const present = new Set(this.items.map((item) => this.elementKey(item)))
+    return head.items
+      .filter((item) => !present.has(this.elementKey(item)))
+      .map((item) => this.toElement(item, { head: item.sourceEvidence }))
+  }
+
+  /** base elements whose full identity is absent from the head; evidence resolves to the base revision */
+  removedIn(head: ArchitectureElementCollection): readonly ArchitectureElement[] {
+    const present = new Set(head.items.map((item) => this.elementKey(item)))
+    return this.items
+      .filter((item) => !present.has(this.elementKey(item)))
+      .map((item) => this.toElement(item, { base: item.sourceEvidence }))
+  }
+
+  /** application pairing: same identity on both sides with any changed association is ONE move
+   *  with dual evidence, never created-plus-deleted; new identities are added, vanished ones removed */
+  applicationAssociationChanges(head: ArchitectureElementCollection): {
+    readonly moves: readonly AssociationMove[]
+    readonly added: readonly ArchitectureElement[]
+    readonly removed: readonly ArchitectureElement[]
+  } {
+    const baseByIdentity = new Map(this.items.map((item) => [this.associationIdentity(item), item]))
+    const headIdentities = new Set(head.items.map((item) => this.associationIdentity(item)))
+    const moves: AssociationMove[] = []
+    const added: ArchitectureElement[] = []
+    for (const item of head.items) {
+      const before = baseByIdentity.get(this.associationIdentity(item))
+      if (before === undefined) {
+        added.push(this.toElement(item, { head: item.sourceEvidence }))
+      } else if (!this.sameRelationships(before.relatedTo, item.relatedTo)) {
+        moves.push(AssociationMove.fromStates(before, item))
+      }
+    }
+    const removed = this.items
+      .filter((item) => !headIdentities.has(this.associationIdentity(item)))
+      .map((item) => this.toElement(item, { base: item.sourceEvidence }))
+    return { moves, added, removed }
+  }
+
+  private elementKey(item: ElementState): string {
+    return JSON.stringify([
+      item.packageKind,
+      item.role,
+      item.name,
+      item.externalClient ?? null,
+      item.relatedTo,
+    ])
+  }
+
+  /** association identity is what the element IS, excluding the relationship collection */
+  private associationIdentity(item: ElementState): string {
+    return JSON.stringify([item.packageKind, item.role, item.name, item.externalClient ?? null])
+  }
+
+  /** both collections are canonicalised (unique + sorted), so index-wise comparison is equality */
+  private sameRelationships(
+    left: readonly ElementRelationship[],
+    right: readonly ElementRelationship[],
+  ): boolean {
+    return (
+      left.length === right.length &&
+      left.every((relationship, index) =>
+        relationship.name === right[index].name && relationship.role === right[index].role)
+    )
+  }
+
+  private toElement(item: ElementState, sourceEvidence: SourceEvidence): ArchitectureElement {
+    return {
+      name: item.name,
+      role: item.role,
+      packageKind: item.packageKind,
+      externalClient: item.externalClient,
+      relatedTo: item.relatedTo.map(({ name, role }) => ({ name, role })),
+      associatedSubdomains: [...item.associatedSubdomains],
+      methods: [...item.methods],
+      sourceEvidence,
+    }
+  }
+}
+
+/** @riviere-role value-object */
+export class AssociationMove {
+  declare private readonly brand: 'AssociationMove'
+
+  private constructor(
+    private readonly base: ElementState,
+    private readonly head: ElementState,
+  ) {}
+
+  /** invariant: both states share one application-owned identity and differ in association */
+  static fromStates(base: ElementState, head: ElementState): AssociationMove {
+    return new AssociationMove(base, head)
+  }
+
+  /** an association change carries BOTH revisions' evidence — recorded once */
+  toElement(): ArchitectureElement {
+    return {
+      name: this.head.name,
+      role: this.head.role,
+      packageKind: this.head.packageKind,
+      externalClient: this.head.externalClient,
+      relatedTo: this.head.relatedTo.map(({ name, role }) => ({ name, role })),
+      associatedSubdomains: [...this.head.associatedSubdomains],
+      methods: [...this.head.methods],
+      sourceEvidence: { base: this.base.sourceEvidence, head: this.head.sourceEvidence },
+    }
+  }
+}
+```
+
+```typescript
+// internal comparison facts (inline-typed like the builder's GraphDiff nested shapes)
+interface ElementRelationship {
+  readonly name: string
+  readonly role: string
+  readonly subdomain: string
+}
+interface ElementState {
+  readonly name: string
+  readonly role: string
+  readonly packageKind: ArchitecturePackageKind
+  readonly externalClient?: string
+  readonly methods: readonly string[]
+  readonly relatedTo: readonly ElementRelationship[]
+  readonly associatedSubdomains: readonly string[]
+  readonly sourceEvidence: SourceLocation
+}
+interface AggregateState {
+  readonly name: string
+  readonly packageKind: ArchitecturePackageKind
+  readonly entities: readonly ElementState[]
+  readonly methods: readonly string[]
+  readonly sourceEvidence: SourceLocation
+}
+interface ArchitectureLayerState {
+  readonly aggregates: readonly AggregateState[]
+  readonly items: readonly ElementState[]
+}
+interface SubdomainFacts {
+  readonly layers: {
+    readonly entrypoints: ArchitectureLayerState
+    readonly useCases: ArchitectureLayerState
+    readonly domain: ArchitectureLayerState
+  }
+}
+
+// --- value-object: projects one fine-grained-role-graph into comparison facts ---
+/** @riviere-role value-object */
+export class ArchitectureSource {
+  declare private readonly brand: 'ArchitectureSource'
+
+  private constructor(
+    private readonly subdomains: ReadonlyMap<string, SubdomainFacts>,
+    private readonly application: ArchitectureElementCollection,
+  ) {}
+
+  static fromGraph(graph: RiviereGraph): ArchitectureSource {
+    const componentsById = new Map(graph.components.map((component) => [component.id, component]))
+    const primariesBySupportingId = supportingPrimaries(graph, componentsById)
+    const subdomains = new Map<string, SubdomainFacts>()
+    const application: ElementState[] = []
+    for (const component of graph.components) {
+      if (component.type !== 'Custom' || component.customTypeName !== 'architecture-review-element') {
+        continue
+      }
+      const packageKind = typeof component.packageKind === 'string' ? component.packageKind : 'domain-model'
+      const relationships = primariesBySupportingId.get(component.id) ?? []
+      const state: ElementState = {
+        name: component.name,
+        role: typeof component.architectureRole === 'string' ? component.architectureRole : '',
+        packageKind,
+        externalClient: typeof component.externalClient === 'string' ? component.externalClient : undefined,
+        methods: stringArray(component.methods),
+        relatedTo: relationships,
+        associatedSubdomains: uniqueSorted(relationships.map(({ subdomain }) => subdomain)),
+        sourceEvidence: component.sourceLocation,
+      }
+      if (packageKind === 'application') {
+        application.push(state) // application-owned elements never join subdomain layers (PRD ownership rule)
+        continue
+      }
+      // aggregateOwnerId mirrors the aggregate-owns-entity link for entity elements
+      const ownerName =
+        typeof component.aggregateOwnerId === 'string'
+          ? componentsById.get(component.aggregateOwnerId)?.name
+          : undefined
+      subdomains.set(component.domain, withElement(subdomains.get(component.domain), state, ownerName))
+    }
+    return new ArchitectureSource(subdomains, ArchitectureElementCollection.fromStates(application))
+  }
+
+  subdomain(name: string): SubdomainFacts | undefined {
+    return this.subdomains.get(name)
+  }
+
+  subdomainNames(): readonly string[] {
+    return [...this.subdomains.keys()].sort()
+  }
+
+  applicationElements(): ArchitectureElementCollection {
+    return this.application
+  }
+}
+
+/** link resolution: supports-primary-element points from primary to supporting element; EVERY link
+ *  is collected so multi-relationship elements keep all facts (POC canonicalRelationships parity) */
+function supportingPrimaries(
+  graph: RiviereGraph,
+  componentsById: ReadonlyMap<string, RiviereGraph['components'][number]>,
+): ReadonlyMap<string, readonly ElementRelationship[]> {
+  const bySupportingId = new Map<string, ElementRelationship[]>()
+  for (const link of graph.links) {
+    if (link.relationshipType !== 'supports-primary-element') continue
+    const primary = componentsById.get(link.source)
+    if (primary === undefined) continue
+    const relationship: ElementRelationship = {
+      name: primary.name,
+      role: typeof primary.architectureRole === 'string' ? primary.architectureRole : '',
+      subdomain: primary.domain,
+    }
+    const existing = bySupportingId.get(link.target) ?? []
+    bySupportingId.set(link.target, canonicalRelationships([...existing, relationship]))
+  }
+  return bySupportingId
+}
+
+/** canonicalisation: unique by role+name, sorted — preserves every relationship */
+function canonicalRelationships(
+  relationships: readonly ElementRelationship[],
+): readonly ElementRelationship[] {
+  const unique = new Map(
+    relationships.map((relationship) => [`${relationship.role}:${relationship.name}`, relationship]),
+  )
+  return [...unique.values()].sort((left, right) => left.name.localeCompare(right.name, 'en'))
+}
+
+function uniqueSorted(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right, 'en'))
+}
+
+function stringArray(value: unknown): readonly string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string') ? value : []
+}
+
+/** layer mapping and aggregate split: one element joins exactly one layer of one subdomain */
+function withElement(
+  subdomain: SubdomainFacts | undefined,
+  element: ElementState,
+  ownerName: string | undefined,
+): SubdomainFacts {
+  const layers =
+    subdomain?.layers ??
+    ({
+      entrypoints: { aggregates: [], items: [] },
+      useCases: { aggregates: [], items: [] },
+      domain: { aggregates: [], items: [] },
+    } satisfies SubdomainFacts['layers'])
+  if (element.packageKind === 'use-cases') {
+    return { layers: { ...layers, useCases: { ...layers.useCases, items: [...layers.useCases.items, element] } } }
+  }
+  if (element.packageKind === 'domain-model' || element.packageKind === 'published-language') {
+    return { layers: { ...layers, domain: withDomainElement(layers.domain, element, ownerName) } }
+  }
+  return { layers: { ...layers, entrypoints: { ...layers.entrypoints, items: [...layers.entrypoints.items, element] } } }
+}
+
+function withDomainElement(
+  domain: ArchitectureLayerState,
+  element: ElementState,
+  ownerName: string | undefined,
+): ArchitectureLayerState {
+  if (ownerName !== undefined) {
+    // entity: attaches to its aggregate through aggregateOwnerId (create-or-attach handles link order)
+    const exists = domain.aggregates.some((aggregate) => aggregate.name === ownerName)
+    const aggregates = exists
+      ? domain.aggregates.map((aggregate) =>
+          aggregate.name === ownerName ? { ...aggregate, entities: [...aggregate.entities, element] } : aggregate,
+        )
+      : [
+          ...domain.aggregates,
+          { name: ownerName, packageKind: element.packageKind, entities: [element], methods: [], sourceEvidence: element.sourceEvidence },
+        ]
+    return { ...domain, aggregates }
+  }
+  if (element.role === 'aggregate') {
+    const exists = domain.aggregates.some((aggregate) => aggregate.name === element.name)
+    const aggregates = exists
+      ? domain.aggregates.map((aggregate) =>
+          aggregate.name === element.name
+            ? { ...aggregate, packageKind: element.packageKind, methods: element.methods, sourceEvidence: element.sourceEvidence }
+            : aggregate,
+        )
+      : [
+          ...domain.aggregates,
+          { name: element.name, packageKind: element.packageKind, entities: [], methods: element.methods, sourceEvidence: element.sourceEvidence },
+        ]
+    return { ...domain, aggregates }
+  }
+  return { ...domain, items: [...domain.items, element] }
+}
+```
+
+##### New dependencies
+
+| Dependency | Status | Used by | Purpose |
+|---|---|---|---|
+| `@living-architecture/riviere-schema-published-language` | Existing | `domain-model` (`ArchitectureComparison`, `ArchitectureSource`) | Reuse `RiviereGraph`, `CustomComponent`, `Link`, `SourceLocation`, `parseRiviereGraph` to validate and project graph input into comparison facts. |
+| `@living-architecture/riviere-schema-published-language` | Existing | `published-language` | Reuse `SourceLocation` in `SourceEvidence`. |
+| `@living-architecture/riviere-architecture-published-language` | New | `riviere-architecture-domain-model`, `riviere-architecture-use-cases` | The shared `ArchitectureDiff` contract and `parseArchitectureDiff`; apps consume the types through the use-cases query exports (envelope, results), never directly. |
+| `@living-architecture/riviere-architecture-use-cases` | New | `apps/cli` | The two query use cases, query models, envelope types, failure unions, and loaders; apps may only import subdomain queries. |
+
+##### Code shape
+
+```text
+packages/riviere-architecture/
+├── published-language/src/published-language/
+│   ├── architecture-diff.ts                 contract incl. AggregateDiff.status, affectedAggregates,
+│   │                                        ArchitectureRelationship collection
+│   └── parse-architecture-diff.ts           published-language-parser
+├── domain-model/src/domain/
+│   ├── architecture-source.ts               ArchitectureSource + fact shapes + projection helpers
+│   ├── architecture-element-collection.ts
+│   ├── association-move.ts
+│   ├── architecture-comparison.ts           facade
+│   ├── invalid-architecture-graph-error.ts
+│   ├── entrypoint-layer-comparison.ts
+│   ├── use-case-layer-comparison.ts
+│   ├── domain-layer-comparison.ts           + memberDiff + removedAggregateDiff + aggregateKey
+│   └── subdomain-grouper.ts
+├── use-cases/src/features/architecture-comparison/
+│   ├── queries/{compare-architectures,compare-architectures-input,compare-architectures-result,
+│   │           architecture-diff-result,architecture-graph-load-failure,
+│   │           load-architecture-diff-envelope,load-architecture-diff-envelope-input,
+│   │           load-architecture-diff-envelope-result,architecture-diff-envelope,
+│   │           architecture-diff-envelope-metadata}.ts
+│   └── data-access/
+│       ├── architecture-diff/{architecture-diff-loader,graph-not-found-error,graph-corrupted-error}.ts
+│       └── architecture-diff-envelope/{architecture-diff-envelope-loader,
+│           architecture-diff-envelope-not-found-error,architecture-diff-envelope-corrupted-error}.ts
+apps/cli/src/features/architecture-diff/entrypoint/
+├── generate-pr-architecture-diff/
+│   ├── entrypoint.ts                        commit-hook command; graph + git-context flags from the hook
+│   ├── compose-commit-architecture-diff-envelope.ts
+│   ├── write-architecture-diff-envelope.ts
+│   └── format-architecture-graph-load-failure.ts
+└── publish-pr-architecture-diff/
+    ├── entrypoint.ts                        PR-time Action command
+    ├── with-pull-request-metadata.ts
+    ├── format-architecture-diff-report.ts   + section formatters
+    ├── format-architecture-diff-envelope-load-failure.ts
+    ├── write-published-architecture-diff-envelope.ts
+    └── write-architecture-diff-report.ts
+apps/eclair/src/features/pr-diff/...         boundary only; feature design deferred
+.githooks/ + .github/workflows/               hook script and PR workflow steps (outside enforced packages)
+```
+
+No file of this feature remains in `apps/cli/src/infra/cli/presentation/`: the complete-diff and load-failure formatters consume the subdomain queries contract, which root infra cannot import.
+
+##### Runtime call outline
+
+```text
+createGeneratePrArchitectureDiffCommand  (commit-hook phase)
+  ├─ compareArchitectures.execute({ baseGraphPath, headGraphPath })   input built directly from parsed flags
+  │  ├─ architectureDiffLoader.load(input.baseGraphPath, input.headGraphPath)
+  │  │  ├─ readGraphJson(baseGraphPath)                      node:fs existsSync, readFileSync, JSON.parse
+  │  │  ├─ readGraphJson(headGraphPath)                      throws GraphNotFoundError or GraphCorruptedError
+  │  │  └─ architectureDiffResult.parse(baseJson, headJson)
+  │  │     └─ architectureComparison.fromRevisions(baseJson, headJson).compare()
+  │  │        ├─ architectureSource.fromGraph(baseGraph)
+  │  │        ├─ architectureSource.fromGraph(headGraph)
+  │  │        └─ architectureComparison.compare()
+  │  │           ├─ base.applicationElements()
+  │  │           ├─ baseCollection.applicationAssociationChanges(headCollection)
+  │  │           │  └─ associationMove.fromStates(baseState, headState)
+  │  │           ├─ groupSubdomainDiff(base, head)
+  │  │           │  ├─ base.subdomainNames()
+  │  │           │  ├─ head.subdomainNames()
+  │  │           │  ├─ base.subdomain(name)
+  │  │           │  └─ head.subdomain(name)
+  │  │           ├─ compareEntrypointLayer(pair.base, pair.head)      per compared subdomain pair
+  │  │           │  ├─ architectureElementCollection.fromStates(items)
+  │  │           │  ├─ baseCollection.addedIn(headCollection)
+  │  │           │  └─ baseCollection.removedIn(headCollection)
+  │  │           ├─ compareUseCaseLayer(pair.base, pair.head)         per compared subdomain pair
+  │  │           │  ├─ architectureElementCollection.fromStates(items)
+  │  │           │  ├─ baseCollection.addedIn(headCollection)
+  │  │           │  └─ baseCollection.removedIn(headCollection)
+  │  │           └─ compareDomainLayer(pair.base, pair.head)          per compared subdomain pair
+  │  │              ├─ architectureElementCollection.fromStates(items)
+  │  │              ├─ baseCollection.addedIn(headCollection)
+  │  │              ├─ baseCollection.removedIn(headCollection)
+  │  │              ├─ memberDiff(baseAggregate, headAggregate)       sets status created or affected
+  │  │              └─ removedAggregateDiff(baseAggregate)            sets status removed
+  │  └─ toArchitectureGraphLoadFailure(error)                when load threw a data-access error
+  ├─ formatArchitectureGraphLoadFailure(failure)             failure path
+  ├─ composeCommitArchitectureDiffEnvelope(result, commitContext)     success path
+  └─ writeArchitectureDiffEnvelope(envelope, outputPath)     writes .riviere/pr-diffs/riviere-architecture-diff.json
+
+createPublishPrArchitectureDiffCommand  (PR-time Action phase)
+  ├─ loadArchitectureDiffEnvelope.execute({ envelopePathOption })
+  │  ├─ architectureDiffEnvelopeLoader.load(input.envelopePathOption)
+  │  │  ├─ existsSync(envelopePath)                          default .riviere/pr-diffs/riviere-architecture-diff.json
+  │  │  ├─ readFileSync(envelopePath), JSON.parse            throws ArchitectureDiffEnvelopeNotFoundError
+  │  │  │                                                    or ArchitectureDiffEnvelopeCorruptedError
+  │  │  └─ parseArchitectureDiff(envelopeJson.diff)          published-language validation of diff
+  │  └─ toArchitectureDiffEnvelopeLoadFailure(error)         when load threw a data-access error
+  ├─ formatArchitectureDiffEnvelopeLoadFailure(failure)      failure path
+  ├─ withPullRequestMetadata(envelope, pullRequestMetadata)  adds metadata.pullRequest.* only
+  ├─ writePublishedArchitectureDiffEnvelope(publishedEnvelope, envelopePath)
+  ├─ formatArchitectureDiffReport(publishedEnvelope)         GitHub markdown from the envelope
+  └─ writeArchitectureDiffReport(markdown, reportOutput)     report file the workflow posts as the comment
+```
+
+##### Design validation
+
+- Domain terminology: pass — reuses established Rivière terms (`Component`, `Domain`, `Entry Point`, source evidence) and the proof-of-concept comparison vocabulary (`subdomain`, `layer`, `aggregate`, `added`/`removed`, `relatedTo` relationships); `affected`/`created` match the PRD's own wording for the both-sides aggregate rule; `AssociationMove` names the PRD's application association change, and `ArchitectureElementCollection` is flagged above as a proposed term.
+- Application/domain separation: pass — both use cases are try/catch load delegation plus failure mapping only; loaders only read + parse JSON (and validate through the published-language parser); the query models only wrap the facade result; every comparison rule lives in the domain value objects and services; envelope composition, PR-metadata merge, and report formatting are presentation-side. Closed unions are matched exhaustively and domain code uses no TypeScript `in` operator.
+- Role and location fit: pass — every `domain-service` declaration carries a per-declaration `@riviere-role-justification` answering the configured aggregate-first/value-object-second question; shared element diffing lives once on a `value-object`; the facade is consumed by a `query-model`; domain-model imports only published-language; use-cases own file reading/parsing in data-access; both cli-entrypoints build their query inputs directly per the canonical query pattern; all formatters and writers live in feature entrypoint folders where consuming the subdomain queries contract is legal (root infra cannot); envelope writers take a `query-model` input, satisfying `cli-response-writer.allowedInputs`.
+- Implementability: pass — mirrors the existing `ListDomains`/`DomainListLoader`/`query-loaders`/`writeFinalizedGraph` patterns and the POC `generate-pr-architecture-diff` entrypoint/formatter/writer placement; respects ADR-002 and `.riviere/role-enforcement.config.ts` template paths (`packages/{subdomain}/...`), so the new package needs no enforcement-config change; no package imports an app; the PR-time phase implements the approved ARCH.md §2 convention exactly (load the tracked JSON, write `metadata.pullRequest.*`, build the report without recalculating the diff).
+
+##### Open decisions
+
+- `ArchitectureComparison` is a new `domain-facade` instance; `.riviere/roles.ts` lists approved instances (currently only `RiviereQuery`), so this facade requires explicit user approval.
+- The Éclair review page feature design (public PR link resolution, upload-envelope parsing, the approved page) is deliberately deferred, as in earlier rounds: `apps/eclair` is in `unassignedPackages`, and the envelope plus `ArchitectureDiff` published here already fix the contract it must consume.
+- How the commit hook materialises the retained `main` graph before invoking the command (worktree, checkout, or cached artifact) is a delivery-planning decision outside this component design; the command takes explicit `--base-graph`/`--head-graph` paths and invents no path convention.
+
+##### Rejected alternative sub-ideas
+
+- Deferring the PR-time publication phase as an open decision (rejected: approved ARCH.md §2 fully specifies the phase — load the tracked JSON, write `metadata.pullRequest.*`, build the report without recalculating — so a complete implementable design must include it; this correction adds the envelope query, merge formatter, and report writer/writers).
+- The complete-diff formatter in root `infra/cli/presentation` (rejected: ADR-002 states root infra cannot import application or domain code, and `app.ts` gives `/infra` own-subtree-only imports; formatting the complete `ArchitectureDiff` needs the full subdomain contract; the POC keeps its formatter in the feature entrypoint folder).
+- Registering no metadata flags and letting the writer receive only the query result (rejected: nothing would compose the approved `{ metadata, diff }` envelope; the composer with explicit field origins and the `query-model` writer input make every field's provenance named and consistent across prose, table, outline, and stress test).
+- Publishing affected aggregates inside `added.aggregates` with no discriminator (rejected: the PRD requires an aggregate changed on both sides to be named as affected while remaining distinguishable from a newly created aggregate; `AggregateDiff.status` plus the layer's `affectedAggregates` list makes the rule machine-checkable for the GitHub and Éclair summaries).
+- `relatedTo` as a single optional string built from a link map keyed by target (rejected: the POC models `relatedTo` as a canonicalised relationship collection — `canonicalRelationships(item.relatedTo ?? [])` — and a single-valued map keeps only the last link, silently dropping multi-relationship facts and breaking complete-output parity).
+- A single monolithic `Architecture` value object holding all comparison logic (rejected: it grows past a clean single-responsibility boundary and hides the layer-specific rules; the direction requires fine-grained decomposition).
+- Separate `classifyChange` and `resolveSourceEvidence` domain services (rejected per the `look-for-missing-value-objects-before-domain-services` memory: presence labelling is a three-branch check absorbed into `groupSubdomainDiff`, and evidence pairing moved onto `ArchitectureElementCollection`/`AssociationMove` where both revision states meet — value objects own the state they label).
+- `addedItems`/`itemKey` duplicated per layer-comparison file (rejected: sharing across files needs an exported role; a `domain-service` home would create a forbidden domain-service→domain-service dependency — the collection value object is the one legal home).
+- Handling application association moves inside per-subdomain entrypoint layers (rejected: a move pairs an application element across the whole revision pair, so per-layer pairing cannot see it; moves are recorded once in the diff's application section with dual evidence, per the PRD ownership rule).
+- A `command-input-factory` for either query input (rejected: that role may only produce `command-use-case-input`; the canonical "CLI Invoking Query Model Use Case" pattern constructs query inputs in the cli-entrypoint).
+- `ArchitectureSource` wrapping a use-cases `query-model` via `fromState` (rejected: domain-model cannot import use-cases; projection now lives on the value object from the published-language graph, resolving the single-home requirement).
+- `CompareArchitectures` returning an alias of the published-language `ArchitectureDiff` (rejected as an unresolved `forbiddenSupertypes` risk; the use case returns a concrete `query-model` result union wrapping the schema).
+- Letting the app supply already-parsed graphs (rejected: approved ownership assigns loading its inputs to use-cases; the loader now owns the two graph files' read + parse).
+- An `ArchitectureDiffAggregate` + `ArchitectureDiffRepository` (rejected: comparison never mutates persisted state and owns no lifecycle invariant, so aggregate/repository would be a forced fit violating the query-side rule).
+- Resolving source evidence inside the use case (rejected: evidence resolution is domain logic and must stay out of orchestration).
+- Modelling the PR-time merge as a command use case (rejected: the merge adds presentation metadata to an already-generated file at the CLI output boundary; no domain state changes, so the formatter + writer pair is sufficient and matches the `writeFinalizedGraph` precedent).
+
+<!-- component-design-option-3:end -->

--- a/docs/project/PRD/pull-request-diffs/marker.yml
+++ b/docs/project/PRD/pull-request-diffs/marker.yml
@@ -1,0 +1,5 @@
+planningId: pull-request-diffs
+stage: solution-exploration
+githubMilestone: pull-request-diffs
+githubIssuesCreated: false
+githubIssueNumbers: []

--- a/docs/project/PRD/pull-request-diffs/marker.yml
+++ b/docs/project/PRD/pull-request-diffs/marker.yml
@@ -1,5 +1,5 @@
 planningId: pull-request-diffs
-stage: solution-exploration
+stage: architecture-drafting
 githubMilestone: pull-request-diffs
 githubIssuesCreated: false
 githubIssueNumbers: []

--- a/docs/project/PRD/pull-request-diffs/message-flows.md
+++ b/docs/project/PRD/pull-request-diffs/message-flows.md
@@ -1,0 +1,79 @@
+# Option 1: Resolve the retained head diff from the PR
+
+Éclair receives a repository and PR ID rather than a direct file URL. It asks GitHub for the current PR context, uses the returned head repository and commit SHA to load the retained `ArchitectureDiff`, and presents the focused review. This keeps the public link stable as the PR changes while pinning each loaded diff and its source evidence to a specific revision.
+
+```mermaid
+flowchart LR
+  subgraph legend[Legend]
+    direction TB
+    legendActor(["👤<br/>Actor"])
+    legendApp[["App"]]
+    legendSubdomain(["Subdomain"])
+    legendSystem{{"External system"}}
+    legendCommand["Command"]
+    legendEvent["Event"]
+    legendQuery["Query"]
+  end
+
+  subgraph scenario["Scenario: Review a public PR architecture diff in Éclair"]
+    direction LR
+
+    reviewer(["👤<br/><b>PR reviewer</b>"])
+    eclair[["Éclair"]]
+    github{{"GitHub"}}
+
+    m1["1 · View PR"]
+    m2["2 · Open architecture review"]
+    m3["3 · Get PR context"]
+    m4["4 · Get architecture diff"]
+    m5["5 · View source evidence"]
+
+    reviewer --> m1 --> github
+    reviewer --> m2 --> eclair
+    eclair --> m3 --> github
+    eclair --> m4 --> github
+    reviewer --> m5 --> github
+  end
+
+  classDef actor fill:#ffffff,stroke:#374151,color:#111827,stroke-width:2px,font-size:18px;
+  classDef app fill:#ccfbf1,stroke:#0f766e,color:#134e4a,stroke-width:4px,font-size:20px;
+  classDef subdomain fill:#ddd6fe,stroke:#7c3aed,color:#2e1065,stroke-width:4px,font-size:20px;
+  classDef system fill:#f3f4f6,stroke:#374151,color:#111827,stroke-width:3px,font-size:18px;
+  classDef command fill:#7dd3fc,stroke:#0369a1,color:#082f49,stroke-width:2px,font-size:13px;
+  classDef event fill:#fdba74,stroke:#c2410c,color:#431407,stroke-width:2px,font-size:13px;
+  classDef query fill:#d9f99d,stroke:#4d7c0f,color:#1a2e05,stroke-width:2px,font-size:13px;
+
+  class reviewer,legendActor actor;
+  class eclair,legendApp app;
+  class legendSubdomain subdomain;
+  class github,legendSystem system;
+  class legendCommand command;
+  class legendEvent event;
+  class m1,m2,m3,m4,m5,legendQuery query;
+```
+
+## Message details
+
+| # | Type | Message | Sender → recipient | Significant data |
+| ---: | --- | --- | --- | --- |
+| 1 | Query | View PR | PR reviewer → GitHub | Request: repository and PR ID. Response: PR page and architecture review link. |
+| 2 | Query | Open architecture review | PR reviewer → Éclair | Request: repository and PR ID. Response after messages 3 and 4: focused architecture review. |
+| 3 | Query | Get PR context | Éclair → GitHub | Request: repository and PR ID. Response: title, description, PR link, head repository, and head commit SHA. |
+| 4 | Query | Get architecture diff | Éclair → GitHub | Request: head repository, head commit SHA, and `.riviere/pr-diffs/riviere-architecture-diff.json`. Response: `ArchitectureDiff` JSON. |
+| 5 | Query | View source evidence | PR reviewer → GitHub | Request: repository, base or head revision, file path, and source lines. Response: source code at that revision. |
+
+## Pros
+
+- The link needs only the repository and PR ID, so it remains usable when the PR head changes.
+- Resolving `head.repo.full_name` supports PRs raised from forks.
+- Loading the diff from the returned head commit SHA avoids following a moving branch during one review load.
+- Éclair obtains current public PR context without requiring its own backend.
+- The reviewer can move from architecture changes to source evidence at the relevant revision.
+
+## Cons
+
+- This flow works only for public repositories; private repositories need the separate upload flow.
+- The retained diff must already exist at the conventional path in the PR head commit.
+- Reopening the same link resolves the PR's current head rather than preserving an earlier comparison.
+- The loading failure behaviour remains unresolved when PR metadata or the retained diff cannot be fetched or validated.
+- Diff generation timing and the process that puts the retained diff into the head commit remain unresolved outside this option.

--- a/docs/project/PRD/pull-request-diffs/problem-definition.md
+++ b/docs/project/PRD/pull-request-diffs/problem-definition.md
@@ -1,0 +1,23 @@
+# Problem Definition: Pull Request Diffs
+
+**Status:** Approved
+
+---
+
+## Approved inputs
+
+**Section approval:** Approved
+
+- Who: Developers and maintainers reviewing changes made by AI agents, plus principal engineers and architects who need to track architecture outside the immediate team.
+- What: Key architecture and domain model changes do not “jump out”. They are easily missed among hundreds of lines of code and require manual extraction. The working proof of concept is an isolated script which nobody else can use.
+- Where: Primarily during pull request review, but also when comparing any two Rivière graph states to understand architectural evolution.
+- When: Before a pull request is merged, as the last chance to prevent unnoticed architecture mistakes; secondarily, when someone returns after time away and needs to understand how the architecture evolved.
+- Why: Users need to be fully aware of every key architecture and domain model change. Architecture mistakes which pass unnoticed are hard to correct later.
+
+## Problem statement
+
+**Section approval:** Approved
+
+AI agents are doing much of the implementation work, while key architecture and domain model changes can remain hidden among hundreds of lines of code. Developers and maintainers reviewing pull requests may therefore miss important decisions before merge, allowing architecture mistakes to pass unnoticed and become difficult to correct later.
+
+The same visibility problem affects principal engineers and architects who need to understand how architecture evolved across a longer period. A working architecture diff proof of concept exists, but it is an isolated script which nobody except its creator can use.

--- a/docs/project/PRD/pull-request-diffs/prototypes/README.md
+++ b/docs/project/PRD/pull-request-diffs/prototypes/README.md
@@ -1,0 +1,42 @@
+# Pull request architecture diff prototypes
+
+## Rivière graph equivalence and performance benchmark
+
+Run:
+
+```bash
+pnpm exec tsc -p docs/project/PRD/pull-request-diffs/prototypes/tsconfig.json
+docs/project/PRD/pull-request-diffs/prototypes/run-pr-478-architecture-diff-benchmark.sh
+```
+
+The benchmark uses pull request #478:
+
+- base: `3ec31c16fbfd02f91122a8d81f3b26010461cc47`
+- head: `aeb7a001d060556ca5ec5fa6c8830e00a1458c29`
+- published architecture diff: [comment 5454459810](https://github.com/NTCoding/living-architecture/pull/478#issuecomment-5454459810)
+
+It compares the current narrow architecture snapshots with valid `fine-grained-role-graph` fixtures containing the same architecture review facts. It fails unless:
+
+1. the graph path produces byte identical Markdown to the current snapshot path;
+2. the graph derived facts rendered in the original PR #478 format match the published comment, apart from trailing blank lines;
+3. output remains equivalent at 1×, 2×, 5×, and 10× the PR #478 fact set.
+
+Generated results are written under `results/`. The runner also measures the snapshot and graph paths in isolated processes with `/usr/bin/time -l`, so their peak memory can be compared without one approach retaining the other's allocations.
+
+## What this proves
+
+- A `fine-grained-role-graph` can represent enough information to reproduce the working architecture diff.
+- The diff does not need every dependency in the repository. The prototype graph contains role elements plus only aggregate ownership and supporting element relationships used by the current diff.
+- The `fine-grained-role-graph` is materially larger and slower to parse than the narrow snapshot representation, despite containing only the required semantic links.
+- The existing `high-level graph` can remain selective and focused on flows and key concepts.
+
+## What this does not prove
+
+- The repository's `high-level graph` contains all role annotated declarations required by the architecture diff.
+- A graph with every role annotated class and method is acceptably fast to extract directly.
+- A Rivière workflow can generate the required `fine-grained-role-graph` facts efficiently without using the disposable architecture snapshot as an intermediate.
+- Code diff guided extraction can preserve complete ownership and relationship changes.
+
+The current role enforcement command cannot yet act as the architecture diff source. Its public result contains duration, exit code, standard output, and standard error, but no role inventory or relationship model. Its internal analysis may still be reusable in a future design.
+
+Direct workflow generation is deliberately deferred to the first delivery ticket. That ticket must reproduce pull request #478 exactly and measure elapsed time, peak memory, and generated graph size before later delivery work relies on the extraction path.

--- a/docs/project/PRD/pull-request-diffs/prototypes/architecture-diff-visual-mockups.html
+++ b/docs/project/PRD/pull-request-diffs/prototypes/architecture-diff-visual-mockups.html
@@ -1,0 +1,3042 @@
+<!DOCTYPE html><html lang="en"><head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Pull request architecture changes</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&amp;family=Lato:wght@400;700&amp;family=Rubik:wght@500;600;700&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/@phosphor-icons/web@2.0.3/src/regular/style.css">
+    <style>
+      :root {
+        --primary: #0d9488;
+        --primary-dark: #06b6d4;
+        --bg-primary: #f8fafc;
+        --bg-secondary: #ffffff;
+        --bg-tertiary: #f1f5f9;
+        --border-color: #e2e8f0;
+        --text-primary: #1e293b;
+        --text-secondary: #334155;
+        --text-tertiary: #64748b;
+        --accent: #ff6b6b;
+        --radius: 12px;
+        --flow-gradient: linear-gradient(90deg, #0d9488 0%, #06b6d4 100%);
+        --github-canvas: #ffffff;
+        --github-subtle: #f6f8fa;
+        --github-border: #d0d7de;
+        --github-text: #1f2328;
+        --github-muted: #656d76;
+        --github-link: #0969da;
+        --green: #1a7f37;
+        --green-soft: #dafbe1;
+        --red: #cf222e;
+        --red-soft: #ffebe9;
+        --heading: 'Rubik', sans-serif;
+        --body: 'Lato', sans-serif;
+        --mono:
+          ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, 'Liberation Mono', monospace;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        scroll-behavior: smooth;
+      }
+      body {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        font-family: var(--body);
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      button {
+        font: inherit;
+      }
+      .app-shell {
+        display: flex;
+        height: 100vh;
+        overflow: hidden;
+      }
+      .sidebar {
+        background: var(--bg-secondary);
+        border-right: 1px solid var(--border-color);
+        display: flex;
+        flex: 0 0 240px;
+        flex-direction: column;
+        overflow: hidden;
+        transition: flex-basis 0.3s ease;
+      }
+      .sidebar.collapsed {
+        flex-basis: 64px;
+      }
+      .sidebar-brand {
+        align-items: center;
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        flex: 0 0 64px;
+        gap: 10px;
+        padding: 0 20px;
+      }
+      .sidebar.collapsed .sidebar-brand {
+        justify-content: center;
+        padding: 0;
+      }
+      .logo {
+        flex: 0 0 36px;
+        height: 36px;
+        width: 36px;
+      }
+      .logo-text {
+        background: var(--flow-gradient);
+        background-clip: text;
+        color: var(--primary);
+        font-family: var(--heading);
+        font-size: 18px;
+        font-weight: 600;
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+      .sidebar-nav {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        gap: 4px;
+        padding: 16px 12px;
+      }
+      .nav-item {
+        align-items: center;
+        border-radius: 12px;
+        color: var(--text-secondary);
+        display: flex;
+        flex: 0 0 40px;
+        font-size: 14px;
+        gap: 12px;
+        padding: 0 12px;
+        text-decoration: none;
+      }
+      .nav-item i {
+        flex: 0 0 18px;
+        font-size: 18px;
+        text-align: center;
+      }
+      .nav-item:hover,
+      .nav-item.active {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+      }
+      .nav-item.active {
+        color: var(--primary);
+        font-weight: 500;
+      }
+      .nav-divider {
+        border-top: 1px solid var(--border-color);
+        margin: 8px 0;
+      }
+      .sidebar-collapse {
+        align-items: center;
+        background: transparent;
+        border: 0;
+        border-radius: 12px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        display: flex;
+        gap: 8px;
+        justify-content: center;
+        margin: 0 12px 12px;
+        min-height: 40px;
+      }
+      .sidebar-collapse:hover {
+        background: var(--bg-tertiary);
+      }
+      .sidebar.collapsed .logo-text,
+      .sidebar.collapsed .nav-label,
+      .sidebar.collapsed .collapse-label {
+        display: none;
+      }
+      .sidebar.collapsed .nav-item {
+        justify-content: center;
+        padding: 0;
+      }
+      .workspace {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        min-width: 0;
+        overflow: hidden;
+      }
+      .topbar {
+        align-items: center;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-color);
+        display: flex;
+        flex: 0 0 64px;
+        padding: 0 32px;
+      }
+      .page-title {
+        color: var(--text-primary);
+        font-family: var(--heading);
+        font-size: 16px;
+        font-weight: 700;
+      }
+      .scroll-region {
+        background: var(--github-canvas);
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        scroll-behavior: auto;
+      }
+      .content {
+        color: var(--github-text);
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        margin: 0 auto;
+        max-width: 1180px;
+        padding: 24px 32px 72px;
+        width: 100%;
+      }
+      code {
+        font-family: var(--mono);
+      }
+      a:focus-visible,
+      summary:focus-visible {
+        outline: 2px solid var(--primary);
+        outline-offset: 2px;
+      }
+      .pr-context {
+        border-bottom: 1px solid var(--github-border);
+        margin-bottom: 24px;
+        padding-bottom: 20px;
+      }
+      .pr-title {
+        align-items: baseline;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px 10px;
+        margin-bottom: 6px;
+      }
+      .pr-title a,
+      .pr-links a {
+        color: var(--github-link);
+        font-size: 14px;
+        font-weight: 600;
+        text-decoration: none;
+      }
+      .pr-title a:hover,
+      .pr-links a:hover,
+      .code-link:hover,
+      .view-code:hover {
+        text-decoration: underline;
+      }
+      .pr-title strong {
+        color: var(--github-text);
+        font-size: 18px;
+        font-weight: 600;
+      }
+      .pr-links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px 16px;
+        margin-bottom: 12px;
+      }
+      .pr-description {
+        border: 1px solid var(--github-border);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+      .pr-description summary {
+        background: var(--github-subtle);
+        color: var(--github-text);
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 600;
+        padding: 9px 12px;
+      }
+      .pr-description[open] summary {
+        border-bottom: 1px solid var(--github-border);
+      }
+      .pr-description-body {
+        color: var(--github-text);
+        font-size: 15px;
+        padding: 16px 18px 18px;
+      }
+      .pr-description-body p {
+        margin: 0 0 14px;
+      }
+      .pr-description-body a {
+        color: var(--github-link);
+        text-decoration: none;
+      }
+      .pr-description-body h2 {
+        border-bottom: 1px solid var(--github-border);
+        font-size: 17px;
+        margin: 20px 0 10px;
+        padding-bottom: 5px;
+      }
+      .pr-description-body ul {
+        padding-left: 28px;
+      }
+      .pr-description-body li {
+        margin: 4px 0;
+      }
+      .changed-subdomains {
+        margin-bottom: 28px;
+      }
+      .changed-subdomains h2 {
+        color: var(--github-muted);
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 8px;
+      }
+      .changed-subdomains ul {
+        border: 1px solid var(--github-border);
+        border-radius: 6px;
+        list-style: none;
+        overflow: hidden;
+      }
+      .changed-subdomains li + li {
+        border-top: 1px solid var(--github-border);
+      }
+      .changed-subdomains a {
+        align-items: center;
+        background: var(--github-canvas);
+        color: var(--github-link);
+        display: grid;
+        font-size: 14px;
+        gap: 9px;
+        grid-template-columns: 18px minmax(0, 1fr) 18px;
+        padding: 9px 12px;
+        text-decoration: none;
+      }
+      .changed-subdomains a:hover {
+        background: var(--github-subtle);
+      }
+      .changed-subdomains a i:last-child {
+        color: var(--github-muted);
+      }
+      .subdomain-section {
+        border: 1px solid var(--github-border);
+        border-radius: 6px;
+        margin-top: 28px;
+        overflow: hidden;
+        scroll-margin-top: 16px;
+      }
+      .subdomain-section > h2 {
+        background: var(--github-subtle);
+        border-bottom: 1px solid var(--github-border);
+        font-size: 19px;
+        font-weight: 600;
+        padding: 12px 16px;
+      }
+      .subdomain-section > h2 code {
+        color: var(--github-link);
+        font-size: 16px;
+      }
+      .architecture-layer {
+        padding: 18px 16px;
+      }
+      .architecture-layer + .architecture-layer {
+        border-top: 1px solid var(--github-border);
+      }
+      .architecture-layer > h3 {
+        border-bottom: 1px solid var(--github-border);
+        font-size: 17px;
+        font-weight: 600;
+        margin-bottom: 14px;
+        padding-bottom: 6px;
+      }
+      .change-section + .change-section {
+        border-top: 1px solid var(--github-border);
+        margin-top: 20px;
+        padding-top: 18px;
+      }
+      .change-section > h4 {
+        border-left: 3px solid currentColor;
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 9px;
+        padding-left: 8px;
+      }
+      .change-section.added > h4 {
+        color: var(--green);
+      }
+      .change-section.removed > h4 {
+        color: var(--red);
+      }
+      .aggregate-card {
+        border: 1px solid var(--github-border);
+        border-radius: 6px;
+        margin-bottom: 12px;
+        overflow: hidden;
+      }
+      .aggregate-header {
+        background: var(--github-subtle);
+        border-bottom: 1px solid var(--github-border);
+        display: grid;
+        gap: 8px 16px;
+        grid-template-columns: minmax(180px, 2fr) minmax(110px, 1fr) minmax(140px, 1fr) 90px;
+        padding: 8px 10px;
+      }
+      .aggregate-field {
+        min-width: 0;
+      }
+      .aggregate-field span {
+        color: var(--github-muted);
+        display: block;
+        font-size: 11px;
+        font-weight: 600;
+        margin-bottom: 2px;
+      }
+      .aggregate-field code {
+        color: var(--github-text);
+        display: block;
+        font-size: 13px;
+        overflow-wrap: anywhere;
+      }
+      .code-link,
+      .view-code {
+        color: var(--github-link);
+        text-decoration: none;
+      }
+      .view-code {
+        display: inline-block;
+        font-size: 13px;
+      }
+      .aggregate-group strong,
+      .aggregate-group summary {
+        background: var(--github-subtle);
+        color: var(--github-muted);
+        display: block;
+        font-size: 13px;
+        font-weight: 600;
+        padding: 7px 10px;
+      }
+      details.aggregate-group summary {
+        cursor: pointer;
+      }
+      .aggregate-group ul {
+        display: block;
+        list-style: none;
+      }
+      .aggregate-group li {
+        align-items: baseline;
+        display: grid;
+        grid-template-columns: 28px minmax(0, 1fr);
+        padding: 5px 10px 5px 0;
+      }
+      .aggregate-group li::before {
+        font-family: var(--mono);
+        text-align: center;
+      }
+      .change-section.removed .aggregate-group li {
+        background: var(--red-soft);
+      }
+      .change-section.removed .aggregate-group li::before {
+        color: var(--red);
+        content: '−';
+      }
+      .change-section.added .aggregate-group li {
+        background: var(--green-soft);
+      }
+      .change-section.added .aggregate-group li::before {
+        color: var(--green);
+        content: '+';
+      }
+      .aggregate-group li code {
+        color: var(--github-text);
+        display: block;
+        font-size: 13px;
+        white-space: nowrap;
+      }
+      .table-wrap {
+        border: 1px solid var(--github-border);
+        border-radius: 6px;
+        overflow-x: auto;
+      }
+      table {
+        border-collapse: collapse;
+        min-width: 680px;
+        width: 100%;
+      }
+      th,
+      td {
+        border-bottom: 1px solid var(--github-border);
+        padding: 7px 10px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: var(--github-subtle);
+        color: var(--github-muted);
+        font-size: 12px;
+        font-weight: 600;
+      }
+      td {
+        color: var(--github-text);
+        font-size: 13px;
+      }
+      td code {
+        white-space: nowrap;
+      }
+      .change-section.added tbody tr {
+        background: var(--green-soft);
+      }
+      .change-section.removed tbody tr {
+        background: var(--red-soft);
+      }
+      tbody tr:last-child td {
+        border-bottom: 0;
+      }
+      tbody tr:hover {
+        filter: brightness(0.98);
+      }
+      @media (max-width: 768px) {
+        .sidebar {
+          flex-basis: 64px;
+        }
+        .sidebar .logo-text,
+        .sidebar .nav-label,
+        .sidebar .collapse-label {
+          display: none;
+        }
+        .sidebar .sidebar-brand,
+        .sidebar .nav-item {
+          justify-content: center;
+          padding-left: 0;
+          padding-right: 0;
+        }
+        .topbar {
+          padding: 0 16px;
+        }
+        .page-title {
+          font-size: 15px;
+        }
+        .content {
+          padding: 20px 16px 56px;
+        }
+        .pr-title {
+          display: block;
+        }
+        .pr-title strong {
+          display: block;
+          margin-top: 4px;
+        }
+        .aggregate-header {
+          grid-template-columns: 1fr;
+        }
+        table {
+          min-width: 680px;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        html,
+        .scroll-region {
+          scroll-behavior: auto;
+        }
+      }
+    </style>
+  <style id="eclair-diff-styles">
+  .scroll-region { background: var(--bg-primary); }
+  .content { color: var(--text-primary); font-family: var(--body); max-width: 1180px; padding: 24px; }
+  .content a { color: var(--primary); }
+  .pr-context { border: 0; margin: 0 0 20px; padding: 0; }
+  .pr-title { margin-bottom: 10px; }
+  .pr-title a { color: var(--primary); font-family: var(--heading); font-size: 13px; }
+  .pr-title strong { color: var(--text-primary); font-family: var(--heading); font-size: 20px; }
+  .pr-description { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: var(--radius); }
+  .pr-description summary { align-items: center; background: transparent; color: var(--text-secondary); display: flex; font-family: var(--body); font-size: 14px; gap: 8px; list-style: none; padding: 10px 14px; }
+  .pr-description summary::-webkit-details-marker,
+  .subdomain-summary::-webkit-details-marker,
+  .layer-summary::-webkit-details-marker,
+  .aggregate-group summary::-webkit-details-marker,
+  .use-case-summary::-webkit-details-marker,
+  .supporting-summary::-webkit-details-marker { display: none; }
+  .pr-description[open] summary { background: var(--bg-tertiary); border-bottom: 1px solid var(--border-color); }
+  .pr-description-body { background: var(--bg-secondary); color: var(--text-secondary); font-family: var(--body); font-size: 14px; padding: 16px; }
+  .pr-description-body h2 { border: 0; color: var(--text-primary); font-family: var(--heading); font-size: 16px; margin: 18px 0 8px; padding: 0; }
+  .disclosure-caret { color: var(--text-tertiary); flex: 0 0 auto; transition: transform .2s ease; }
+  details[open] > summary > .disclosure-caret { transform: rotate(90deg); }
+  .diff-summary { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: var(--radius); margin-bottom: 28px; overflow: hidden; }
+  .summary-facts { align-items: center; background: var(--bg-tertiary); border-bottom: 1px solid var(--border-color); color: var(--text-secondary); display: flex; flex-wrap: wrap; font-size: 13px; gap: 7px 20px; padding: 11px 16px; }
+  .summary-facts span { align-items: center; display: inline-flex; gap: 6px; }
+  .summary-facts i { color: var(--primary); font-size: 16px; }
+  .subdomain-summary-wrap { overflow-x: auto; }
+  .subdomain-summary-table { min-width: 900px; }
+  .subdomain-summary-table th { background: var(--bg-secondary); }
+  .subdomain-summary-table td { vertical-align: top; }
+  .subdomain-summary-table td:first-child { width: 190px; }
+  .subdomain-summary-table td:nth-child(2) { color: var(--text-tertiary); width: 80px; }
+  .subdomain-summary-table td:nth-child(3) { width: 170px; }
+  .subdomain-summary-table td::before { display: none; }
+  .subdomain-summary-table .subdomain-name { color: var(--text-primary); font-size: 13px; font-weight: 600; }
+  .summary-package-list { display: flex; flex-direction: column; gap: 3px; list-style: none; }
+  .summary-package-list li { align-items: baseline; display: flex; gap: 7px; justify-content: space-between; }
+  .summary-package-list code { color: var(--text-secondary); font-size: 12px; }
+  .summary-package-list strong { font-family: var(--mono); font-size: 12px; white-space: nowrap; }
+  .summary-package-list.added strong { color: var(--green); }
+  .summary-package-list.removed strong { color: var(--accent); }
+  .summary-aggregate { display: block; }
+  .summary-aggregate code { color: var(--text-primary); font-size: 12px; font-weight: 600; }
+  .summary-aggregate span { color: var(--text-tertiary); display: block; font-size: 11px; margin-top: 1px; }
+  .summary-empty { color: var(--text-tertiary); }
+  .application-group,
+  .subdomain-group { margin-top: 22px; scroll-margin-top: 16px; }
+  .application-summary,
+  .subdomain-summary { align-items: center; cursor: pointer; display: flex; gap: 10px; list-style: none; min-height: 52px; }
+  .application-summary::-webkit-details-marker { display: none; }
+  .application-icon,
+  .subdomain-icon { align-items: center; background: var(--flow-gradient); border-radius: 10px; color: white; display: flex; flex: 0 0 38px; height: 38px; justify-content: center; }
+  .application-summary-text,
+  .subdomain-summary-text { min-width: 0; }
+  .application-label,
+  .subdomain-label { color: var(--text-tertiary); display: block; font-size: 10px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+  .application-summary h2,
+  .subdomain-summary h2 { color: var(--text-primary); font-family: var(--heading); font-size: 19px; margin: 0; overflow-wrap: anywhere; }
+  .change-totals { display: flex; font-family: var(--mono); font-size: 12px; gap: 10px; margin-left: auto; }
+  .added-total { color: var(--green); }
+  .removed-total { color: var(--accent); }
+  .application-content,
+  .subdomain-content { display: grid; gap: 10px; padding: 10px 0 6px 48px; }
+  .reassignment-context { align-items: center; background: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: calc(var(--radius) / 2); color: var(--text-secondary); display: flex; flex-wrap: wrap; font-size: 13px; gap: 8px; margin-bottom: 14px; padding: 9px 11px; }
+  .reassignment-context code { color: var(--text-primary); font-size: 12px; }
+  .reassignment-context i { color: var(--text-tertiary); }
+  .application-entrypoint-list { border: 1px solid var(--border-color); border-radius: calc(var(--radius) / 2); overflow: hidden; }
+  .application-entrypoint + .application-entrypoint { border-top: 1px solid var(--border-color); }
+  .application-entrypoint-summary { align-items: center; background: var(--bg-secondary); cursor: pointer; display: flex; gap: 8px; list-style: none; min-height: 43px; padding: 8px 11px; }
+  .application-entrypoint-summary::-webkit-details-marker { display: none; }
+  .application-entrypoint-summary:hover { background: var(--bg-tertiary); }
+  .application-entrypoint-summary .code-link { font-weight: 600; }
+  .application-entrypoint-meta { color: var(--text-tertiary); font-size: 11px; margin-left: auto; }
+  .application-entrypoint-body { border-top: 1px solid var(--border-color); }
+  .entrypoint-evidence { align-items: center; background: var(--bg-tertiary); color: var(--text-secondary); display: flex; flex-wrap: wrap; font-size: 12px; gap: 7px 14px; padding: 8px 11px; }
+  .entrypoint-evidence strong { color: var(--text-tertiary); font-size: 10px; letter-spacing: .03em; text-transform: uppercase; }
+  .evidence-link { color: var(--primary); font-size: 12px; font-weight: 600; text-decoration: none; }
+  .supporting-elements { border-top: 1px solid var(--border-color); }
+  .supporting-elements h6 { background: var(--bg-tertiary); color: var(--text-tertiary); font-size: 10px; letter-spacing: .04em; padding: 7px 11px; text-transform: uppercase; }
+  .application-entrypoint-body .table-wrap { border: 0; border-radius: 0; }
+  .application-entrypoint-body table { min-width: 560px; }
+  .application-entrypoint-body th { background: var(--bg-secondary); }
+  .application-entrypoint-body td:last-child { white-space: nowrap; }
+  .layer-card { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: var(--radius); overflow: hidden; }
+  .layer-summary { align-items: center; cursor: pointer; display: flex; gap: 10px; list-style: none; min-height: 54px; padding: 10px 14px; transition: background .2s ease; }
+  .layer-summary:hover { background: var(--bg-tertiary); }
+  .layer-summary-text { min-width: 0; }
+  .layer-summary h3 { color: var(--text-primary); font-family: var(--heading); font-size: 15px; margin: 0; }
+  .layer-packages { color: var(--text-tertiary); display: block; font-family: var(--mono); font-size: 11px; margin-top: 1px; }
+  .layer-body { border-top: 1px solid var(--border-color); padding: 14px; }
+  .change-section + .change-section { border-top: 1px solid var(--border-color); margin-top: 18px; padding-top: 16px; }
+  .change-section > h4 { border: 0; color: var(--text-secondary); font-family: var(--heading); font-size: 12px; letter-spacing: .04em; margin: 0 0 9px; padding: 0; text-transform: uppercase; }
+  .change-section.added > h4 { color: var(--green); }
+  .change-section.removed > h4 { color: var(--accent); }
+  .package-group { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: calc(var(--radius) / 2); overflow: hidden; }
+  .package-header { align-items: center; background: var(--bg-tertiary); color: var(--text-secondary); cursor: pointer; display: flex; gap: 7px; list-style: none; min-height: 40px; padding: 7px 10px; }
+  .package-header::-webkit-details-marker { display: none; }
+  .package-group[open] > .package-header { border-bottom: 1px solid var(--border-color); }
+  .package-header > i:not(.disclosure-caret) { color: var(--primary); }
+  .package-header span { color: var(--text-tertiary); font-size: 11px; font-weight: 700; text-transform: uppercase; }
+  .package-header code { color: var(--text-primary); font-size: 12px; font-weight: 600; }
+  .package-change-count { color: var(--text-tertiary) !important; font-family: var(--mono); font-size: 11px !important; font-weight: 500 !important; margin-left: auto; text-transform: none !important; }
+  .aggregate-card { border: 0; border-bottom: 1px solid var(--border-color); border-radius: 0; margin: 0; }
+  .aggregate-header { background: var(--bg-secondary); border-bottom: 0; display: grid; gap: 8px 16px; grid-template-columns: minmax(180px, 2fr) minmax(110px, 1fr) minmax(140px, 1fr); padding: 11px 12px; }
+  .aggregate-field span { color: var(--text-tertiary); font-size: 10px; text-transform: uppercase; }
+  .aggregate-field code { color: var(--text-primary); font-size: 13px; }
+  .code-link { color: var(--primary); text-decoration: none; }
+  .aggregate-group { border-top: 1px solid var(--border-color); }
+  .aggregate-group summary { align-items: center; background: var(--bg-tertiary); color: var(--text-secondary); cursor: pointer; display: flex; font-size: 12px; font-weight: 700; gap: 7px; list-style: none; padding: 8px 11px; }
+  .aggregate-group li { align-items: baseline; background: var(--bg-secondary) !important; border-top: 1px solid var(--border-color); display: grid; grid-template-columns: 26px minmax(0, 1fr); padding: 6px 10px 6px 0; }
+  .aggregate-group li::before { color: var(--text-tertiary) !important; content: '·' !important; font-family: var(--mono); text-align: center; }
+  .aggregate-group li code { color: var(--text-primary); font-size: 13px; white-space: nowrap; }
+  .use-case-category + .use-case-category,
+  .supporting-group { margin-top: 14px; }
+  .use-case-category-title { color: var(--text-secondary); font-family: var(--heading); font-size: 12px; letter-spacing: .03em; margin: 0 0 7px; text-transform: uppercase; }
+  .use-case-list { border: 1px solid var(--border-color); border-radius: calc(var(--radius) / 2); overflow: hidden; }
+  .use-case-group + .use-case-group { border-top: 1px solid var(--border-color); }
+  .use-case-summary,
+  .supporting-summary { align-items: center; background: var(--bg-secondary); cursor: pointer; display: flex; gap: 8px; list-style: none; min-height: 43px; padding: 8px 11px; }
+  .use-case-summary:hover,
+  .supporting-summary:hover { background: var(--bg-tertiary); }
+  .use-case-summary .code-link { font-weight: 600; }
+  .use-case-role { color: var(--text-tertiary); font-size: 11px; margin-left: 2px; }
+  .use-case-count { color: var(--text-tertiary); font-size: 12px; margin-left: auto; white-space: nowrap; }
+  .use-case-body { border-top: 1px solid var(--border-color); }
+  .use-case-body .table-wrap,
+  .supporting-group .table-wrap { border: 0; border-radius: 0; }
+  .use-case-body table,
+  .supporting-group table { min-width: 480px; }
+  .use-case-body th,
+  .supporting-group th { background: var(--bg-tertiary); }
+  .supporting-group { border: 1px solid var(--border-color); border-radius: calc(var(--radius) / 2); overflow: hidden; }
+  .supporting-summary strong { color: var(--text-secondary); font-size: 13px; }
+  .supporting-summary .use-case-count { font-weight: 400; }
+  .table-wrap { border: 1px solid var(--border-color); border-radius: calc(var(--radius) / 2); overflow-x: auto; }
+  .package-group .table-wrap { border: 0; border-radius: 0; }
+  table { border-collapse: collapse; min-width: 560px; width: 100%; }
+  th, td { border-bottom: 1px solid var(--border-color); padding: 8px 11px; text-align: left; }
+  th { background: var(--bg-tertiary); color: var(--text-tertiary); font-size: 11px; font-weight: 700; text-transform: uppercase; }
+  td { background: var(--bg-secondary) !important; color: var(--text-primary); font-size: 13px; }
+  .change-section.added tbody td:first-child { border-left: 3px solid var(--green); }
+  .change-section.removed tbody td:first-child { border-left: 3px solid var(--accent); }
+  tbody tr:last-child td { border-bottom: 0; }
+  tbody tr:hover td { background: var(--bg-tertiary) !important; }
+  @media (max-width: 840px) {
+    .summary-facts { align-items: flex-start; flex-direction: column; }
+  }
+  @media (max-width: 768px) {
+    .content { padding: 20px 16px 48px; }
+    .pr-title { display: block; }
+    .pr-title strong { display: block; margin-top: 4px; }
+    .subdomain-summary-wrap { overflow: visible; }
+    .subdomain-summary-table,
+    .subdomain-summary-table tbody { display: block; min-width: 0; }
+    .subdomain-summary-table thead { display: none; }
+    .subdomain-summary-table tbody tr { border-bottom: 1px solid var(--border-color); display: block; padding: 10px 11px; }
+    .subdomain-summary-table tbody tr:last-child { border-bottom: 0; }
+    .subdomain-summary-table tbody td { align-items: start; border: 0; display: grid; gap: 8px; grid-template-columns: 60px minmax(0, 1fr); padding: 3px 0; width: auto; }
+    .subdomain-summary-table tbody td::before { color: var(--text-tertiary); content: attr(data-label); display: block; font-size: 10px; font-weight: 700; letter-spacing: .03em; text-transform: uppercase; }
+    .subdomain-summary-table tbody td:first-child { display: block; margin-bottom: 3px; }
+    .subdomain-summary-table tbody td:first-child::before { display: none; }
+    .summary-package-list { gap: 2px; }
+    .application-content,
+    .subdomain-content { padding-left: 0; }
+    .application-entrypoint-meta { flex: 0 0 100%; margin-left: 24px; }
+    .aggregate-header { grid-template-columns: 1fr; }
+    .use-case-summary { align-items: flex-start; flex-wrap: wrap; }
+    .use-case-count { flex: 0 0 100%; margin-left: 24px; }
+  }
+</style></head>
+  <body>
+    <div class="app-shell">
+      <aside class="sidebar" id="sidebar">
+        <div class="sidebar-brand">
+          <svg class="logo" viewBox="0 0 40 40" fill="none" aria-label="Éclair">
+            <defs>
+              <linearGradient id="logo-gradient" x1="0" y1="0" x2="40" y2="40">
+                <stop offset="0%" stop-color="#0D9488"></stop>
+                <stop offset="100%" stop-color="#06B6D4"></stop>
+              </linearGradient>
+            </defs>
+            <rect width="40" height="40" rx="12" fill="url(#logo-gradient)"></rect>
+            <circle cx="12" cy="12" r="2.5" fill="white"></circle>
+            <circle cx="28" cy="12" r="2.5" fill="white"></circle>
+            <circle cx="20" cy="20" r="3.5" fill="white"></circle>
+            <circle cx="12" cy="28" r="2.5" fill="white" opacity="0.8"></circle>
+            <circle cx="28" cy="28" r="2.5" fill="white" opacity="0.8"></circle>
+            <line x1="12" y1="12" x2="20" y2="20" stroke="white" stroke-width="1.5" opacity="0.8"></line>
+            <line x1="28" y1="12" x2="20" y2="20" stroke="white" stroke-width="1.5" opacity="0.8"></line>
+            <line x1="20" y1="20" x2="12" y2="28" stroke="white" stroke-width="1.5" opacity="0.6"></line>
+            <line x1="20" y1="20" x2="28" y2="28" stroke="white" stroke-width="1.5" opacity="0.6"></line>
+          </svg>
+          <span class="logo-text">Éclair</span>
+        </div>
+        <nav class="sidebar-nav" aria-label="Primary navigation">
+          <a class="nav-item" href="#"><i class="ph ph-house" aria-hidden="true"></i><span class="nav-label">Overview</span></a>
+          <a class="nav-item" href="#"><i class="ph ph-flow-arrow" aria-hidden="true"></i><span class="nav-label">Flows</span></a>
+          <a class="nav-item" href="#"><i class="ph ph-circles-three" aria-hidden="true"></i><span class="nav-label">Domain Map</span></a>
+          <a class="nav-item" href="#"><i class="ph ph-graph" aria-hidden="true"></i><span class="nav-label">Full Graph</span></a>
+          <a class="nav-item" href="#"><i class="ph ph-cube" aria-hidden="true"></i><span class="nav-label">Entities</span></a>
+          <a class="nav-item" href="#"><i class="ph ph-stack" aria-hidden="true"></i><span class="nav-label">Modules</span></a>
+          <a class="nav-item" href="#"><i class="ph ph-broadcast" aria-hidden="true"></i><span class="nav-label">Events</span></a>
+          <a class="nav-item active" href="#" aria-current="page"><i class="ph ph-git-diff" aria-hidden="true"></i><span class="nav-label">Compare</span></a>
+          <div class="nav-divider"></div>
+          <a class="nav-item" href="https://living-architecture.dev"><i class="ph ph-info" aria-hidden="true"></i><span class="nav-label">About Rivière</span></a>
+        </nav>
+        <button class="sidebar-collapse" id="sidebar-collapse" type="button" aria-label="Collapse sidebar">
+          <i class="ph ph-caret-left" id="collapse-icon" aria-hidden="true"></i><span class="collapse-label">Collapse</span>
+        </button>
+      </aside>
+      <section class="workspace">
+        <header class="topbar">
+          <div class="page-title">Pull request architecture changes</div>
+        </header>
+        <div class="scroll-region">
+          <main class="content">
+            <section class="pr-context">
+              <div class="pr-title">
+                <a href="https://github.com/NTCoding/living-architecture/pull/478" target="_blank" rel="noreferrer">NTCoding/living-architecture · Pull request #478</a>
+                <strong>feat: evolve issue 407 project domain model</strong>
+              </div>
+
+              <details class="pr-description">
+                <summary><i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i><span>Pull request description</span></summary>
+                <div class="pr-description-body">
+                  <p>
+                    Closes
+                    #407
+                  </p>
+                  <h2>What changed</h2>
+                  <ul>
+                    <li>
+                      makes RiviereProject the aggregate for graph commands and workflow rebuilds
+                    </li>
+                    <li>
+                      moves RiviereBuilder and Component into the builder published language as
+                      mutable value objects
+                    </li>
+                    <li>
+                      adds the Workflow entity, workflow loading, ordered accumulated rebuilds,
+                      fresh graph state and failure rollback
+                    </li>
+                    <li>
+                      keeps construction diagnostics on the Builder and moves graph queries to
+                      RiviereQuery
+                    </li>
+                    <li>
+                      retires RiviereBuilderRepository and routes graph commands through
+                      RiviereProjectRepository
+                    </li>
+                    <li>
+                      aligns the issue, PRDs, architecture memory, generated domain guide and role
+                      enforcement
+                    </li>
+                  </ul>
+                  <h2>Verification</h2>
+                  <ul>
+                    <li>CI=true pnpm verify</li>
+                    <li>role enforcement: 0 warnings and 0 errors</li>
+                    <li>CLI: 79 files and 578 tests with 100% coverage</li>
+                    <li>Builder published language: 29 files and 268 tests with 100% coverage</li>
+                    <li>retained the 80,000 component and 80,000 link performance tests</li>
+                  </ul>
+                </div>
+              </details>
+            </section><section class="diff-summary" aria-label="Architecture change summary">
+  <div class="summary-facts">
+    <span><i class="ph ph-circles-three" aria-hidden="true"></i><strong>3</strong> changed subdomains</span>
+    <span><i class="ph ph-package" aria-hidden="true"></i><strong>4</strong> changed packages</span>
+    <span><i class="ph ph-cube" aria-hidden="true"></i><strong>2</strong> affected aggregates</span>
+  </div>
+  <div class="subdomain-summary-wrap">
+    <table class="subdomain-summary-table">
+      <thead>
+        <tr>
+          <th>Subdomain</th>
+          <th>Status</th>
+          <th>Affected aggregates</th>
+          <th>Added</th>
+          <th>Removed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td data-label="Subdomain"><code class="subdomain-name">riviere-builder</code></td>
+          <td data-label="Status">Changed</td>
+          <td data-label="Affected aggregates">
+            <span class="summary-aggregate"><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L90" target="_blank" rel="noreferrer"><code>RiviereBuilder</code></a><span>Removed as aggregate</span></span>
+          </td>
+          <td data-label="Added">
+            <ul class="summary-package-list added">
+              <li><code>use-cases</code><strong>+11</strong></li>
+              <li><code>published-language</code><strong>+46</strong></li>
+            </ul>
+          </td>
+          <td data-label="Removed">
+            <ul class="summary-package-list removed">
+              <li><code>use-cases</code><strong>−68</strong></li>
+              <li><code>domain-model</code><strong>−38</strong></li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td data-label="Subdomain"><code class="subdomain-name">riviere-extract-config</code></td>
+          <td data-label="Status">Changed</td>
+          <td data-label="Affected aggregates"><span class="summary-empty">—</span></td>
+          <td data-label="Added">
+            <ul class="summary-package-list added">
+              <li><code>published-language</code><strong>+11</strong></li>
+            </ul>
+          </td>
+          <td data-label="Removed"><span class="summary-empty">—</span></td>
+        </tr>
+        <tr>
+          <td data-label="Subdomain"><code class="subdomain-name">riviere-extract-ts</code></td>
+          <td data-label="Status">Changed</td>
+          <td data-label="Affected aggregates">
+            <span class="summary-aggregate"><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L33" target="_blank" rel="noreferrer"><code>RiviereProject</code></a><span>Changed</span></span>
+          </td>
+          <td data-label="Added">
+            <ul class="summary-package-list added">
+              <li><code>use-cases</code><strong>+66</strong></li>
+              <li><code>domain-model</code><strong>+5</strong></li>
+            </ul>
+          </td>
+          <td data-label="Removed">
+            <ul class="summary-package-list removed">
+              <li><code>domain-model</code><strong>−3</strong></li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+            <details class="subdomain-group" id="subdomain-riviere-builder" open=""><summary class="subdomain-summary">
+    <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+    <span class="subdomain-icon"><i class="ph ph-circles-three" aria-hidden="true"></i></span>
+    <div class="subdomain-summary-text">
+      <span class="subdomain-label">Subdomain</span>
+      <h2>riviere-builder</h2>
+    </div>
+    <div class="change-totals">
+      <span class="added-total">+57</span>
+      <span class="removed-total">−106</span>
+    </div></summary><div class="subdomain-content"><details class="layer-card"><summary class="layer-summary">
+      <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+      <div class="layer-summary-text">
+        <h3>Entry points</h3>
+
+      </div>
+      <div class="change-totals">
+
+        <span class="removed-total">−34</span>
+      </div></summary><div class="layer-body"><section class="change-section removed">
+                  <h4>Removed</h4>
+
+                  <div class="table-wrap removed">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createAddComponentCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/add-component/entrypoint.ts#L47" target="_blank" rel="noreferrer"><code>createAddComponentCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateAddComponentCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/add-component/entrypoint.ts#L36" target="_blank" rel="noreferrer"><code>CreateAddComponentCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createAddDomainCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/add-domain/entrypoint.ts#L25" target="_blank" rel="noreferrer"><code>createAddDomainCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateAddDomainCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/add-domain/entrypoint.ts#L16" target="_blank" rel="noreferrer"><code>CreateAddDomainCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createAddSourceCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/add-source/entrypoint.ts#L23" target="_blank" rel="noreferrer"><code>createAddSourceCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateAddSourceCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/add-source/entrypoint.ts#L14" target="_blank" rel="noreferrer"><code>CreateAddSourceCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createCheckConsistencyCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/check-consistency/entrypoint.ts#L22" target="_blank" rel="noreferrer"><code>createCheckConsistencyCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateCheckConsistencyCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/check-consistency/entrypoint.ts#L13" target="_blank" rel="noreferrer"><code>CreateCheckConsistencyCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createDefineCustomTypeCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/define-custom-type/entrypoint.ts#L28" target="_blank" rel="noreferrer"><code>createDefineCustomTypeCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateDefineCustomTypeCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/define-custom-type/entrypoint.ts#L18" target="_blank" rel="noreferrer"><code>CreateDefineCustomTypeCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createDefineRelationshipTypeCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/define-relationship-type/entrypoint.ts#L24" target="_blank" rel="noreferrer"><code>createDefineRelationshipTypeCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateDefineRelationshipTypeCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/define-relationship-type/entrypoint.ts#L15" target="_blank" rel="noreferrer"><code>CreateDefineRelationshipTypeCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createEnrichCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/enrich/entrypoint.ts#L34" target="_blank" rel="noreferrer"><code>createEnrichCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateEnrichCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/enrich/entrypoint.ts#L23" target="_blank" rel="noreferrer"><code>CreateEnrichCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createFinalizeCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/finalize/entrypoint.ts#L27" target="_blank" rel="noreferrer"><code>createFinalizeCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateFinalizeCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/finalize/entrypoint.ts#L16" target="_blank" rel="noreferrer"><code>CreateFinalizeCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createFinalizeGraphInput&quot;,&quot;command-input-factory&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/finalize/create-finalize-graph-input.ts#L10" target="_blank" rel="noreferrer"><code>createFinalizeGraphInput</code></a></td>
+                          <td><code>command-input-factory</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createInitCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/init/entrypoint.ts#L32" target="_blank" rel="noreferrer"><code>createInitCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateInitCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/init/entrypoint.ts#L23" target="_blank" rel="noreferrer"><code>CreateInitCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createLinkCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/link/entrypoint.ts#L36" target="_blank" rel="noreferrer"><code>createLinkCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateLinkCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/link/entrypoint.ts#L26" target="_blank" rel="noreferrer"><code>CreateLinkCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createLinkExternalCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/link-external/entrypoint.ts#L27" target="_blank" rel="noreferrer"><code>createLinkExternalCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateLinkExternalCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/link-external/entrypoint.ts#L18" target="_blank" rel="noreferrer"><code>CreateLinkExternalCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createLinkHttpCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/link-http/entrypoint.ts#L29" target="_blank" rel="noreferrer"><code>createLinkHttpCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateLinkHttpCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/link-http/entrypoint.ts#L20" target="_blank" rel="noreferrer"><code>CreateLinkHttpCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;createValidateCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/validate/entrypoint.ts#L22" target="_blank" rel="noreferrer"><code>createValidateCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;CreateValidateCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/validate/entrypoint.ts#L13" target="_blank" rel="noreferrer"><code>CreateValidateCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;parseAddComponentInput&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/add-component/parse-add-component-input.ts#L50" target="_blank" rel="noreferrer"><code>parseAddComponentInput</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;parseDomainJson&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/init/domain-input-parser.ts#L30" target="_blank" rel="noreferrer"><code>parseDomainJson</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;parseLinkSourceLocation&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/link/link-source-location-options.ts#L26" target="_blank" rel="noreferrer"><code>parseLinkSourceLocation</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;parsePropertySpecs&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/define-custom-type/custom-type-parser.ts#L39" target="_blank" rel="noreferrer"><code>parsePropertySpecs</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;parseSignature&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/enrich/signature-parser.ts#L77" target="_blank" rel="noreferrer"><code>parseSignature</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;parseStateChanges&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/enrich/enrichment-parser.ts#L26" target="_blank" rel="noreferrer"><code>parseStateChanges</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Entry points" data-change="Removed" data-values="[&quot;writeFinalizedGraph&quot;,&quot;cli-response-writer&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/apps/cli/src/features/builder/entrypoint/finalize/write-finalized-graph.ts#L5" target="_blank" rel="noreferrer"><code>writeFinalizedGraph</code></a></td>
+                          <td><code>cli-response-writer</code></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </section></div></details><details class="layer-card"><summary class="layer-summary">
+      <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+      <div class="layer-summary-text">
+        <h3>Use cases</h3>
+
+      </div>
+      <div class="change-totals">
+        <span class="added-total">+11</span>
+        <span class="removed-total">−68</span>
+      </div></summary><div class="layer-body"><section class="change-section added">
+                  <h4>Added</h4>
+
+                  <div class="table-wrap added">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ChecklistComponent&quot;,&quot;query-model-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-checklist-result.ts#L2" target="_blank" rel="noreferrer"><code>ChecklistComponent</code></a></td>
+                          <td><code>query-model-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentChecklist&quot;,&quot;query-model-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-checklist.ts#L12" target="_blank" rel="noreferrer"><code>ComponentChecklist</code></a></td>
+                          <td><code>query-model-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentChecklistErrorCode&quot;,&quot;query-model-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-checklist-result.ts#L10" target="_blank" rel="noreferrer"><code>ComponentChecklistErrorCode</code></a></td>
+                          <td><code>query-model-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentChecklistInput&quot;,&quot;query-model-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-checklist-input.ts#L2" target="_blank" rel="noreferrer"><code>ComponentChecklistInput</code></a></td>
+                          <td><code>query-model-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentChecklistLoader&quot;,&quot;query-model-loader&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/data-access/graph/query-loaders.ts#L64" target="_blank" rel="noreferrer"><code>ComponentChecklistLoader</code></a></td>
+                          <td><code>query-model-loader</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentChecklistResult&quot;,&quot;query-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-checklist-result.ts#L25" target="_blank" rel="noreferrer"><code>ComponentChecklistResult</code></a></td>
+                          <td><code>query-model</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentSummary&quot;,&quot;query-model-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-summary.ts#L8" target="_blank" rel="noreferrer"><code>ComponentSummary</code></a></td>
+                          <td><code>query-model-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentSummaryErrorCode&quot;,&quot;query-model-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-summary-result.ts#L5" target="_blank" rel="noreferrer"><code>ComponentSummaryErrorCode</code></a></td>
+                          <td><code>query-model-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentSummaryInput&quot;,&quot;query-model-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-summary-input.ts#L2" target="_blank" rel="noreferrer"><code>ComponentSummaryInput</code></a></td>
+                          <td><code>query-model-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentSummaryLoader&quot;,&quot;query-model-loader&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/data-access/graph/query-loaders.ts#L76" target="_blank" rel="noreferrer"><code>ComponentSummaryLoader</code></a></td>
+                          <td><code>query-model-loader</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Added" data-values="[&quot;ComponentSummaryResult&quot;,&quot;query-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/use-cases/src/features/query/queries/component-summary-result.ts#L16" target="_blank" rel="noreferrer"><code>ComponentSummaryResult</code></a></td>
+                          <td><code>query-model</code></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </section><section class="change-section removed">
+                  <h4>Removed</h4>
+
+                  <div class="table-wrap removed">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddComponent&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-component.ts#L15" target="_blank" rel="noreferrer"><code>AddComponent</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddComponentErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-component-result.ts#L2" target="_blank" rel="noreferrer"><code>AddComponentErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddComponentInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-component-input.ts#L2" target="_blank" rel="noreferrer"><code>AddComponentInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddComponentResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-component-result.ts#L10" target="_blank" rel="noreferrer"><code>AddComponentResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddDomain&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-domain.ts#L10" target="_blank" rel="noreferrer"><code>AddDomain</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddDomainErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-domain-result.ts#L2" target="_blank" rel="noreferrer"><code>AddDomainErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddDomainInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-domain-input.ts#L2" target="_blank" rel="noreferrer"><code>AddDomainInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddDomainResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-domain-result.ts#L9" target="_blank" rel="noreferrer"><code>AddDomainResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddSource&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-source.ts#L8" target="_blank" rel="noreferrer"><code>AddSource</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddSourceErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-source-result.ts#L2" target="_blank" rel="noreferrer"><code>AddSourceErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddSourceInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-source-input.ts#L2" target="_blank" rel="noreferrer"><code>AddSourceInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;AddSourceResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/add-source-result.ts#L5" target="_blank" rel="noreferrer"><code>AddSourceResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;BuilderWarnings&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/check-consistency-result.ts#L7" target="_blank" rel="noreferrer"><code>BuilderWarnings</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;CheckConsistency&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/check-consistency.ts#L8" target="_blank" rel="noreferrer"><code>CheckConsistency</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;CheckConsistencyErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/check-consistency-result.ts#L4" target="_blank" rel="noreferrer"><code>CheckConsistencyErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;CheckConsistencyInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/check-consistency-input.ts#L2" target="_blank" rel="noreferrer"><code>CheckConsistencyInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;CheckConsistencyResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/check-consistency-result.ts#L10" target="_blank" rel="noreferrer"><code>CheckConsistencyResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ChecklistComponent&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-checklist-result.ts#L2" target="_blank" rel="noreferrer"><code>ChecklistComponent</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentChecklist&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-checklist.ts#L13" target="_blank" rel="noreferrer"><code>ComponentChecklist</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentChecklistErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-checklist-result.ts#L10" target="_blank" rel="noreferrer"><code>ComponentChecklistErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentChecklistInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-checklist-input.ts#L2" target="_blank" rel="noreferrer"><code>ComponentChecklistInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentChecklistResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-checklist-result.ts#L13" target="_blank" rel="noreferrer"><code>ComponentChecklistResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentSummary&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-summary.ts#L8" target="_blank" rel="noreferrer"><code>ComponentSummary</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentSummaryErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-summary-result.ts#L4" target="_blank" rel="noreferrer"><code>ComponentSummaryErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentSummaryInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-summary-input.ts#L2" target="_blank" rel="noreferrer"><code>ComponentSummaryInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ComponentSummaryResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/component-summary-result.ts#L7" target="_blank" rel="noreferrer"><code>ComponentSummaryResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineCustomType&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-custom-type.ts#L11" target="_blank" rel="noreferrer"><code>DefineCustomType</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineCustomTypeErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-custom-type-result.ts#L4" target="_blank" rel="noreferrer"><code>DefineCustomTypeErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineCustomTypeInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-custom-type-input.ts#L2" target="_blank" rel="noreferrer"><code>DefineCustomTypeInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineCustomTypeResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-custom-type-result.ts#L7" target="_blank" rel="noreferrer"><code>DefineCustomTypeResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineRelationshipType&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-relationship-type.ts#L12" target="_blank" rel="noreferrer"><code>DefineRelationshipType</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineRelationshipTypeErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-relationship-type-result.ts#L2" target="_blank" rel="noreferrer"><code>DefineRelationshipTypeErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineRelationshipTypeInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-relationship-type-input.ts#L2" target="_blank" rel="noreferrer"><code>DefineRelationshipTypeInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;DefineRelationshipTypeResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/define-relationship-type-result.ts#L8" target="_blank" rel="noreferrer"><code>DefineRelationshipTypeResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;EnrichComponent&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/enrich-component.ts#L10" target="_blank" rel="noreferrer"><code>EnrichComponent</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;EnrichComponentErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/enrich-component-result.ts#L2" target="_blank" rel="noreferrer"><code>EnrichComponentErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;EnrichComponentInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/enrich-component-input.ts#L2" target="_blank" rel="noreferrer"><code>EnrichComponentInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;EnrichComponentResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/enrich-component-result.ts#L9" target="_blank" rel="noreferrer"><code>EnrichComponentResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;FinalizedGraph&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/finalize-graph-result.ts#L7" target="_blank" rel="noreferrer"><code>FinalizedGraph</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;FinalizeGraph&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/finalize-graph.ts#L8" target="_blank" rel="noreferrer"><code>FinalizeGraph</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;FinalizeGraphErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/finalize-graph-result.ts#L4" target="_blank" rel="noreferrer"><code>FinalizeGraphErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;FinalizeGraphInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/finalize-graph-input.ts#L2" target="_blank" rel="noreferrer"><code>FinalizeGraphInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;FinalizeGraphResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/finalize-graph-result.ts#L10" target="_blank" rel="noreferrer"><code>FinalizeGraphResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;InitDomainInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/init-graph-input.ts#L2" target="_blank" rel="noreferrer"><code>InitDomainInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;InitGraph&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/init-graph.ts#L10" target="_blank" rel="noreferrer"><code>InitGraph</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;InitGraphErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/init-graph-result.ts#L2" target="_blank" rel="noreferrer"><code>InitGraphErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;InitGraphInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/init-graph-input.ts#L9" target="_blank" rel="noreferrer"><code>InitGraphInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;InitGraphResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/init-graph-result.ts#L5" target="_blank" rel="noreferrer"><code>InitGraphResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkComponents&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-components.ts#L16" target="_blank" rel="noreferrer"><code>LinkComponents</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkComponentsErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-components-result.ts#L4" target="_blank" rel="noreferrer"><code>LinkComponentsErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkComponentsInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-components-input.ts#L2" target="_blank" rel="noreferrer"><code>LinkComponentsInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkComponentsResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-components-result.ts#L11" target="_blank" rel="noreferrer"><code>LinkComponentsResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkExternal&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-external.ts#L11" target="_blank" rel="noreferrer"><code>LinkExternal</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkExternalErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-external-result.ts#L4" target="_blank" rel="noreferrer"><code>LinkExternalErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkExternalInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-external-input.ts#L2" target="_blank" rel="noreferrer"><code>LinkExternalInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkExternalResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-external-result.ts#L11" target="_blank" rel="noreferrer"><code>LinkExternalResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkHttp&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-http.ts#L18" target="_blank" rel="noreferrer"><code>LinkHttp</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkHttpErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-http-result.ts#L11" target="_blank" rel="noreferrer"><code>LinkHttpErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkHttpInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-http-input.ts#L2" target="_blank" rel="noreferrer"><code>LinkHttpInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;LinkHttpResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-http-result.ts#L19" target="_blank" rel="noreferrer"><code>LinkHttpResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;MatchedApi&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/link-http-result.ts#L4" target="_blank" rel="noreferrer"><code>MatchedApi</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;RiviereBuilderRepository&quot;,&quot;aggregate-repository&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/data-access/riviere-builder/riviere-builder-repository.ts#L9" target="_blank" rel="noreferrer"><code>RiviereBuilderRepository</code></a></td>
+                          <td><code>aggregate-repository</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ValidateGraph&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/validate-graph.ts#L8" target="_blank" rel="noreferrer"><code>ValidateGraph</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ValidateGraphErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/validate-graph-result.ts#L7" target="_blank" rel="noreferrer"><code>ValidateGraphErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ValidateGraphInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/validate-graph-input.ts#L2" target="_blank" rel="noreferrer"><code>ValidateGraphInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ValidateGraphResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/validate-graph-result.ts#L10" target="_blank" rel="noreferrer"><code>ValidateGraphResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;ValidationData&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/features/builder/commands/validate-graph-result.ts#L4" target="_blank" rel="noreferrer"><code>ValidationData</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Use cases" data-change="Removed" data-values="[&quot;writeUtf8File&quot;,&quot;external-client-service&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/use-cases/src/infra/external-clients/filesystem/write-utf8-file.ts#L4" target="_blank" rel="noreferrer"><code>writeUtf8File</code></a></td>
+                          <td><code>external-client-service</code></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </section></div></details><details class="layer-card"><summary class="layer-summary">
+      <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+      <div class="layer-summary-text">
+        <h3>Domain</h3>
+        <span class="layer-packages">published-language · domain-model</span>
+      </div>
+      <div class="change-totals">
+        <span class="added-total">+46</span>
+        <span class="removed-total">−38</span>
+      </div></summary><div class="layer-body"><section class="change-section added">
+                  <h4>Added</h4>
+
+
+                <section class="package-group"><header class="package-header"><i class="ph ph-package" aria-hidden="true"></i><span>Package</span><code>published-language</code></header><div class="table-wrap added">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ApiDefinition&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/api-definition.ts#L7" target="_blank" rel="noreferrer"><code>ApiDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;BuildValidationError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L185" target="_blank" rel="noreferrer"><code>BuildValidationError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;BusinessRules&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/business-rules.ts#L2" target="_blank" rel="noreferrer"><code>BusinessRules</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;Component&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/component.ts#L35" target="_blank" rel="noreferrer"><code>Component</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ComponentDefinition&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/component-definition.ts#L82" target="_blank" rel="noreferrer"><code>ComponentDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ComponentNotFoundError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L80" target="_blank" rel="noreferrer"><code>ComponentNotFoundError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ComponentType&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/component-type.ts#L16" target="_blank" rel="noreferrer"><code>ComponentType</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ComponentTypeMismatchError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L63" target="_blank" rel="noreferrer"><code>ComponentTypeMismatchError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;CustomComponentDefinition&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/custom-component-definition.ts#L2" target="_blank" rel="noreferrer"><code>CustomComponentDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;CustomComponentProperties&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/custom-component-properties.ts#L16" target="_blank" rel="noreferrer"><code>CustomComponentProperties</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;CustomTypeAlreadyDefinedError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L98" target="_blank" rel="noreferrer"><code>CustomTypeAlreadyDefinedError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;CustomTypeNotFoundError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L35" target="_blank" rel="noreferrer"><code>CustomTypeNotFoundError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;DomainNotFoundError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L24" target="_blank" rel="noreferrer"><code>DomainNotFoundError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;DomainOperationBehavior&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/domain-operation-behavior.ts#L4" target="_blank" rel="noreferrer"><code>DomainOperationBehavior</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;DuplicateComponentError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L52" target="_blank" rel="noreferrer"><code>DuplicateComponentError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;DuplicateDomainError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L2" target="_blank" rel="noreferrer"><code>DuplicateDomainError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;DuplicateLinkError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L137" target="_blank" rel="noreferrer"><code>DuplicateLinkError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;DuplicateLinkWarning&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L35" target="_blank" rel="noreferrer"><code>DuplicateLinkWarning</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ExistingValuePreference&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/existing-value-preference.ts#L2" target="_blank" rel="noreferrer"><code>ExistingValuePreference</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ExternalLink&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/external-link.ts#L13" target="_blank" rel="noreferrer"><code>ExternalLink</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;GraphDiagnostics&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L76" target="_blank" rel="noreferrer"><code>GraphDiagnostics</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;GraphWarning&quot;,&quot;published-language-union&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L22" target="_blank" rel="noreferrer"><code>GraphWarning</code></a></td>
+                          <td><code>published-language-union</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;HttpMethod&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/http-method.ts#L7" target="_blank" rel="noreferrer"><code>HttpMethod</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;InvalidEnrichmentTargetError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/enrichment-errors.ts#L2" target="_blank" rel="noreferrer"><code>InvalidEnrichmentTargetError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;InvalidGraphError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L161" target="_blank" rel="noreferrer"><code>InvalidGraphError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;Link&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/link.ts#L14" target="_blank" rel="noreferrer"><code>Link</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;LinkType&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/link-type.ts#L7" target="_blank" rel="noreferrer"><code>LinkType</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;MissingDomainsError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L177" target="_blank" rel="noreferrer"><code>MissingDomainsError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;MissingRequiredPropertiesError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L148" target="_blank" rel="noreferrer"><code>MissingRequiredPropertiesError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;MissingSourcesError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L169" target="_blank" rel="noreferrer"><code>MissingSourcesError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;NearMatchMismatch&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L62" target="_blank" rel="noreferrer"><code>NearMatchMismatch</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;NearMatchOptions&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L56" target="_blank" rel="noreferrer"><code>NearMatchOptions</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;NearMatchQuery&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L49" target="_blank" rel="noreferrer"><code>NearMatchQuery</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;NearMatchResult&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L69" target="_blank" rel="noreferrer"><code>NearMatchResult</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;OperationWarning&quot;,&quot;published-language-union&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L46" target="_blank" rel="noreferrer"><code>OperationWarning</code></a></td>
+                          <td><code>published-language-union</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;OrphanComponentWarning&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L8" target="_blank" rel="noreferrer"><code>OrphanComponentWarning</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;RelationshipTypeAlreadyDefinedError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L109" target="_blank" rel="noreferrer"><code>RelationshipTypeAlreadyDefinedError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;RelationshipTypeNotFoundError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L120" target="_blank" rel="noreferrer"><code>RelationshipTypeNotFoundError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;RiviereBuilder&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/riviere-builder.ts#L75" target="_blank" rel="noreferrer"><code>RiviereBuilder</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;RiviereGraphDefinition&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/riviere-graph-definition.ts#L30" target="_blank" rel="noreferrer"><code>RiviereGraphDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;ScalarOverwriteWarning&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L25" target="_blank" rel="noreferrer"><code>ScalarOverwriteWarning</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;SourceConflictError&quot;,&quot;domain-error&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/construction-errors.ts#L13" target="_blank" rel="noreferrer"><code>SourceConflictError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;StateTransitions&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/state-transitions.ts#L4" target="_blank" rel="noreferrer"><code>StateTransitions</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;SubscribedEvents&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/subscribed-events.ts#L2" target="_blank" rel="noreferrer"><code>SubscribedEvents</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;SystemType&quot;,&quot;value-object&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/system-type.ts#L7" target="_blank" rel="noreferrer"><code>SystemType</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Added" data-values="[&quot;UnusedDomainWarning&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-builder/published-language/src/published-language/graph-diagnostics.ts#L15" target="_blank" rel="noreferrer"><code>UnusedDomainWarning</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div></section></section><section class="change-section removed">
+                  <h4>Removed</h4>
+
+
+                <section class="package-group"><header class="package-header"><i class="ph ph-package" aria-hidden="true"></i><span>Package</span><code>domain-model</code></header><article class="aggregate-card architecture-aggregate" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-name="RiviereBuilder" data-package="domain-model" data-groups="[{&quot;name&quot;:&quot;Methods&quot;,&quot;values&quot;:[&quot;addApi&quot;,&quot;addCustom&quot;,&quot;addDomain&quot;,&quot;addDomainOp&quot;,&quot;addEvent&quot;,&quot;addEventHandler&quot;,&quot;addSource&quot;,&quot;addUI&quot;,&quot;addUseCase&quot;,&quot;build&quot;,&quot;defineCustomType&quot;,&quot;defineRelationshipType&quot;,&quot;enrichComponent&quot;,&quot;link&quot;,&quot;linkExternal&quot;,&quot;nearMatches&quot;,&quot;new&quot;,&quot;orphans&quot;,&quot;resume&quot;,&quot;serialize&quot;,&quot;stats&quot;,&quot;upsertApi&quot;,&quot;upsertCustom&quot;,&quot;upsertDomainOp&quot;,&quot;upsertEvent&quot;,&quot;upsertEventHandler&quot;,&quot;upsertUI&quot;,&quot;upsertUseCase&quot;,&quot;validate&quot;,&quot;warnings&quot;]}]">
+                    <header class="aggregate-header">
+                      <div class="aggregate-field">
+                        <span>Name</span><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L90" target="_blank" rel="noreferrer"><code>RiviereBuilder</code></a>
+                      </div>
+                      <div class="aggregate-field"><span>Role</span><code>aggregate</code></div>
+                      <div class="aggregate-field">
+                        <span>Package</span><code>domain-model</code>
+                      </div>
+
+                    </header>
+                    <details class="aggregate-group">
+                      <summary><i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i><span>Methods</span></summary>
+                      <ul>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L189" target="_blank" rel="noreferrer"><code>addApi</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L313" target="_blank" rel="noreferrer"><code>addCustom</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L158" target="_blank" rel="noreferrer"><code>addDomain</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L227" target="_blank" rel="noreferrer"><code>addDomainOp</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L246" target="_blank" rel="noreferrer"><code>addEvent</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L265" target="_blank" rel="noreferrer"><code>addEventHandler</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L150" target="_blank" rel="noreferrer"><code>addSource</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L170" target="_blank" rel="noreferrer"><code>addUI</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L208" target="_blank" rel="noreferrer"><code>addUseCase</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L431" target="_blank" rel="noreferrer"><code>build</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L286" target="_blank" rel="noreferrer"><code>defineCustomType</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L302" target="_blank" rel="noreferrer"><code>defineRelationshipType</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L338" target="_blank" rel="noreferrer"><code>enrichComponent</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L360" target="_blank" rel="noreferrer"><code>link</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L380" target="_blank" rel="noreferrer"><code>linkExternal</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L348" target="_blank" rel="noreferrer"><code>nearMatches</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L132" target="_blank" rel="noreferrer"><code>new</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L421" target="_blank" rel="noreferrer"><code>orphans</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L121" target="_blank" rel="noreferrer"><code>resume</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L426" target="_blank" rel="noreferrer"><code>serialize</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L411" target="_blank" rel="noreferrer"><code>stats</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L199" target="_blank" rel="noreferrer"><code>upsertApi</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L324" target="_blank" rel="noreferrer"><code>upsertCustom</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L237" target="_blank" rel="noreferrer"><code>upsertDomainOp</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L256" target="_blank" rel="noreferrer"><code>upsertEvent</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L275" target="_blank" rel="noreferrer"><code>upsertEventHandler</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L180" target="_blank" rel="noreferrer"><code>upsertUI</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L218" target="_blank" rel="noreferrer"><code>upsertUseCase</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L416" target="_blank" rel="noreferrer"><code>validate</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-builder.ts#L403" target="_blank" rel="noreferrer"><code>warnings</code></a>
+                        </li>
+                      </ul>
+                    </details>
+                  </article><div class="table-wrap removed">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;ApiDefinition&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/api-definition.ts#L7" target="_blank" rel="noreferrer"><code>ApiDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;BuildValidationError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L185" target="_blank" rel="noreferrer"><code>BuildValidationError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;BusinessRules&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/business-rules.ts#L2" target="_blank" rel="noreferrer"><code>BusinessRules</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;calculateStats&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/inspection/inspection-functions.ts#L85" target="_blank" rel="noreferrer"><code>calculateStats</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;Component&quot;,&quot;aggregate-entity&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/component.ts#L35" target="_blank" rel="noreferrer"><code>Component</code></a></td>
+                          <td><code>aggregate-entity</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;ComponentDefinition&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/component-definition.ts#L82" target="_blank" rel="noreferrer"><code>ComponentDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;ComponentType&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/component-type.ts#L16" target="_blank" rel="noreferrer"><code>ComponentType</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;ComponentTypeMismatchError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L63" target="_blank" rel="noreferrer"><code>ComponentTypeMismatchError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;CustomComponentDefinition&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/custom-component-definition.ts#L2" target="_blank" rel="noreferrer"><code>CustomComponentDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;CustomComponentProperties&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/custom-component-properties.ts#L16" target="_blank" rel="noreferrer"><code>CustomComponentProperties</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;CustomTypeAlreadyDefinedError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L98" target="_blank" rel="noreferrer"><code>CustomTypeAlreadyDefinedError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;CustomTypeNotFoundError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L35" target="_blank" rel="noreferrer"><code>CustomTypeNotFoundError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;detectOrphanComponents&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/query/graph-validation.ts#L8" target="_blank" rel="noreferrer"><code>detectOrphanComponents</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;DomainNotFoundError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L24" target="_blank" rel="noreferrer"><code>DomainNotFoundError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;DomainOperationBehavior&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/domain-operation-behavior.ts#L4" target="_blank" rel="noreferrer"><code>DomainOperationBehavior</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;DuplicateComponentError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L52" target="_blank" rel="noreferrer"><code>DuplicateComponentError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;DuplicateDomainError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L2" target="_blank" rel="noreferrer"><code>DuplicateDomainError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;DuplicateLinkError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L137" target="_blank" rel="noreferrer"><code>DuplicateLinkError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;ExistingValuePreference&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/existing-value-preference.ts#L2" target="_blank" rel="noreferrer"><code>ExistingValuePreference</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;ExternalLink&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/external-link.ts#L13" target="_blank" rel="noreferrer"><code>ExternalLink</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;findNearMatches&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/error-recovery/component-suggestion.ts#L104" target="_blank" rel="noreferrer"><code>findNearMatches</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;findOrphans&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/inspection/inspection-functions.ts#L55" target="_blank" rel="noreferrer"><code>findOrphans</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;findWarnings&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/inspection/inspection-functions.ts#L122" target="_blank" rel="noreferrer"><code>findWarnings</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;HttpMethod&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/http-method.ts#L7" target="_blank" rel="noreferrer"><code>HttpMethod</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;InvalidEnrichmentTargetError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/enrichment/enrichment-errors.ts#L2" target="_blank" rel="noreferrer"><code>InvalidEnrichmentTargetError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;InvalidGraphError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L161" target="_blank" rel="noreferrer"><code>InvalidGraphError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;Link&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/link.ts#L14" target="_blank" rel="noreferrer"><code>Link</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;LinkType&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/link-type.ts#L7" target="_blank" rel="noreferrer"><code>LinkType</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;MissingDomainsError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L177" target="_blank" rel="noreferrer"><code>MissingDomainsError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;MissingRequiredPropertiesError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L148" target="_blank" rel="noreferrer"><code>MissingRequiredPropertiesError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;MissingSourcesError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L169" target="_blank" rel="noreferrer"><code>MissingSourcesError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;RelationshipTypeAlreadyDefinedError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L109" target="_blank" rel="noreferrer"><code>RelationshipTypeAlreadyDefinedError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;RelationshipTypeNotFoundError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L120" target="_blank" rel="noreferrer"><code>RelationshipTypeNotFoundError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;RiviereGraphDefinition&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/riviere-graph-definition.ts#L30" target="_blank" rel="noreferrer"><code>RiviereGraphDefinition</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;SourceConflictError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/construction/construction-errors.ts#L13" target="_blank" rel="noreferrer"><code>SourceConflictError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;StateTransitions&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/state-transitions.ts#L4" target="_blank" rel="noreferrer"><code>StateTransitions</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;SubscribedEvents&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/subscribed-events.ts#L2" target="_blank" rel="noreferrer"><code>SubscribedEvents</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-builder" data-layer="Domain" data-change="Removed" data-values="[&quot;SystemType&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-builder/domain-model/src/domain/system-type.ts#L7" target="_blank" rel="noreferrer"><code>SystemType</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div></section></section></div></details></div></details>
+            <details class="subdomain-group" id="subdomain-riviere-extract-config" open=""><summary class="subdomain-summary">
+    <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+    <span class="subdomain-icon"><i class="ph ph-circles-three" aria-hidden="true"></i></span>
+    <div class="subdomain-summary-text">
+      <span class="subdomain-label">Subdomain</span>
+      <h2>riviere-extract-config</h2>
+    </div>
+    <div class="change-totals">
+      <span class="added-total">+11</span>
+
+    </div></summary><div class="subdomain-content"><details class="layer-card"><summary class="layer-summary">
+      <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+      <div class="layer-summary-text">
+        <h3>Domain</h3>
+        <span class="layer-packages">published-language</span>
+      </div>
+      <div class="change-totals">
+        <span class="added-total">+11</span>
+
+      </div></summary><div class="layer-body"><section class="change-section added">
+                  <h4>Added</h4>
+
+
+                <section class="package-group"><header class="package-header"><i class="ph ph-package" aria-hidden="true"></i><span>Package</span><code>published-language</code></header><div class="table-wrap added">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;parseWorkflowDefinition&quot;,&quot;published-language-parser&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L162" target="_blank" rel="noreferrer"><code>parseWorkflowDefinition</code></a></td>
+                          <td><code>published-language-parser</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowDefinition&quot;,&quot;published-language-schema&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L50" target="_blank" rel="noreferrer"><code>WorkflowDefinition</code></a></td>
+                          <td><code>published-language-schema</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowDefinitionParseFailure&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L64" target="_blank" rel="noreferrer"><code>WorkflowDefinitionParseFailure</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowDefinitionParseResult&quot;,&quot;published-language-union&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L70" target="_blank" rel="noreferrer"><code>WorkflowDefinitionParseResult</code></a></td>
+                          <td><code>published-language-union</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowDefinitionParseSuccess&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L58" target="_blank" rel="noreferrer"><code>WorkflowDefinitionParseSuccess</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowExtractStageDefinition&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L22" target="_blank" rel="noreferrer"><code>WorkflowExtractStageDefinition</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowGraphDefinition&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L8" target="_blank" rel="noreferrer"><code>WorkflowGraphDefinition</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowLinkStageDefinition&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L30" target="_blank" rel="noreferrer"><code>WorkflowLinkStageDefinition</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowRunLogDefinition&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L17" target="_blank" rel="noreferrer"><code>WorkflowRunLogDefinition</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowStageDefinition&quot;,&quot;published-language-union&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L44" target="_blank" rel="noreferrer"><code>WorkflowStageDefinition</code></a></td>
+                          <td><code>published-language-union</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-config" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowValidateStageDefinition&quot;,&quot;published-language-data-structure&quot;,&quot;published-language&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-config/published-language/src/published-language/workflow-definition.ts#L38" target="_blank" rel="noreferrer"><code>WorkflowValidateStageDefinition</code></a></td>
+                          <td><code>published-language-data-structure</code></td>
+
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div></section></section></div></details></div></details>
+            <details class="subdomain-group" id="subdomain-riviere-extract-ts" open=""><summary class="subdomain-summary">
+    <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+    <span class="subdomain-icon"><i class="ph ph-circles-three" aria-hidden="true"></i></span>
+    <div class="subdomain-summary-text">
+      <span class="subdomain-label">Subdomain</span>
+      <h2>riviere-extract-ts</h2>
+    </div>
+    <div class="change-totals">
+      <span class="added-total">+71</span>
+      <span class="removed-total">−3</span>
+    </div></summary><div class="subdomain-content"><details class="layer-card"><summary class="layer-summary">
+      <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+      <div class="layer-summary-text">
+        <h3>Entry points</h3>
+
+      </div>
+      <div class="change-totals">
+        <span class="added-total">+34</span>
+
+      </div></summary><div class="layer-body"><section class="change-section added">
+                  <h4>Added</h4>
+
+                  <div class="table-wrap added">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createAddComponentCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/add-component/entrypoint.ts#L47" target="_blank" rel="noreferrer"><code>createAddComponentCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateAddComponentCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/add-component/entrypoint.ts#L36" target="_blank" rel="noreferrer"><code>CreateAddComponentCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createAddDomainCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/add-domain/entrypoint.ts#L25" target="_blank" rel="noreferrer"><code>createAddDomainCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateAddDomainCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/add-domain/entrypoint.ts#L16" target="_blank" rel="noreferrer"><code>CreateAddDomainCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createAddSourceCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/add-source/entrypoint.ts#L23" target="_blank" rel="noreferrer"><code>createAddSourceCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateAddSourceCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/add-source/entrypoint.ts#L14" target="_blank" rel="noreferrer"><code>CreateAddSourceCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createCheckConsistencyCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/check-consistency/entrypoint.ts#L22" target="_blank" rel="noreferrer"><code>createCheckConsistencyCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateCheckConsistencyCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/check-consistency/entrypoint.ts#L13" target="_blank" rel="noreferrer"><code>CreateCheckConsistencyCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createDefineCustomTypeCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/define-custom-type/entrypoint.ts#L28" target="_blank" rel="noreferrer"><code>createDefineCustomTypeCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateDefineCustomTypeCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/define-custom-type/entrypoint.ts#L18" target="_blank" rel="noreferrer"><code>CreateDefineCustomTypeCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createDefineRelationshipTypeCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/define-relationship-type/entrypoint.ts#L24" target="_blank" rel="noreferrer"><code>createDefineRelationshipTypeCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateDefineRelationshipTypeCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/define-relationship-type/entrypoint.ts#L15" target="_blank" rel="noreferrer"><code>CreateDefineRelationshipTypeCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createEnrichCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/enrich/entrypoint.ts#L34" target="_blank" rel="noreferrer"><code>createEnrichCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateEnrichCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/enrich/entrypoint.ts#L23" target="_blank" rel="noreferrer"><code>CreateEnrichCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createFinalizeCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/finalize/entrypoint.ts#L27" target="_blank" rel="noreferrer"><code>createFinalizeCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateFinalizeCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/finalize/entrypoint.ts#L16" target="_blank" rel="noreferrer"><code>CreateFinalizeCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createFinalizeGraphInput&quot;,&quot;command-input-factory&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/finalize/create-finalize-graph-input.ts#L10" target="_blank" rel="noreferrer"><code>createFinalizeGraphInput</code></a></td>
+                          <td><code>command-input-factory</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createInitCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/init/entrypoint.ts#L32" target="_blank" rel="noreferrer"><code>createInitCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateInitCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/init/entrypoint.ts#L23" target="_blank" rel="noreferrer"><code>CreateInitCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createLinkCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/link/entrypoint.ts#L36" target="_blank" rel="noreferrer"><code>createLinkCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateLinkCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/link/entrypoint.ts#L26" target="_blank" rel="noreferrer"><code>CreateLinkCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createLinkExternalCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/link-external/entrypoint.ts#L27" target="_blank" rel="noreferrer"><code>createLinkExternalCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateLinkExternalCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/link-external/entrypoint.ts#L18" target="_blank" rel="noreferrer"><code>CreateLinkExternalCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createLinkHttpCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/link-http/entrypoint.ts#L29" target="_blank" rel="noreferrer"><code>createLinkHttpCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateLinkHttpCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/link-http/entrypoint.ts#L20" target="_blank" rel="noreferrer"><code>CreateLinkHttpCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;createValidateCommand&quot;,&quot;cli-entrypoint&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/validate/entrypoint.ts#L22" target="_blank" rel="noreferrer"><code>createValidateCommand</code></a></td>
+                          <td><code>cli-entrypoint</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;CreateValidateCommandEntrypointDependencies&quot;,&quot;cli-entrypoint-dependencies&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/validate/entrypoint.ts#L13" target="_blank" rel="noreferrer"><code>CreateValidateCommandEntrypointDependencies</code></a></td>
+                          <td><code>cli-entrypoint-dependencies</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;parseAddComponentInput&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/add-component/parse-add-component-input.ts#L50" target="_blank" rel="noreferrer"><code>parseAddComponentInput</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;parseDomainJson&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/init/domain-input-parser.ts#L30" target="_blank" rel="noreferrer"><code>parseDomainJson</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;parseLinkSourceLocation&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/link/link-source-location-options.ts#L26" target="_blank" rel="noreferrer"><code>parseLinkSourceLocation</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;parsePropertySpecs&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/define-custom-type/custom-type-parser.ts#L39" target="_blank" rel="noreferrer"><code>parsePropertySpecs</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;parseSignature&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/enrich/signature-parser.ts#L77" target="_blank" rel="noreferrer"><code>parseSignature</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;parseStateChanges&quot;,&quot;entrypoint-cli-input-parser&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/enrich/enrichment-parser.ts#L26" target="_blank" rel="noreferrer"><code>parseStateChanges</code></a></td>
+                          <td><code>entrypoint-cli-input-parser</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Entry points" data-change="Added" data-values="[&quot;writeFinalizedGraph&quot;,&quot;cli-response-writer&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/apps/cli/src/features/builder/entrypoint/finalize/write-finalized-graph.ts#L5" target="_blank" rel="noreferrer"><code>writeFinalizedGraph</code></a></td>
+                          <td><code>cli-response-writer</code></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </section></div></details><details class="layer-card"><summary class="layer-summary">
+      <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+      <div class="layer-summary-text">
+        <h3>Use cases</h3>
+
+      </div>
+      <div class="change-totals">
+        <span class="added-total">+66</span>
+
+      </div></summary><div class="layer-body"><section class="change-section added">
+                  <h4>Added</h4>
+
+                  <div class="table-wrap added">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddComponent&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-component.ts#L14" target="_blank" rel="noreferrer"><code>AddComponent</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddComponentErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-component-result.ts#L2" target="_blank" rel="noreferrer"><code>AddComponentErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddComponentInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-component-input.ts#L2" target="_blank" rel="noreferrer"><code>AddComponentInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddComponentResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-component-result.ts#L10" target="_blank" rel="noreferrer"><code>AddComponentResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddDomain&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-domain.ts#L12" target="_blank" rel="noreferrer"><code>AddDomain</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddDomainErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-domain-result.ts#L2" target="_blank" rel="noreferrer"><code>AddDomainErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddDomainInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-domain-input.ts#L2" target="_blank" rel="noreferrer"><code>AddDomainInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddDomainResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-domain-result.ts#L9" target="_blank" rel="noreferrer"><code>AddDomainResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddSource&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-source.ts#L8" target="_blank" rel="noreferrer"><code>AddSource</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddSourceErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-source-result.ts#L2" target="_blank" rel="noreferrer"><code>AddSourceErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddSourceInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-source-input.ts#L2" target="_blank" rel="noreferrer"><code>AddSourceInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;AddSourceResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/add-source-result.ts#L5" target="_blank" rel="noreferrer"><code>AddSourceResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;BuilderWarnings&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/check-consistency-result.ts#L7" target="_blank" rel="noreferrer"><code>BuilderWarnings</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;CheckConsistency&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/check-consistency.ts#L8" target="_blank" rel="noreferrer"><code>CheckConsistency</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;CheckConsistencyErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/check-consistency-result.ts#L4" target="_blank" rel="noreferrer"><code>CheckConsistencyErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;CheckConsistencyInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/check-consistency-input.ts#L2" target="_blank" rel="noreferrer"><code>CheckConsistencyInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;CheckConsistencyResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/check-consistency-result.ts#L10" target="_blank" rel="noreferrer"><code>CheckConsistencyResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;createTypeScriptProjects&quot;,&quot;external-client-service&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/infra/external-clients/ts-morph/create-typescript-projects.ts#L5" target="_blank" rel="noreferrer"><code>createTypeScriptProjects</code></a></td>
+                          <td><code>external-client-service</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineCustomType&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-custom-type.ts#L11" target="_blank" rel="noreferrer"><code>DefineCustomType</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineCustomTypeErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-custom-type-result.ts#L4" target="_blank" rel="noreferrer"><code>DefineCustomTypeErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineCustomTypeInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-custom-type-input.ts#L2" target="_blank" rel="noreferrer"><code>DefineCustomTypeInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineCustomTypeResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-custom-type-result.ts#L7" target="_blank" rel="noreferrer"><code>DefineCustomTypeResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineRelationshipType&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-relationship-type.ts#L12" target="_blank" rel="noreferrer"><code>DefineRelationshipType</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineRelationshipTypeErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-relationship-type-result.ts#L2" target="_blank" rel="noreferrer"><code>DefineRelationshipTypeErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineRelationshipTypeInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-relationship-type-input.ts#L2" target="_blank" rel="noreferrer"><code>DefineRelationshipTypeInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;DefineRelationshipTypeResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/define-relationship-type-result.ts#L8" target="_blank" rel="noreferrer"><code>DefineRelationshipTypeResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;EnrichComponent&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/enrich-component.ts#L12" target="_blank" rel="noreferrer"><code>EnrichComponent</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;EnrichComponentErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/enrich-component-result.ts#L2" target="_blank" rel="noreferrer"><code>EnrichComponentErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;EnrichComponentInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/enrich-component-input.ts#L2" target="_blank" rel="noreferrer"><code>EnrichComponentInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;EnrichComponentResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/enrich-component-result.ts#L9" target="_blank" rel="noreferrer"><code>EnrichComponentResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;FinalizedGraph&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/finalize-graph-result.ts#L7" target="_blank" rel="noreferrer"><code>FinalizedGraph</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;FinalizeGraph&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/finalize-graph.ts#L8" target="_blank" rel="noreferrer"><code>FinalizeGraph</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;FinalizeGraphErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/finalize-graph-result.ts#L4" target="_blank" rel="noreferrer"><code>FinalizeGraphErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;FinalizeGraphInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/finalize-graph-input.ts#L2" target="_blank" rel="noreferrer"><code>FinalizeGraphInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;FinalizeGraphResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/finalize-graph-result.ts#L10" target="_blank" rel="noreferrer"><code>FinalizeGraphResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;globSourceFiles&quot;,&quot;external-client-service&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/infra/external-clients/glob/glob-source-files.ts#L5" target="_blank" rel="noreferrer"><code>globSourceFiles</code></a></td>
+                          <td><code>external-client-service</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;GraphCorruptedError&quot;,&quot;data-access-error&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/graph-corrupted-error.ts#L2" target="_blank" rel="noreferrer"><code>GraphCorruptedError</code></a></td>
+                          <td><code>data-access-error</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;GraphNotFoundError&quot;,&quot;data-access-error&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/data-access/riviere-project/graph-not-found-error.ts#L2" target="_blank" rel="noreferrer"><code>GraphNotFoundError</code></a></td>
+                          <td><code>data-access-error</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;InitDomainInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/init-graph-input.ts#L2" target="_blank" rel="noreferrer"><code>InitDomainInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;InitGraph&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/init-graph.ts#L10" target="_blank" rel="noreferrer"><code>InitGraph</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;InitGraphErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/init-graph-result.ts#L2" target="_blank" rel="noreferrer"><code>InitGraphErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;InitGraphInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/init-graph-input.ts#L9" target="_blank" rel="noreferrer"><code>InitGraphInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;InitGraphResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/init-graph-result.ts#L5" target="_blank" rel="noreferrer"><code>InitGraphResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkComponents&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-components.ts#L16" target="_blank" rel="noreferrer"><code>LinkComponents</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkComponentsErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-components-result.ts#L4" target="_blank" rel="noreferrer"><code>LinkComponentsErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkComponentsInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-components-input.ts#L2" target="_blank" rel="noreferrer"><code>LinkComponentsInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkComponentsResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-components-result.ts#L11" target="_blank" rel="noreferrer"><code>LinkComponentsResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkExternal&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-external.ts#L13" target="_blank" rel="noreferrer"><code>LinkExternal</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkExternalErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-external-result.ts#L4" target="_blank" rel="noreferrer"><code>LinkExternalErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkExternalInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-external-input.ts#L2" target="_blank" rel="noreferrer"><code>LinkExternalInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkExternalResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-external-result.ts#L11" target="_blank" rel="noreferrer"><code>LinkExternalResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkHttp&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-http.ts#L20" target="_blank" rel="noreferrer"><code>LinkHttp</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkHttpErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-http-result.ts#L11" target="_blank" rel="noreferrer"><code>LinkHttpErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkHttpInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-http-input.ts#L2" target="_blank" rel="noreferrer"><code>LinkHttpInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;LinkHttpResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-http-result.ts#L19" target="_blank" rel="noreferrer"><code>LinkHttpResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;MatchedApi&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/link-http-result.ts#L4" target="_blank" rel="noreferrer"><code>MatchedApi</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;RunWorkflow&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/run-workflow.ts#L8" target="_blank" rel="noreferrer"><code>RunWorkflow</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;RunWorkflowInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/run-workflow-input.ts#L2" target="_blank" rel="noreferrer"><code>RunWorkflowInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;RunWorkflowResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/run-workflow-result.ts#L23" target="_blank" rel="noreferrer"><code>RunWorkflowResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;ValidateGraph&quot;,&quot;command-use-case&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/validate-graph.ts#L8" target="_blank" rel="noreferrer"><code>ValidateGraph</code></a></td>
+                          <td><code>command-use-case</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;ValidateGraphErrorCode&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/validate-graph-result.ts#L7" target="_blank" rel="noreferrer"><code>ValidateGraphErrorCode</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;ValidateGraphInput&quot;,&quot;command-use-case-input&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/validate-graph-input.ts#L2" target="_blank" rel="noreferrer"><code>ValidateGraphInput</code></a></td>
+                          <td><code>command-use-case-input</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;ValidateGraphResult&quot;,&quot;command-use-case-result&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/validate-graph-result.ts#L10" target="_blank" rel="noreferrer"><code>ValidateGraphResult</code></a></td>
+                          <td><code>command-use-case-result</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;ValidationData&quot;,&quot;command-use-case-result-value&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/features/extract/commands/validate-graph-result.ts#L4" target="_blank" rel="noreferrer"><code>ValidationData</code></a></td>
+                          <td><code>command-use-case-result-value</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;YamlDocumentError&quot;,&quot;external-client-error&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/infra/external-clients/yaml/yaml-document-reader.ts#L4" target="_blank" rel="noreferrer"><code>YamlDocumentError</code></a></td>
+                          <td><code>external-client-error</code></td>
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Use cases" data-change="Added" data-values="[&quot;YamlDocumentReader&quot;,&quot;external-client-service&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/use-cases/src/infra/external-clients/yaml/yaml-document-reader.ts#L7" target="_blank" rel="noreferrer"><code>YamlDocumentReader</code></a></td>
+                          <td><code>external-client-service</code></td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </section></div></details><details class="layer-card"><summary class="layer-summary">
+      <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+      <div class="layer-summary-text">
+        <h3>Domain</h3>
+        <span class="layer-packages">domain-model</span>
+      </div>
+      <div class="change-totals">
+        <span class="added-total">+5</span>
+        <span class="removed-total">−3</span>
+      </div></summary><div class="layer-body"><section class="change-section added">
+                  <h4>Added</h4>
+
+
+                <section class="package-group"><header class="package-header"><i class="ph ph-package" aria-hidden="true"></i><span>Package</span><code>domain-model</code></header><article class="aggregate-card architecture-aggregate" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Added" data-name="RiviereProject" data-package="domain-model" data-groups="[{&quot;name&quot;:&quot;Aggregate entities&quot;,&quot;values&quot;:[&quot;Workflow&quot;]},{&quot;name&quot;:&quot;Methods&quot;,&quot;values&quot;:[&quot;addComponent&quot;,&quot;addDomain&quot;,&quot;addSource&quot;,&quot;addWorkflow&quot;,&quot;build&quot;,&quot;defineCustomType&quot;,&quot;defineRelationshipType&quot;,&quot;enrichComponent&quot;,&quot;link&quot;,&quot;linkExternal&quot;,&quot;rebuildGraph&quot;,&quot;rehydrate&quot;,&quot;serialize&quot;,&quot;start&quot;,&quot;validate&quot;,&quot;warnings&quot;]}]">
+                    <header class="aggregate-header">
+                      <div class="aggregate-field">
+                        <span>Name</span><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L33" target="_blank" rel="noreferrer"><code>RiviereProject</code></a>
+                      </div>
+                      <div class="aggregate-field"><span>Role</span><code>aggregate</code></div>
+                      <div class="aggregate-field">
+                        <span>Package</span><code>domain-model</code>
+                      </div>
+
+                    </header>
+                    <details class="aggregate-group"><summary><i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i><span>Aggregate entities</span></summary><ul>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/workflow.ts#L64" target="_blank" rel="noreferrer"><code>Workflow</code></a>
+                        </li>
+                      </ul></details>
+                    <details class="aggregate-group">
+                      <summary><i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i><span>Methods</span></summary>
+                      <ul>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L84" target="_blank" rel="noreferrer"><code>addComponent</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L80" target="_blank" rel="noreferrer"><code>addDomain</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L76" target="_blank" rel="noreferrer"><code>addSource</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L70" target="_blank" rel="noreferrer"><code>addWorkflow</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L132" target="_blank" rel="noreferrer"><code>build</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L104" target="_blank" rel="noreferrer"><code>defineCustomType</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L108" target="_blank" rel="noreferrer"><code>defineRelationshipType</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L112" target="_blank" rel="noreferrer"><code>enrichComponent</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L116" target="_blank" rel="noreferrer"><code>link</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L120" target="_blank" rel="noreferrer"><code>linkExternal</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L140" target="_blank" rel="noreferrer"><code>rebuildGraph</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L66" target="_blank" rel="noreferrer"><code>rehydrate</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L136" target="_blank" rel="noreferrer"><code>serialize</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L43" target="_blank" rel="noreferrer"><code>start</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L128" target="_blank" rel="noreferrer"><code>validate</code></a>
+                        </li>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L124" target="_blank" rel="noreferrer"><code>warnings</code></a>
+                        </li>
+                      </ul>
+                    </details>
+                  </article><div class="table-wrap added">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Added" data-values="[&quot;ExtractionConfigurationUnavailableError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-errors.ts#L2" target="_blank" rel="noreferrer"><code>ExtractionConfigurationUnavailableError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Added" data-values="[&quot;GraphStateUnavailableError&quot;,&quot;domain-error&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/riviere-project-errors.ts#L9" target="_blank" rel="noreferrer"><code>GraphStateUnavailableError</code></a></td>
+                          <td><code>domain-error</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowDefinitionFailure&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/workflow-definition-failure.ts#L7" target="_blank" rel="noreferrer"><code>WorkflowDefinitionFailure</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowRunEvent&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/workflow-run-event.ts#L10" target="_blank" rel="noreferrer"><code>WorkflowRunEvent</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Added" data-values="[&quot;WorkflowStage&quot;,&quot;value-object&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/aeb7a001d060556ca5ec5fa6c8830e00a1458c29/packages/riviere-extract-ts/domain-model/src/domain/workflow-stage.ts#L23" target="_blank" rel="noreferrer"><code>WorkflowStage</code></a></td>
+                          <td><code>value-object</code></td>
+
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div></section></section><section class="change-section removed">
+                  <h4>Removed</h4>
+
+
+                <section class="package-group"><header class="package-header"><i class="ph ph-package" aria-hidden="true"></i><span>Package</span><code>domain-model</code></header><article class="aggregate-card architecture-aggregate" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Removed" data-name="RiviereProject" data-package="domain-model" data-groups="[{&quot;name&quot;:&quot;Methods&quot;,&quot;values&quot;:[&quot;parse&quot;]}]">
+                    <header class="aggregate-header">
+                      <div class="aggregate-field">
+                        <span>Name</span><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L34" target="_blank" rel="noreferrer"><code>RiviereProject</code></a>
+                      </div>
+                      <div class="aggregate-field"><span>Role</span><code>aggregate</code></div>
+                      <div class="aggregate-field">
+                        <span>Package</span><code>domain-model</code>
+                      </div>
+
+                    </header>
+                    <details class="aggregate-group">
+                      <summary><i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i><span>Methods</span></summary>
+                      <ul>
+                        <li>
+                          <a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-extract-ts/domain-model/src/domain/riviere-project.ts#L42" target="_blank" rel="noreferrer"><code>parse</code></a>
+                        </li>
+                      </ul>
+                    </details>
+                  </article><div class="table-wrap removed">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Role</th>
+
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Removed" data-values="[&quot;detectCallsInCallable&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-extract-ts/domain-model/src/domain/connection-detection/call-graph/detect-calls-in-callable.ts#L14" target="_blank" rel="noreferrer"><code>detectCallsInCallable</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Removed" data-values="[&quot;locateComponentCallables&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-extract-ts/domain-model/src/domain/connection-detection/call-graph/locate-component-callables.ts#L10" target="_blank" rel="noreferrer"><code>locateComponentCallables</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                        <tr class="architecture-record" data-subdomain="riviere-extract-ts" data-layer="Domain" data-change="Removed" data-values="[&quot;resolveCallTargets&quot;,&quot;domain-service&quot;,&quot;domain-model&quot;]">
+                          <td><a class="code-link" href="https://github.com/NTCoding/living-architecture/blob/3ec31c16fbfd02f91122a8d81f3b26010461cc47/packages/riviere-extract-ts/domain-model/src/domain/connection-detection/call-graph/resolve-call-targets.ts#L23" target="_blank" rel="noreferrer"><code>resolveCallTargets</code></a></td>
+                          <td><code>domain-service</code></td>
+
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div></section></section></div></details></div></details>
+          </main>
+        </div>
+      </section>
+    </div>
+    <script>
+      const sidebar = document.querySelector('#sidebar')
+      const collapseButton = document.querySelector('#sidebar-collapse')
+      const collapseIcon = document.querySelector('#collapse-icon')
+      collapseButton.addEventListener('click', () => {
+        const collapsed = sidebar.classList.toggle('collapsed')
+        collapseButton.setAttribute('aria-label', collapsed ? 'Expand sidebar' : 'Collapse sidebar')
+        collapseIcon.className = collapsed ? 'ph ph-caret-right' : 'ph ph-caret-left'
+      })
+
+      const packageByLayer = {
+        'Use cases': 'Package: use-cases',
+      }
+
+      document.querySelectorAll('.layer-card').forEach((layer) => {
+        const summaryText = layer.querySelector('.layer-summary-text')
+        const heading = summaryText?.querySelector('h3')
+        if (summaryText === null || heading === null) return
+        const existingPackages = summaryText.querySelector('.layer-packages')
+        const packageLabel = packageByLayer[heading.textContent]
+        if (packageLabel !== undefined) {
+          const label = existingPackages ?? document.createElement('span')
+          label.className = 'layer-packages'
+          label.textContent = packageLabel
+          if (existingPackages === null) summaryText.append(label)
+          return
+        }
+        if (existingPackages !== null) {
+          const packageNames = existingPackages.textContent
+          existingPackages.textContent = `${packageNames.includes('·') ? 'Packages' : 'Package'}: ${packageNames}`
+        }
+      })
+
+      document.querySelectorAll('section.package-group').forEach((packageSection) => {
+        const header = packageSection.querySelector(':scope > .package-header')
+        if (header === null) return
+        const packageDetails = document.createElement('details')
+        packageDetails.className = 'package-group'
+        const summary = document.createElement('summary')
+        summary.className = 'package-header'
+        summary.innerHTML = '<i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>'
+        while (header.firstChild !== null) summary.append(header.firstChild)
+        const elementCount = packageSection.querySelectorAll('.architecture-record').length
+        const aggregateCount = packageSection.querySelectorAll('.architecture-aggregate').length
+        const count = document.createElement('span')
+        count.className = 'package-change-count'
+        count.textContent = `${elementCount} ${elementCount === 1 ? 'element' : 'elements'}${aggregateCount === 0 ? '' : ` · ${aggregateCount} ${aggregateCount === 1 ? 'aggregate' : 'aggregates'}`}`
+        summary.append(count)
+        packageDetails.append(summary)
+        ;[...packageSection.children]
+          .filter((child) => child !== header)
+          .forEach((child) => packageDetails.append(child))
+        packageSection.replaceWith(packageDetails)
+      })
+
+      const primaryRoles = new Map([
+        ['command-use-case', { heading: 'Command use cases', label: 'Command use case' }],
+        ['query-model-use-case', { heading: 'Query use cases', label: 'Query use case' }],
+      ])
+      const speciallyRelatedNames = new Map([
+        ['CheckConsistency', new Set(['BuilderWarnings'])],
+        ['ComponentChecklist', new Set(['ChecklistComponent'])],
+        ['FinalizeGraph', new Set(['FinalizedGraph'])],
+        ['InitGraph', new Set(['InitDomainInput'])],
+        ['LinkHttp', new Set(['MatchedApi'])],
+        ['ValidateGraph', new Set(['ValidationData'])],
+      ])
+
+      function recordValues(record) {
+        return JSON.parse(record.dataset.values)
+      }
+
+      function recordName(record) {
+        return recordValues(record)[0]
+      }
+
+      function recordRole(record) {
+        return recordValues(record)[1]
+      }
+
+      const entrypointHelpers = new Map([
+        ['createAddComponentCommand', ['parseAddComponentInput']],
+        ['createDefineCustomTypeCommand', ['parsePropertySpecs']],
+        ['createEnrichCommand', ['parseSignature', 'parseStateChanges']],
+        ['createFinalizeCommand', ['createFinalizeGraphInput', 'writeFinalizedGraph']],
+        ['createInitCommand', ['parseDomainJson']],
+        ['createLinkCommand', ['parseLinkSourceLocation']],
+      ])
+
+      function cloneEvidenceLink(record, label) {
+        const link = record.querySelector('.code-link')?.cloneNode(true)
+        if (link === undefined) return document.createTextNode(label)
+        link.className = 'evidence-link'
+        link.textContent = label
+        return link
+      }
+
+      function createApplicationRecordTable(pairs) {
+        const wrap = document.createElement('div')
+        wrap.className = 'table-wrap'
+        const table = document.createElement('table')
+        const head = document.createElement('thead')
+        head.innerHTML = '<tr><th>Role</th><th>Component</th><th>Code evidence</th></tr>'
+        const body = document.createElement('tbody')
+        pairs.forEach(({ base, head: current }) => {
+          const row = document.createElement('tr')
+          row.className = 'application-element-record'
+          row.dataset.values = current.dataset.values
+          const role = document.createElement('td')
+          role.innerHTML = `<code>${recordRole(current)}</code>`
+          const component = document.createElement('td')
+          component.innerHTML = `<code>${recordName(current)}</code>`
+          const evidence = document.createElement('td')
+          evidence.append(
+            cloneEvidenceLink(base, 'Base'),
+            document.createTextNode(' · '),
+            cloneEvidenceLink(current, 'Head'),
+          )
+          row.append(role, component, evidence)
+          body.append(row)
+        })
+        table.append(head, body)
+        wrap.append(table)
+        return wrap
+      }
+
+      function createApplicationEntrypoint(primary, relatedPairs) {
+        const group = document.createElement('details')
+        group.className = 'application-entrypoint application-element-record'
+        group.dataset.values = primary.head.dataset.values
+        const summary = document.createElement('summary')
+        summary.className = 'application-entrypoint-summary'
+        summary.innerHTML = '<i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>'
+        const sourceLink = primary.head.querySelector('.code-link')?.cloneNode(true)
+        if (sourceLink !== undefined) summary.append(sourceLink)
+        const meta = document.createElement('span')
+        meta.className = 'application-entrypoint-meta'
+        meta.textContent = `${relatedPairs.length} supporting ${relatedPairs.length === 1 ? 'element' : 'elements'}`
+        summary.append(meta)
+
+        const body = document.createElement('div')
+        body.className = 'application-entrypoint-body'
+        const evidence = document.createElement('div')
+        evidence.className = 'entrypoint-evidence'
+        evidence.innerHTML = '<strong>Subdomain association</strong><code>riviere-builder</code><i class="ph ph-arrow-right" aria-hidden="true"></i><code>riviere-extract-ts</code><strong>Code evidence</strong>'
+        evidence.append(
+          cloneEvidenceLink(primary.base, 'Base'),
+          cloneEvidenceLink(primary.head, 'Head'),
+        )
+        body.append(evidence)
+        if (relatedPairs.length > 0) {
+          const supporting = document.createElement('section')
+          supporting.className = 'supporting-elements'
+          supporting.innerHTML = '<h6>Supporting application elements</h6>'
+          supporting.append(createApplicationRecordTable(relatedPairs))
+          body.append(supporting)
+        }
+        group.append(summary, body)
+        return group
+      }
+
+      function entrypointLayer(subdomainId) {
+        const subdomain = document.querySelector(subdomainId)
+        return [...(subdomain?.querySelectorAll(':scope > .subdomain-content > .layer-card') ?? [])].find(
+          (layer) => layer.querySelector('.layer-summary h3')?.textContent === 'Entry points',
+        )
+      }
+
+      function renderApplicationEntrypoints() {
+        const previousLayer = entrypointLayer('#subdomain-riviere-builder')
+        const currentLayer = entrypointLayer('#subdomain-riviere-extract-ts')
+        if (previousLayer === undefined || currentLayer === undefined) return
+        const previousRecords = [...previousLayer.querySelectorAll('.architecture-record')]
+        const currentRecords = [...currentLayer.querySelectorAll('.architecture-record')]
+        const currentByValue = new Map(
+          currentRecords.map((record) => [record.dataset.values, record]),
+        )
+        const pairs = previousRecords.flatMap((base) => {
+          const current = currentByValue.get(base.dataset.values)
+          return current === undefined ? [] : [{ base, head: current }]
+        })
+        const primaries = pairs.filter(({ head: current }) => recordRole(current) === 'cli-entrypoint')
+        const assigned = new Set(primaries.map(({ head: current }) => current.dataset.values))
+        const entrypointGroups = primaries.map((primary) => {
+          const name = recordName(primary.head)
+          const dependency = `${name[0].toUpperCase()}${name.slice(1)}EntrypointDependencies`
+          const relatedNames = new Set([dependency, ...(entrypointHelpers.get(name) ?? [])])
+          const related = pairs.filter(({ head: current }) => relatedNames.has(recordName(current)))
+          related.forEach(({ head: current }) => assigned.add(current.dataset.values))
+          return createApplicationEntrypoint(primary, related)
+        })
+        const unassigned = pairs.filter(({ head: current }) => !assigned.has(current.dataset.values))
+
+        const application = document.createElement('details')
+        application.className = 'application-group'
+        application.id = 'application-cli'
+        application.open = true
+        application.innerHTML = `<summary class="application-summary">
+          <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+          <span class="application-icon"><i class="ph ph-terminal-window" aria-hidden="true"></i></span>
+          <div class="application-summary-text"><span class="application-label">Application</span><h2>apps/cli</h2></div>
+          <div class="change-totals"><span>34 reassigned</span></div>
+        </summary>`
+        const applicationContent = document.createElement('div')
+        applicationContent.className = 'application-content'
+        const layer = document.createElement('details')
+        layer.className = 'layer-card'
+        layer.innerHTML = `<summary class="layer-summary">
+          <i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>
+          <div class="layer-summary-text"><h3>Entry points</h3><span class="layer-packages">13 CLI entry points · 21 supporting elements</span></div>
+          <div class="change-totals"><span>34 reassigned</span></div>
+        </summary>`
+        const layerBody = document.createElement('div')
+        layerBody.className = 'layer-body'
+        layerBody.innerHTML = '<div class="reassignment-context"><strong>Subdomain association</strong><code>riviere-builder</code><i class="ph ph-arrow-right" aria-hidden="true"></i><code>riviere-extract-ts</code></div><h5 class="use-case-category-title">CLI entry points (13)</h5>'
+        const list = document.createElement('div')
+        list.className = 'application-entrypoint-list'
+        list.append(...entrypointGroups)
+        layerBody.append(list)
+        if (unassigned.length > 0) {
+          const supporting = document.createElement('section')
+          supporting.className = 'supporting-elements'
+          supporting.innerHTML = '<h6>Other application elements</h6>'
+          supporting.append(createApplicationRecordTable(unassigned))
+          layerBody.append(supporting)
+        }
+        layer.append(layerBody)
+        applicationContent.append(layer)
+        application.append(applicationContent)
+        document.querySelector('.subdomain-group')?.before(application)
+        previousLayer.remove()
+        currentLayer.remove()
+      }
+
+      renderApplicationEntrypoints()
+
+      function isPrimaryRecord(record) {
+        return primaryRoles.has(recordRole(record))
+      }
+
+      function isRelatedRecord(primary, candidate) {
+        if (isPrimaryRecord(candidate)) return false
+        const primaryName = recordName(primary)
+        const candidateName = recordName(candidate)
+        return (
+          candidateName.startsWith(primaryName) ||
+          speciallyRelatedNames.get(primaryName)?.has(candidateName) === true
+        )
+      }
+
+      function createRecordTable(records) {
+        const wrap = document.createElement('div')
+        wrap.className = 'table-wrap'
+        const table = document.createElement('table')
+        const head = document.createElement('thead')
+        head.innerHTML = '<tr><th>Role</th><th>Component</th></tr>'
+        const body = document.createElement('tbody')
+        records.forEach((record) => {
+          const cells = record.querySelectorAll(':scope > td')
+          if (cells.length >= 2) record.insertBefore(cells[1], cells[0])
+          body.append(record)
+        })
+        table.append(head, body)
+        wrap.append(table)
+        return wrap
+      }
+
+      function createUseCaseGroup(primary, relatedRecords, roleLabel) {
+        const group = document.createElement('details')
+        group.className = 'use-case-group architecture-record'
+        group.dataset.subdomain = primary.dataset.subdomain
+        group.dataset.layer = primary.dataset.layer
+        group.dataset.change = primary.dataset.change
+        group.dataset.values = primary.dataset.values
+
+        const summary = document.createElement('summary')
+        summary.className = 'use-case-summary'
+        summary.innerHTML = '<i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i>'
+        const sourceLink = primary.querySelector('.code-link')?.cloneNode(true)
+        if (sourceLink !== undefined) summary.append(sourceLink)
+        const role = document.createElement('span')
+        role.className = 'use-case-role'
+        role.textContent = roleLabel
+        const count = document.createElement('span')
+        count.className = 'use-case-count'
+        count.textContent = `${relatedRecords.length + 1} elements`
+        summary.append(role, count)
+
+        const body = document.createElement('div')
+        body.className = 'use-case-body'
+        body.append(createRecordTable(relatedRecords))
+        group.append(summary, body)
+        primary.remove()
+        return group
+      }
+
+      function createUseCaseCategory(role, primaries, records, assigned) {
+        const definition = primaryRoles.get(role)
+        const category = document.createElement('section')
+        category.className = 'use-case-category'
+        const heading = document.createElement('h5')
+        heading.className = 'use-case-category-title'
+        heading.textContent = `${definition.heading} (${primaries.length})`
+        const list = document.createElement('div')
+        list.className = 'use-case-list'
+
+        primaries.forEach((primary) => {
+          const related = records.filter(
+            (candidate) => !assigned.has(candidate) && isRelatedRecord(primary, candidate),
+          )
+          assigned.add(primary)
+          related.forEach((record) => assigned.add(record))
+          list.append(createUseCaseGroup(primary, related, definition.label))
+        })
+        category.append(heading, list)
+        return category
+      }
+
+      function createSupportingGroup(records) {
+        const group = document.createElement('details')
+        group.className = 'supporting-group'
+        const summary = document.createElement('summary')
+        summary.className = 'supporting-summary'
+        summary.innerHTML = '<i class="ph ph-caret-right disclosure-caret" aria-hidden="true"></i><strong>Supporting changes</strong>'
+        const count = document.createElement('span')
+        count.className = 'use-case-count'
+        count.textContent = `${records.length} elements`
+        summary.append(count)
+        group.append(summary, createRecordTable(records))
+        return group
+      }
+
+      document.querySelectorAll('.layer-card').forEach((layer) => {
+        if (layer.querySelector('.layer-summary h3')?.textContent !== 'Use cases') return
+        layer.querySelectorAll('.change-section').forEach((changeSection) => {
+          const records = [...changeSection.querySelectorAll('tbody > .architecture-record')]
+          const primaries = records.filter(isPrimaryRecord)
+          if (primaries.length === 0) return
+          const assigned = new Set()
+          const categories = [...primaryRoles.keys()].flatMap((role) => {
+            const rolePrimaries = primaries.filter((record) => recordRole(record) === role)
+            return rolePrimaries.length === 0
+              ? []
+              : [createUseCaseCategory(role, rolePrimaries, records, assigned)]
+          })
+          const supporting = records.filter((record) => !assigned.has(record))
+          changeSection.querySelector(':scope > .table-wrap')?.remove()
+          changeSection.append(...categories)
+          if (supporting.length > 0) changeSection.append(createSupportingGroup(supporting))
+        })
+      })
+    </script>
+
+
+</body></html>

--- a/docs/project/PRD/pull-request-diffs/prototypes/benchmark-architecture-diff-memory-worker.ts
+++ b/docs/project/PRD/pull-request-diffs/prototypes/benchmark-architecture-diff-memory-worker.ts
@@ -1,0 +1,66 @@
+import { TypescriptWorkspaceReader } from '@living-architecture/living-documentation-use-cases/infra/external-clients/typescript/typescript-workspace-reader'
+import { architectureSnapshotToRiviereGraph } from './riviere-architecture-graph-fixture'
+import { ArchitectureDiffPrototypeError } from './riviere-architecture-graph-types'
+import {
+  architectureDiffFromRiviereGraphs,
+  architectureDiffFromSnapshots,
+} from './riviere-graph-architecture-diff-poc'
+
+const [approach, baseWorkspaceRoot, headWorkspaceRoot, baseCommit, headCommit] =
+  process.argv.slice(2)
+if (
+  (approach !== 'snapshot' && approach !== 'graph') ||
+  baseWorkspaceRoot === undefined ||
+  headWorkspaceRoot === undefined ||
+  baseCommit === undefined ||
+  headCommit === undefined
+) {
+  throw new ArchitectureDiffPrototypeError(
+    'Usage: benchmark-architecture-diff-memory-worker.ts <snapshot|graph> <base-workspace> <head-workspace> <base-commit> <head-commit>',
+  )
+}
+
+const validatedBaseCommit: string = baseCommit
+const validatedHeadCommit: string = headCommit
+const reader = new TypescriptWorkspaceReader()
+const baseSnapshot = reader.readArchitectureSnapshot(baseWorkspaceRoot)
+const headSnapshot = reader.readArchitectureSnapshot(headWorkspaceRoot)
+const output =
+  approach === 'snapshot'
+    ? repeatedOutput(() => architectureDiffFromSnapshots(baseSnapshot, headSnapshot))
+    : graphOutput()
+
+process.stdout.write(`${Buffer.byteLength(output)}\n`)
+
+function graphOutput(): string {
+  const baseGraphJson = JSON.stringify(
+    architectureSnapshotToRiviereGraph(
+      baseSnapshot,
+      'NTCoding/living-architecture',
+      validatedBaseCommit,
+    ),
+  )
+  const headGraphJson = JSON.stringify(
+    architectureSnapshotToRiviereGraph(
+      headSnapshot,
+      'NTCoding/living-architecture',
+      validatedHeadCommit,
+    ),
+  )
+  return repeatedOutput(() =>
+    architectureDiffFromRiviereGraphs(
+      JSON.parse(baseGraphJson),
+      JSON.parse(headGraphJson),
+      'architecture-diff.md',
+    ),
+  )
+}
+
+function repeatedOutput(operation: () => string): string {
+  const outputs = Array.from({ length: 25 }, operation)
+  const final = outputs.at(-1)
+  if (final === undefined) {
+    throw new ArchitectureDiffPrototypeError('Expected at least one memory benchmark operation.')
+  }
+  return final
+}

--- a/docs/project/PRD/pull-request-diffs/prototypes/benchmark-riviere-graph-architecture-diff.ts
+++ b/docs/project/PRD/pull-request-diffs/prototypes/benchmark-riviere-graph-architecture-diff.ts
@@ -1,0 +1,281 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { fileURLToPath } from 'node:url'
+import {
+  ArchitectureDiff,
+  ArchitectureSource,
+  extractArchitecture,
+} from '@living-architecture/living-documentation-domain-model/domain/architecture'
+import { TypescriptWorkspaceReader } from '@living-architecture/living-documentation-use-cases/infra/external-clients/typescript/typescript-workspace-reader'
+import {
+  architectureDiffFromRiviereGraphs,
+  architectureDiffFromSnapshots,
+  architectureSnapshotFromRiviereGraph,
+} from './riviere-graph-architecture-diff-poc'
+import { architectureSnapshotToRiviereGraph } from './riviere-architecture-graph-fixture'
+import { ArchitectureDiffPrototypeError } from './riviere-architecture-graph-types'
+import { renderOriginalPullRequestArchitectureDiff } from './render-original-pr-architecture-diff'
+
+interface Measurement<T> {
+  readonly durationMilliseconds: number
+  readonly result: T
+}
+
+type ArchitectureSnapshot = ReturnType<TypescriptWorkspaceReader['readArchitectureSnapshot']>
+
+interface ScalingMeasurement {
+  readonly factor: number
+  readonly graphBytes: number
+  readonly graphDurationMilliseconds: number
+  readonly snapshotBytes: number
+  readonly snapshotDurationMilliseconds: number
+}
+
+const repetitions = 25
+const [baseWorkspace, headWorkspace, baseCommit, headCommit] = process.argv.slice(2)
+if (
+  baseWorkspace === undefined ||
+  headWorkspace === undefined ||
+  baseCommit === undefined ||
+  headCommit === undefined
+) {
+  throw new ArchitectureDiffPrototypeError(
+    'Expected base workspace, head workspace, base commit, and head commit arguments.',
+  )
+}
+
+const validatedBaseCommit: string = baseCommit
+const validatedHeadCommit: string = headCommit
+const reader = new TypescriptWorkspaceReader()
+const extraction = measure(() => ({
+  base: reader.readArchitectureSnapshot(baseWorkspace),
+  head: reader.readArchitectureSnapshot(headWorkspace),
+}))
+const baseline = repeatedMeasurement(() =>
+  architectureDiffFromSnapshots(extraction.result.base, extraction.result.head),
+)
+const graphCreation = measure(() => ({
+  base: architectureSnapshotToRiviereGraph(
+    extraction.result.base,
+    'NTCoding/living-architecture',
+    validatedBaseCommit,
+  ),
+  head: architectureSnapshotToRiviereGraph(
+    extraction.result.head,
+    'NTCoding/living-architecture',
+    validatedHeadCommit,
+  ),
+}))
+const baseGraphJson = JSON.stringify(graphCreation.result.base)
+const headGraphJson = JSON.stringify(graphCreation.result.head)
+const graphComparison = repeatedMeasurement(() =>
+  architectureDiffFromRiviereGraphs(
+    JSON.parse(baseGraphJson),
+    JSON.parse(headGraphJson),
+    'architecture-diff.md',
+  ),
+)
+
+if (baseline.result !== graphComparison.result) {
+  throw new ArchitectureDiffPrototypeError(
+    'Expected graph architecture diff to be byte identical to snapshot baseline.',
+  )
+}
+
+const resultsDirectory = path.join(path.dirname(fileURLToPath(import.meta.url)), 'results')
+mkdirSync(resultsDirectory, { recursive: true })
+writeFileSync(
+  path.join(resultsDirectory, 'pr-478-riviere-architecture-diff.txt'),
+  graphComparison.result,
+)
+const originalDiff = ArchitectureDiff.fromArchitectures(
+  extractArchitecture(
+    ArchitectureSource.from(
+      originalProofOfConceptSnapshot(
+        architectureSnapshotFromRiviereGraph(graphCreation.result.base),
+      ),
+    ),
+  ),
+  extractArchitecture(
+    ArchitectureSource.from(
+      originalProofOfConceptSnapshot(
+        architectureSnapshotFromRiviereGraph(graphCreation.result.head),
+      ),
+    ),
+  ),
+)
+const originalFormat = renderOriginalPullRequestArchitectureDiff(originalDiff.changes())
+writeFileSync(
+  path.join(resultsDirectory, 'pr-478-riviere-architecture-diff-original-format.txt'),
+  originalFormat,
+)
+
+const snapshotBytes = Buffer.byteLength(
+  JSON.stringify({ base: extraction.result.base, head: extraction.result.head }),
+)
+const graphBytes = Buffer.byteLength(baseGraphJson) + Buffer.byteLength(headGraphJson)
+const baseComponentCount = graphCreation.result.base.components.length
+const headComponentCount = graphCreation.result.head.components.length
+const baseLinkCount = graphCreation.result.base.links.length
+const headLinkCount = graphCreation.result.head.links.length
+const scalingMeasurements = [1, 2, 5, 10].map((factor) =>
+  measureScaling(extraction.result.base, extraction.result.head, factor),
+)
+const scalingRows = scalingMeasurements.map(
+  (measurement) =>
+    `| ${measurement.factor}× | ${formatBytes(measurement.snapshotBytes)} | ${formatMilliseconds(measurement.snapshotDurationMilliseconds)} | ${formatBytes(measurement.graphBytes)} | ${formatMilliseconds(measurement.graphDurationMilliseconds)} |`,
+)
+const report = `# PR #478 architecture diff representation benchmark
+
+**Result:** Graph-derived Markdown is byte identical to the current snapshot-derived Markdown. Rendering the same graph-derived facts with PR #478's original format also matches the published PR comment, apart from trailing blank lines.
+
+| Measurement | Result |
+| --- | ---: |
+| TypeScript snapshot extraction | ${formatMilliseconds(extraction.durationMilliseconds)} |
+| Snapshot diff and Markdown mean (${repetitions} runs) | ${formatMilliseconds(baseline.durationMilliseconds)} |
+| Snapshot JSON size | ${formatBytes(snapshotBytes)} |
+| Diff-specific graph creation | ${formatMilliseconds(graphCreation.durationMilliseconds)} |
+| Graph parse, projection, diff, and Markdown mean (${repetitions} runs) | ${formatMilliseconds(graphComparison.durationMilliseconds)} |
+| Diff-specific graph JSON size | ${formatBytes(graphBytes)} |
+| Base graph components | ${baseComponentCount} |
+| Head graph components | ${headComponentCount} |
+| Base graph semantic links | ${baseLinkCount} |
+| Head graph semantic links | ${headLinkCount} |
+| Combined benchmark process maximum resident set size | ${formatBytes(process.resourceUsage().maxRSS * 1024)} |
+
+## Synthetic scaling of representation and comparison
+
+| PR #478 fact set | Snapshot size | Snapshot diff mean | Diff graph size | Graph parse and diff mean |
+| ---: | ---: | ---: | ---: | ---: |
+${scalingRows.join('\n')}
+
+The scaling benchmark duplicates PR #478's architecture facts under distinct subdomains. It isolates representation and comparison costs; it does not simulate extraction time.
+
+The graph contains only architecture review elements and the semantic links required by the current diff. It is not the repository's main flow graph. Fixture generation uses the current TypeScript reader so this benchmark proves representation and output equivalence, not the future extraction path.
+`
+writeFileSync(path.join(resultsDirectory, 'pr-478-benchmark.txt'), report)
+process.stdout.write(report)
+
+function originalProofOfConceptSnapshot(
+  snapshot: ReturnType<TypescriptWorkspaceReader['readArchitectureSnapshot']>,
+): ReturnType<TypescriptWorkspaceReader['readArchitectureSnapshot']> {
+  return {
+    subdomains: snapshot.subdomains.map((subdomain) => ({
+      name: subdomain.name,
+      layers: {
+        domain: originalProofOfConceptLayer(subdomain.layers.domain),
+        entrypoints: originalProofOfConceptLayer(subdomain.layers.entrypoints),
+        'use-cases': originalProofOfConceptLayer(subdomain.layers['use-cases']),
+      },
+    })),
+  }
+}
+
+function originalProofOfConceptLayer(
+  layer: ReturnType<
+    TypescriptWorkspaceReader['readArchitectureSnapshot']
+  >['subdomains'][number]['layers']['domain'],
+): ReturnType<
+  TypescriptWorkspaceReader['readArchitectureSnapshot']
+>['subdomains'][number]['layers']['domain'] {
+  return {
+    aggregates: layer.aggregates.map((aggregate) => ({
+      entities: aggregate.entities.map(originalProofOfConceptItem),
+      methods: aggregate.methods,
+      name: aggregate.name,
+      packageKind: aggregate.packageKind,
+    })),
+    items: layer.items.map(originalProofOfConceptItem),
+  }
+}
+
+function originalProofOfConceptItem(
+  item: ReturnType<
+    TypescriptWorkspaceReader['readArchitectureSnapshot']
+  >['subdomains'][number]['layers']['domain']['items'][number],
+) {
+  return { name: item.name, packageKind: item.packageKind, role: item.role }
+}
+
+function measureScaling(
+  base: ArchitectureSnapshot,
+  head: ArchitectureSnapshot,
+  factor: number,
+): ScalingMeasurement {
+  const scaledBase = scaledSnapshot(base, factor)
+  const scaledHead = scaledSnapshot(head, factor)
+  const snapshotComparison = repeatedMeasurement(() =>
+    architectureDiffFromSnapshots(scaledBase, scaledHead),
+  )
+  const baseGraph = architectureSnapshotToRiviereGraph(
+    scaledBase,
+    'NTCoding/living-architecture',
+    validatedBaseCommit,
+  )
+  const headGraph = architectureSnapshotToRiviereGraph(
+    scaledHead,
+    'NTCoding/living-architecture',
+    validatedHeadCommit,
+  )
+  const baseJson = JSON.stringify(baseGraph)
+  const headJson = JSON.stringify(headGraph)
+  const graphComparison = repeatedMeasurement(() =>
+    architectureDiffFromRiviereGraphs(
+      JSON.parse(baseJson),
+      JSON.parse(headJson),
+      'architecture-diff.md',
+    ),
+  )
+  if (snapshotComparison.result !== graphComparison.result) {
+    throw new ArchitectureDiffPrototypeError(
+      `Expected equivalent output for ${factor}× scaling benchmark.`,
+    )
+  }
+  return {
+    factor,
+    graphBytes: Buffer.byteLength(baseJson) + Buffer.byteLength(headJson),
+    graphDurationMilliseconds: graphComparison.durationMilliseconds,
+    snapshotBytes: Buffer.byteLength(JSON.stringify({ base: scaledBase, head: scaledHead })),
+    snapshotDurationMilliseconds: snapshotComparison.durationMilliseconds,
+  }
+}
+
+function scaledSnapshot(snapshot: ArchitectureSnapshot, factor: number): ArchitectureSnapshot {
+  return {
+    subdomains: Array.from({ length: factor }, (_, index) =>
+      snapshot.subdomains.map((subdomain) => ({
+        ...subdomain,
+        name: `${subdomain.name}-benchmark-${index + 1}`,
+      })),
+    ).flat(),
+  }
+}
+
+function repeatedMeasurement<T>(operation: () => T): Measurement<T> {
+  const measurements = Array.from({ length: repetitions }, () => measure(operation))
+  const final = measurements.at(-1)
+  if (final === undefined) {
+    throw new ArchitectureDiffPrototypeError('Expected at least one benchmark measurement.')
+  }
+  return {
+    durationMilliseconds:
+      measurements.reduce((total, measurement) => total + measurement.durationMilliseconds, 0) /
+      measurements.length,
+    result: final.result,
+  }
+}
+
+function measure<T>(operation: () => T): Measurement<T> {
+  const startedAt = performance.now()
+  const result = operation()
+  return { durationMilliseconds: performance.now() - startedAt, result }
+}
+
+function formatMilliseconds(durationMilliseconds: number): string {
+  return `${durationMilliseconds.toFixed(2)} ms`
+}
+
+function formatBytes(bytes: number): string {
+  return `${bytes.toLocaleString('en-GB')} bytes`
+}

--- a/docs/project/PRD/pull-request-diffs/prototypes/render-original-pr-architecture-diff.ts
+++ b/docs/project/PRD/pull-request-diffs/prototypes/render-original-pr-architecture-diff.ts
@@ -1,0 +1,140 @@
+import type { ArchitectureDiff } from '@living-architecture/living-documentation-domain-model/domain/architecture'
+
+type Diff = ReturnType<ArchitectureDiff['changes']>
+type SubdomainChanges = Diff['subdomains'][number]
+type LayerName = keyof SubdomainChanges['layers']
+type LayerChanges = SubdomainChanges['layers'][LayerName]
+type ChangeSet = LayerChanges['added']
+type AggregateChanges = ChangeSet['aggregates'][number]
+
+const commentMarker = '<!-- pull-request-architecture-review -->'
+const layerLabels: Readonly<Record<LayerName, string>> = {
+  domain: 'Domain',
+  entrypoints: 'Entry points',
+  'use-cases': 'Use cases',
+}
+const layerNames: readonly LayerName[] = ['entrypoints', 'use-cases', 'domain']
+
+export function renderOriginalPullRequestArchitectureDiff(changes: Diff): string {
+  if (changes.subdomains.length === 0) {
+    return [
+      commentMarker,
+      '# Pull request architecture changes',
+      '',
+      'No architecture changes detected.',
+      '',
+    ].join('\n')
+  }
+  return [
+    commentMarker,
+    '# Pull request architecture changes',
+    '',
+    '## Changed subdomains',
+    '',
+    ...changes.subdomains.map((subdomain) => renderSubdomainSummary(subdomain.name)),
+    '',
+    ...changes.subdomains.flatMap(renderSubdomain),
+  ].join('\n')
+}
+
+function renderSubdomainSummary(name: string): string {
+  const renderedName = renderCodeSpan(name)
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)
+    ? `- [${renderedName}](#subdomain-${name})`
+    : `- ${renderedName}`
+}
+
+function renderSubdomain(subdomain: SubdomainChanges): readonly string[] {
+  return [
+    `## Subdomain: ${renderCodeSpan(subdomain.name)}`,
+    '',
+    ...layerNames.flatMap((layer) => renderLayer(layer, subdomain.layers[layer])),
+  ]
+}
+
+function renderLayer(layer: LayerName, changes: LayerChanges): readonly string[] {
+  if (!hasLayerChanges(changes)) return []
+  return [
+    `### ${layerLabels[layer]}`,
+    '',
+    ...renderChangeSet('Added', layer, changes.added),
+    ...renderChangeSet('Removed', layer, changes.removed),
+  ]
+}
+
+function renderChangeSet(
+  heading: 'Added' | 'Removed',
+  layer: LayerName,
+  changes: ChangeSet,
+): readonly string[] {
+  if (!hasChangeSetChanges(changes)) return []
+  return [
+    `#### ${heading}`,
+    '',
+    ...changes.aggregates.flatMap(renderAggregate),
+    ...renderItems(layer, changes.items),
+  ]
+}
+
+function renderAggregate(aggregate: AggregateChanges): readonly string[] {
+  return [
+    `##### Aggregate: ${renderCodeSpan(aggregate.name)} (${renderCodeSpan(aggregate.packageKind)})`,
+    '',
+    ...renderAggregateMembers(
+      'Aggregate entities',
+      aggregate.entities.map((entity) => entity.name),
+    ),
+    ...renderAggregateMembers('Methods', aggregate.methods),
+    '',
+  ]
+}
+
+function renderAggregateMembers(
+  label: 'Aggregate entities' | 'Methods',
+  members: readonly string[],
+): readonly string[] {
+  return members.length === 0
+    ? []
+    : [`- ${label}`, ...members.map((member) => `    - ${renderCodeSpan(member)}`)]
+}
+
+function renderItems(layer: LayerName, items: ChangeSet['items']): readonly string[] {
+  if (items.length === 0) return []
+  const includePackage = layer === 'domain'
+  return [
+    includePackage ? '| Name | Role | Package |' : '| Name | Role |',
+    includePackage ? '| --- | --- | --- |' : '| --- | --- |',
+    ...items.map((item) =>
+      includePackage
+        ? `| ${renderTableCode(item.name)} | ${renderTableCode(item.role)} | ${renderTableCode(item.packageKind)} |`
+        : `| ${renderTableCode(item.name)} | ${renderTableCode(item.role)} |`,
+    ),
+    '',
+  ]
+}
+
+function hasLayerChanges(changes: LayerChanges): boolean {
+  return hasChangeSetChanges(changes.added) || hasChangeSetChanges(changes.removed)
+}
+
+function hasChangeSetChanges(changes: ChangeSet): boolean {
+  return changes.aggregates.length > 0 || changes.items.length > 0
+}
+
+function renderTableCode(value: string): string {
+  return renderCodeSpan(value, true)
+}
+
+function renderCodeSpan(value: string, escapePipes = false): string {
+  const normalized = value.replaceAll('\r', ' ').replaceAll('\n', ' ')
+  const singleLine = escapePipes
+    ? normalized.replaceAll('\\', '\\\\').replaceAll('|', '\\|')
+    : normalized
+  const delimiter = '`'.repeat(longestBacktickRun(singleLine) + 1)
+  const padding = singleLine.includes('`') ? ' ' : ''
+  return `${delimiter}${padding}${singleLine}${padding}${delimiter}`
+}
+
+function longestBacktickRun(value: string): number {
+  return Math.max(0, ...[...value.matchAll(/`+/g)].map((match) => match[0].length))
+}

--- a/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-benchmark.txt
+++ b/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-benchmark.txt
@@ -1,0 +1,30 @@
+# PR #478 architecture diff representation benchmark
+
+**Result:** Graph-derived Markdown is byte identical to the current snapshot-derived Markdown. Rendering the same graph-derived facts with PR #478's original format also matches the published PR comment, apart from trailing blank lines.
+
+| Measurement | Result |
+| --- | ---: |
+| TypeScript snapshot extraction | 747.01 ms |
+| Snapshot diff and Markdown mean (25 runs) | 3.59 ms |
+| Snapshot JSON size | 136,993 bytes |
+| Diff-specific graph creation | 12.08 ms |
+| Graph parse, projection, diff, and Markdown mean (25 runs) | 7.72 ms |
+| Diff-specific graph JSON size | 576,478 bytes |
+| Base graph components | 598 |
+| Head graph components | 626 |
+| Base graph semantic links | 152 |
+| Head graph semantic links | 158 |
+| Combined benchmark process maximum resident set size | 559,775,744 bytes |
+
+## Synthetic scaling of representation and comparison
+
+| PR #478 fact set | Snapshot size | Snapshot diff mean | Diff graph size | Graph parse and diff mean |
+| ---: | ---: | ---: | ---: | ---: |
+| 1× | 137,161 bytes | 3.24 ms | 628,354 bytes | 6.31 ms |
+| 2× | 274,273 bytes | 6.55 ms | 1,255,280 bytes | 14.06 ms |
+| 5× | 685,609 bytes | 15.91 ms | 3,136,058 bytes | 50.76 ms |
+| 10× | 1,371,183 bytes | 32.03 ms | 6,275,011 bytes | 148.13 ms |
+
+The scaling benchmark duplicates PR #478's architecture facts under distinct subdomains. It isolates representation and comparison costs; it does not simulate extraction time.
+
+The graph contains only architecture review elements and the semantic links required by the current diff. It is not the repository's main flow graph. Fixture generation uses the current TypeScript reader so this benchmark proves representation and output equivalence, not the future extraction path.

--- a/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-peak-memory.txt
+++ b/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-peak-memory.txt
@@ -1,0 +1,8 @@
+# PR #478 isolated peak memory benchmark
+
+Median of five isolated process runs. Each range shows the minimum and maximum measured process peak.
+
+| Approach | Median maximum resident set size | Five-run range |
+| --- | ---: | ---: |
+| Snapshot extraction and diff | 364707840 bytes | 364429312-366575616 bytes |
+| Diff graph extraction, creation, parse, and diff | 367329280 bytes | 366821376-370196480 bytes |

--- a/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-riviere-architecture-diff-original-format.txt
+++ b/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-riviere-architecture-diff-original-format.txt
@@ -1,0 +1,455 @@
+<!-- pull-request-architecture-review -->
+# Pull request architecture changes
+
+## Changed subdomains
+
+- [`riviere-builder`](#subdomain-riviere-builder)
+- [`riviere-extract-config`](#subdomain-riviere-extract-config)
+- [`riviere-extract-ts`](#subdomain-riviere-extract-ts)
+
+## Subdomain: `riviere-builder`
+
+### Entry points
+
+#### Removed
+
+| Name | Role |
+| --- | --- |
+| `createAddComponentCommand` | `cli-entrypoint` |
+| `CreateAddComponentCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createAddDomainCommand` | `cli-entrypoint` |
+| `CreateAddDomainCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createAddSourceCommand` | `cli-entrypoint` |
+| `CreateAddSourceCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createCheckConsistencyCommand` | `cli-entrypoint` |
+| `CreateCheckConsistencyCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createDefineCustomTypeCommand` | `cli-entrypoint` |
+| `CreateDefineCustomTypeCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createDefineRelationshipTypeCommand` | `cli-entrypoint` |
+| `CreateDefineRelationshipTypeCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createEnrichCommand` | `cli-entrypoint` |
+| `CreateEnrichCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createFinalizeCommand` | `cli-entrypoint` |
+| `CreateFinalizeCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createFinalizeGraphInput` | `command-input-factory` |
+| `createInitCommand` | `cli-entrypoint` |
+| `CreateInitCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createLinkCommand` | `cli-entrypoint` |
+| `CreateLinkCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createLinkExternalCommand` | `cli-entrypoint` |
+| `CreateLinkExternalCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createLinkHttpCommand` | `cli-entrypoint` |
+| `CreateLinkHttpCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createValidateCommand` | `cli-entrypoint` |
+| `CreateValidateCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `parseAddComponentInput` | `entrypoint-cli-input-parser` |
+| `parseDomainJson` | `entrypoint-cli-input-parser` |
+| `parseLinkSourceLocation` | `entrypoint-cli-input-parser` |
+| `parsePropertySpecs` | `entrypoint-cli-input-parser` |
+| `parseSignature` | `entrypoint-cli-input-parser` |
+| `parseStateChanges` | `entrypoint-cli-input-parser` |
+| `writeFinalizedGraph` | `cli-response-writer` |
+
+### Use cases
+
+#### Added
+
+| Name | Role |
+| --- | --- |
+| `ChecklistComponent` | `query-model-value` |
+| `ComponentChecklist` | `query-model-use-case` |
+| `ComponentChecklistErrorCode` | `query-model-value` |
+| `ComponentChecklistInput` | `query-model-use-case-input` |
+| `ComponentChecklistLoader` | `query-model-loader` |
+| `ComponentChecklistResult` | `query-model` |
+| `ComponentSummary` | `query-model-use-case` |
+| `ComponentSummaryErrorCode` | `query-model-value` |
+| `ComponentSummaryInput` | `query-model-use-case-input` |
+| `ComponentSummaryLoader` | `query-model-loader` |
+| `ComponentSummaryResult` | `query-model` |
+
+#### Removed
+
+| Name | Role |
+| --- | --- |
+| `AddComponent` | `command-use-case` |
+| `AddComponentErrorCode` | `command-use-case-result-value` |
+| `AddComponentInput` | `command-use-case-input` |
+| `AddComponentResult` | `command-use-case-result` |
+| `AddDomain` | `command-use-case` |
+| `AddDomainErrorCode` | `command-use-case-result-value` |
+| `AddDomainInput` | `command-use-case-input` |
+| `AddDomainResult` | `command-use-case-result` |
+| `AddSource` | `command-use-case` |
+| `AddSourceErrorCode` | `command-use-case-result-value` |
+| `AddSourceInput` | `command-use-case-input` |
+| `AddSourceResult` | `command-use-case-result` |
+| `BuilderWarnings` | `command-use-case-result-value` |
+| `CheckConsistency` | `command-use-case` |
+| `CheckConsistencyErrorCode` | `command-use-case-result-value` |
+| `CheckConsistencyInput` | `command-use-case-input` |
+| `CheckConsistencyResult` | `command-use-case-result` |
+| `ChecklistComponent` | `command-use-case-result-value` |
+| `ComponentChecklist` | `command-use-case` |
+| `ComponentChecklistErrorCode` | `command-use-case-result-value` |
+| `ComponentChecklistInput` | `command-use-case-input` |
+| `ComponentChecklistResult` | `command-use-case-result` |
+| `ComponentSummary` | `command-use-case` |
+| `ComponentSummaryErrorCode` | `command-use-case-result-value` |
+| `ComponentSummaryInput` | `command-use-case-input` |
+| `ComponentSummaryResult` | `command-use-case-result` |
+| `DefineCustomType` | `command-use-case` |
+| `DefineCustomTypeErrorCode` | `command-use-case-result-value` |
+| `DefineCustomTypeInput` | `command-use-case-input` |
+| `DefineCustomTypeResult` | `command-use-case-result` |
+| `DefineRelationshipType` | `command-use-case` |
+| `DefineRelationshipTypeErrorCode` | `command-use-case-result-value` |
+| `DefineRelationshipTypeInput` | `command-use-case-input` |
+| `DefineRelationshipTypeResult` | `command-use-case-result` |
+| `EnrichComponent` | `command-use-case` |
+| `EnrichComponentErrorCode` | `command-use-case-result-value` |
+| `EnrichComponentInput` | `command-use-case-input` |
+| `EnrichComponentResult` | `command-use-case-result` |
+| `FinalizedGraph` | `command-use-case-result-value` |
+| `FinalizeGraph` | `command-use-case` |
+| `FinalizeGraphErrorCode` | `command-use-case-result-value` |
+| `FinalizeGraphInput` | `command-use-case-input` |
+| `FinalizeGraphResult` | `command-use-case-result` |
+| `InitDomainInput` | `command-use-case-input` |
+| `InitGraph` | `command-use-case` |
+| `InitGraphErrorCode` | `command-use-case-result-value` |
+| `InitGraphInput` | `command-use-case-input` |
+| `InitGraphResult` | `command-use-case-result` |
+| `LinkComponents` | `command-use-case` |
+| `LinkComponentsErrorCode` | `command-use-case-result-value` |
+| `LinkComponentsInput` | `command-use-case-input` |
+| `LinkComponentsResult` | `command-use-case-result` |
+| `LinkExternal` | `command-use-case` |
+| `LinkExternalErrorCode` | `command-use-case-result-value` |
+| `LinkExternalInput` | `command-use-case-input` |
+| `LinkExternalResult` | `command-use-case-result` |
+| `LinkHttp` | `command-use-case` |
+| `LinkHttpErrorCode` | `command-use-case-result-value` |
+| `LinkHttpInput` | `command-use-case-input` |
+| `LinkHttpResult` | `command-use-case-result` |
+| `MatchedApi` | `command-use-case-result-value` |
+| `RiviereBuilderRepository` | `aggregate-repository` |
+| `ValidateGraph` | `command-use-case` |
+| `ValidateGraphErrorCode` | `command-use-case-result-value` |
+| `ValidateGraphInput` | `command-use-case-input` |
+| `ValidateGraphResult` | `command-use-case-result` |
+| `ValidationData` | `command-use-case-result-value` |
+| `writeUtf8File` | `external-client-service` |
+
+### Domain
+
+#### Added
+
+| Name | Role | Package |
+| --- | --- | --- |
+| `ApiDefinition` | `value-object` | `published-language` |
+| `BuildValidationError` | `domain-error` | `published-language` |
+| `BusinessRules` | `value-object` | `published-language` |
+| `Component` | `value-object` | `published-language` |
+| `ComponentDefinition` | `value-object` | `published-language` |
+| `ComponentNotFoundError` | `domain-error` | `published-language` |
+| `ComponentType` | `value-object` | `published-language` |
+| `ComponentTypeMismatchError` | `domain-error` | `published-language` |
+| `CustomComponentDefinition` | `value-object` | `published-language` |
+| `CustomComponentProperties` | `value-object` | `published-language` |
+| `CustomTypeAlreadyDefinedError` | `domain-error` | `published-language` |
+| `CustomTypeNotFoundError` | `domain-error` | `published-language` |
+| `DomainNotFoundError` | `domain-error` | `published-language` |
+| `DomainOperationBehavior` | `value-object` | `published-language` |
+| `DuplicateComponentError` | `domain-error` | `published-language` |
+| `DuplicateDomainError` | `domain-error` | `published-language` |
+| `DuplicateLinkError` | `domain-error` | `published-language` |
+| `DuplicateLinkWarning` | `published-language-data-structure` | `published-language` |
+| `ExistingValuePreference` | `value-object` | `published-language` |
+| `ExternalLink` | `value-object` | `published-language` |
+| `GraphDiagnostics` | `value-object` | `published-language` |
+| `GraphWarning` | `published-language-union` | `published-language` |
+| `HttpMethod` | `value-object` | `published-language` |
+| `InvalidEnrichmentTargetError` | `domain-error` | `published-language` |
+| `InvalidGraphError` | `domain-error` | `published-language` |
+| `Link` | `value-object` | `published-language` |
+| `LinkType` | `value-object` | `published-language` |
+| `MissingDomainsError` | `domain-error` | `published-language` |
+| `MissingRequiredPropertiesError` | `domain-error` | `published-language` |
+| `MissingSourcesError` | `domain-error` | `published-language` |
+| `NearMatchMismatch` | `published-language-data-structure` | `published-language` |
+| `NearMatchOptions` | `published-language-data-structure` | `published-language` |
+| `NearMatchQuery` | `published-language-data-structure` | `published-language` |
+| `NearMatchResult` | `published-language-data-structure` | `published-language` |
+| `OperationWarning` | `published-language-union` | `published-language` |
+| `OrphanComponentWarning` | `published-language-data-structure` | `published-language` |
+| `RelationshipTypeAlreadyDefinedError` | `domain-error` | `published-language` |
+| `RelationshipTypeNotFoundError` | `domain-error` | `published-language` |
+| `RiviereBuilder` | `value-object` | `published-language` |
+| `RiviereGraphDefinition` | `value-object` | `published-language` |
+| `ScalarOverwriteWarning` | `published-language-data-structure` | `published-language` |
+| `SourceConflictError` | `domain-error` | `published-language` |
+| `StateTransitions` | `value-object` | `published-language` |
+| `SubscribedEvents` | `value-object` | `published-language` |
+| `SystemType` | `value-object` | `published-language` |
+| `UnusedDomainWarning` | `published-language-data-structure` | `published-language` |
+
+#### Removed
+
+##### Aggregate: `RiviereBuilder` (`domain-model`)
+
+- Methods
+    - `addApi`
+    - `addCustom`
+    - `addDomain`
+    - `addDomainOp`
+    - `addEvent`
+    - `addEventHandler`
+    - `addSource`
+    - `addUI`
+    - `addUseCase`
+    - `build`
+    - `defineCustomType`
+    - `defineRelationshipType`
+    - `enrichComponent`
+    - `link`
+    - `linkExternal`
+    - `nearMatches`
+    - `new`
+    - `orphans`
+    - `resume`
+    - `serialize`
+    - `stats`
+    - `upsertApi`
+    - `upsertCustom`
+    - `upsertDomainOp`
+    - `upsertEvent`
+    - `upsertEventHandler`
+    - `upsertUI`
+    - `upsertUseCase`
+    - `validate`
+    - `warnings`
+
+| Name | Role | Package |
+| --- | --- | --- |
+| `ApiDefinition` | `value-object` | `domain-model` |
+| `BuildValidationError` | `domain-error` | `domain-model` |
+| `BusinessRules` | `value-object` | `domain-model` |
+| `calculateStats` | `domain-service` | `domain-model` |
+| `Component` | `aggregate-entity` | `domain-model` |
+| `ComponentDefinition` | `value-object` | `domain-model` |
+| `ComponentType` | `value-object` | `domain-model` |
+| `ComponentTypeMismatchError` | `domain-error` | `domain-model` |
+| `CustomComponentDefinition` | `value-object` | `domain-model` |
+| `CustomComponentProperties` | `value-object` | `domain-model` |
+| `CustomTypeAlreadyDefinedError` | `domain-error` | `domain-model` |
+| `CustomTypeNotFoundError` | `domain-error` | `domain-model` |
+| `detectOrphanComponents` | `domain-service` | `domain-model` |
+| `DomainNotFoundError` | `domain-error` | `domain-model` |
+| `DomainOperationBehavior` | `value-object` | `domain-model` |
+| `DuplicateComponentError` | `domain-error` | `domain-model` |
+| `DuplicateDomainError` | `domain-error` | `domain-model` |
+| `DuplicateLinkError` | `domain-error` | `domain-model` |
+| `ExistingValuePreference` | `value-object` | `domain-model` |
+| `ExternalLink` | `value-object` | `domain-model` |
+| `findNearMatches` | `domain-service` | `domain-model` |
+| `findOrphans` | `domain-service` | `domain-model` |
+| `findWarnings` | `domain-service` | `domain-model` |
+| `HttpMethod` | `value-object` | `domain-model` |
+| `InvalidEnrichmentTargetError` | `domain-error` | `domain-model` |
+| `InvalidGraphError` | `domain-error` | `domain-model` |
+| `Link` | `value-object` | `domain-model` |
+| `LinkType` | `value-object` | `domain-model` |
+| `MissingDomainsError` | `domain-error` | `domain-model` |
+| `MissingRequiredPropertiesError` | `domain-error` | `domain-model` |
+| `MissingSourcesError` | `domain-error` | `domain-model` |
+| `RelationshipTypeAlreadyDefinedError` | `domain-error` | `domain-model` |
+| `RelationshipTypeNotFoundError` | `domain-error` | `domain-model` |
+| `RiviereGraphDefinition` | `value-object` | `domain-model` |
+| `SourceConflictError` | `domain-error` | `domain-model` |
+| `StateTransitions` | `value-object` | `domain-model` |
+| `SubscribedEvents` | `value-object` | `domain-model` |
+| `SystemType` | `value-object` | `domain-model` |
+
+## Subdomain: `riviere-extract-config`
+
+### Domain
+
+#### Added
+
+| Name | Role | Package |
+| --- | --- | --- |
+| `parseWorkflowDefinition` | `published-language-parser` | `published-language` |
+| `WorkflowDefinition` | `published-language-schema` | `published-language` |
+| `WorkflowDefinitionParseFailure` | `published-language-data-structure` | `published-language` |
+| `WorkflowDefinitionParseResult` | `published-language-union` | `published-language` |
+| `WorkflowDefinitionParseSuccess` | `published-language-data-structure` | `published-language` |
+| `WorkflowExtractStageDefinition` | `published-language-data-structure` | `published-language` |
+| `WorkflowGraphDefinition` | `published-language-data-structure` | `published-language` |
+| `WorkflowLinkStageDefinition` | `published-language-data-structure` | `published-language` |
+| `WorkflowRunLogDefinition` | `published-language-data-structure` | `published-language` |
+| `WorkflowStageDefinition` | `published-language-union` | `published-language` |
+| `WorkflowValidateStageDefinition` | `published-language-data-structure` | `published-language` |
+
+## Subdomain: `riviere-extract-ts`
+
+### Entry points
+
+#### Added
+
+| Name | Role |
+| --- | --- |
+| `createAddComponentCommand` | `cli-entrypoint` |
+| `CreateAddComponentCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createAddDomainCommand` | `cli-entrypoint` |
+| `CreateAddDomainCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createAddSourceCommand` | `cli-entrypoint` |
+| `CreateAddSourceCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createCheckConsistencyCommand` | `cli-entrypoint` |
+| `CreateCheckConsistencyCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createDefineCustomTypeCommand` | `cli-entrypoint` |
+| `CreateDefineCustomTypeCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createDefineRelationshipTypeCommand` | `cli-entrypoint` |
+| `CreateDefineRelationshipTypeCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createEnrichCommand` | `cli-entrypoint` |
+| `CreateEnrichCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createFinalizeCommand` | `cli-entrypoint` |
+| `CreateFinalizeCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createFinalizeGraphInput` | `command-input-factory` |
+| `createInitCommand` | `cli-entrypoint` |
+| `CreateInitCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createLinkCommand` | `cli-entrypoint` |
+| `CreateLinkCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createLinkExternalCommand` | `cli-entrypoint` |
+| `CreateLinkExternalCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createLinkHttpCommand` | `cli-entrypoint` |
+| `CreateLinkHttpCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `createValidateCommand` | `cli-entrypoint` |
+| `CreateValidateCommandEntrypointDependencies` | `cli-entrypoint-dependencies` |
+| `parseAddComponentInput` | `entrypoint-cli-input-parser` |
+| `parseDomainJson` | `entrypoint-cli-input-parser` |
+| `parseLinkSourceLocation` | `entrypoint-cli-input-parser` |
+| `parsePropertySpecs` | `entrypoint-cli-input-parser` |
+| `parseSignature` | `entrypoint-cli-input-parser` |
+| `parseStateChanges` | `entrypoint-cli-input-parser` |
+| `writeFinalizedGraph` | `cli-response-writer` |
+
+### Use cases
+
+#### Added
+
+| Name | Role |
+| --- | --- |
+| `AddComponent` | `command-use-case` |
+| `AddComponentErrorCode` | `command-use-case-result-value` |
+| `AddComponentInput` | `command-use-case-input` |
+| `AddComponentResult` | `command-use-case-result` |
+| `AddDomain` | `command-use-case` |
+| `AddDomainErrorCode` | `command-use-case-result-value` |
+| `AddDomainInput` | `command-use-case-input` |
+| `AddDomainResult` | `command-use-case-result` |
+| `AddSource` | `command-use-case` |
+| `AddSourceErrorCode` | `command-use-case-result-value` |
+| `AddSourceInput` | `command-use-case-input` |
+| `AddSourceResult` | `command-use-case-result` |
+| `BuilderWarnings` | `command-use-case-result-value` |
+| `CheckConsistency` | `command-use-case` |
+| `CheckConsistencyErrorCode` | `command-use-case-result-value` |
+| `CheckConsistencyInput` | `command-use-case-input` |
+| `CheckConsistencyResult` | `command-use-case-result` |
+| `createTypeScriptProjects` | `external-client-service` |
+| `DefineCustomType` | `command-use-case` |
+| `DefineCustomTypeErrorCode` | `command-use-case-result-value` |
+| `DefineCustomTypeInput` | `command-use-case-input` |
+| `DefineCustomTypeResult` | `command-use-case-result` |
+| `DefineRelationshipType` | `command-use-case` |
+| `DefineRelationshipTypeErrorCode` | `command-use-case-result-value` |
+| `DefineRelationshipTypeInput` | `command-use-case-input` |
+| `DefineRelationshipTypeResult` | `command-use-case-result` |
+| `EnrichComponent` | `command-use-case` |
+| `EnrichComponentErrorCode` | `command-use-case-result-value` |
+| `EnrichComponentInput` | `command-use-case-input` |
+| `EnrichComponentResult` | `command-use-case-result` |
+| `FinalizedGraph` | `command-use-case-result-value` |
+| `FinalizeGraph` | `command-use-case` |
+| `FinalizeGraphErrorCode` | `command-use-case-result-value` |
+| `FinalizeGraphInput` | `command-use-case-input` |
+| `FinalizeGraphResult` | `command-use-case-result` |
+| `globSourceFiles` | `external-client-service` |
+| `GraphCorruptedError` | `data-access-error` |
+| `GraphNotFoundError` | `data-access-error` |
+| `InitDomainInput` | `command-use-case-input` |
+| `InitGraph` | `command-use-case` |
+| `InitGraphErrorCode` | `command-use-case-result-value` |
+| `InitGraphInput` | `command-use-case-input` |
+| `InitGraphResult` | `command-use-case-result` |
+| `LinkComponents` | `command-use-case` |
+| `LinkComponentsErrorCode` | `command-use-case-result-value` |
+| `LinkComponentsInput` | `command-use-case-input` |
+| `LinkComponentsResult` | `command-use-case-result` |
+| `LinkExternal` | `command-use-case` |
+| `LinkExternalErrorCode` | `command-use-case-result-value` |
+| `LinkExternalInput` | `command-use-case-input` |
+| `LinkExternalResult` | `command-use-case-result` |
+| `LinkHttp` | `command-use-case` |
+| `LinkHttpErrorCode` | `command-use-case-result-value` |
+| `LinkHttpInput` | `command-use-case-input` |
+| `LinkHttpResult` | `command-use-case-result` |
+| `MatchedApi` | `command-use-case-result-value` |
+| `RunWorkflow` | `command-use-case` |
+| `RunWorkflowInput` | `command-use-case-input` |
+| `RunWorkflowResult` | `command-use-case-result` |
+| `ValidateGraph` | `command-use-case` |
+| `ValidateGraphErrorCode` | `command-use-case-result-value` |
+| `ValidateGraphInput` | `command-use-case-input` |
+| `ValidateGraphResult` | `command-use-case-result` |
+| `ValidationData` | `command-use-case-result-value` |
+| `YamlDocumentError` | `external-client-error` |
+| `YamlDocumentReader` | `external-client-service` |
+
+### Domain
+
+#### Added
+
+##### Aggregate: `RiviereProject` (`domain-model`)
+
+- Aggregate entities
+    - `Workflow`
+- Methods
+    - `addComponent`
+    - `addDomain`
+    - `addSource`
+    - `addWorkflow`
+    - `build`
+    - `defineCustomType`
+    - `defineRelationshipType`
+    - `enrichComponent`
+    - `link`
+    - `linkExternal`
+    - `rebuildGraph`
+    - `rehydrate`
+    - `serialize`
+    - `start`
+    - `validate`
+    - `warnings`
+
+| Name | Role | Package |
+| --- | --- | --- |
+| `ExtractionConfigurationUnavailableError` | `domain-error` | `domain-model` |
+| `GraphStateUnavailableError` | `domain-error` | `domain-model` |
+| `WorkflowDefinitionFailure` | `value-object` | `domain-model` |
+| `WorkflowRunEvent` | `value-object` | `domain-model` |
+| `WorkflowStage` | `value-object` | `domain-model` |
+
+#### Removed
+
+##### Aggregate: `RiviereProject` (`domain-model`)
+
+- Methods
+    - `parse`
+
+| Name | Role | Package |
+| --- | --- | --- |
+| `detectCallsInCallable` | `domain-service` | `domain-model` |
+| `locateComponentCallables` | `domain-service` | `domain-model` |
+| `resolveCallTargets` | `domain-service` | `domain-model` |

--- a/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-riviere-architecture-diff.txt
+++ b/docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-riviere-architecture-diff.txt
@@ -1,0 +1,921 @@
+<!-- pull-request-architecture-review -->
+# Architecture changes
+
+## Summary
+
+| Subdomain | Status | Added | Removed |
+| --- | --- | --- | --- |
+| 🌍 **`riviere-builder`** | Changed | 2 query use cases · 3 query model values · 46 domain items | 13 entry points · 15 command use cases · 1 aggregate · 38 domain items · `filesystem` external client with 1 component · 23 uncategorised changes |
+| 🌍 **`riviere-extract-config`** | Changed | 11 domain items | — |
+| 🌍 **`riviere-extract-ts`** | Changed | 13 entry points · 16 command use cases · 1 aggregate · 5 domain items · `glob` external client with 1 component · `ts-morph` external client with 1 component · `yaml` external client with 2 components · 18 uncategorised changes | 2 command use cases · 1 aggregate · 3 domain items |
+
+---
+
+<details open>
+<summary><h2>🌍 riviere-builder</h2></summary>
+
+### Entry points (13 removed)
+
+<details>
+<summary>createAddComponentCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseAddComponentInput` |
+
+</details>
+
+- <span>createAddDomainCommand</span>
+
+- <span>createAddSourceCommand</span>
+
+- <span>createCheckConsistencyCommand</span>
+
+<details>
+<summary>createDefineCustomTypeCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parsePropertySpecs` |
+
+</details>
+
+- <span>createDefineRelationshipTypeCommand</span>
+
+<details>
+<summary>createEnrichCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseSignature` |
+| `entrypoint-cli-input-parser` | `parseStateChanges` |
+
+</details>
+
+<details>
+<summary>createFinalizeCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-input-factory` | `createFinalizeGraphInput` |
+| `cli-response-writer` | `writeFinalizedGraph` |
+
+</details>
+
+<details>
+<summary>createInitCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseDomainJson` |
+
+</details>
+
+<details>
+<summary>createLinkCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseLinkSourceLocation` |
+
+</details>
+
+- <span>createLinkExternalCommand</span>
+
+- <span>createLinkHttpCommand</span>
+
+- <span>createValidateCommand</span>
+
+### Command use cases (15 removed)
+
+<details>
+<summary>AddComponent</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `AddComponentInput` |
+| `command-use-case-result` | `AddComponentResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>AddDomain</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `AddDomainInput` |
+| `command-use-case-result` | `AddDomainResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>AddSource</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `AddSourceInput` |
+| `command-use-case-result` | `AddSourceResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>CheckConsistency</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `CheckConsistencyInput` |
+| `command-use-case-result` | `CheckConsistencyResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>ComponentChecklist</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `ComponentChecklistInput` |
+| `command-use-case-result` | `ComponentChecklistResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>ComponentSummary</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `ComponentSummaryInput` |
+| `command-use-case-result` | `ComponentSummaryResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>DefineCustomType</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `DefineCustomTypeInput` |
+| `command-use-case-result` | `DefineCustomTypeResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>DefineRelationshipType</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `DefineRelationshipTypeInput` |
+| `command-use-case-result` | `DefineRelationshipTypeResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>EnrichComponent</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `EnrichComponentInput` |
+| `command-use-case-result` | `EnrichComponentResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>FinalizeGraph</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `FinalizeGraphInput` |
+| `command-use-case-result` | `FinalizeGraphResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>InitGraph</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `InitGraphInput` |
+| `command-use-case-result` | `InitGraphResult` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>LinkComponents</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `LinkComponentsInput` |
+| `command-use-case-result` | `LinkComponentsResult` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>LinkExternal</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `LinkExternalInput` |
+| `command-use-case-result` | `LinkExternalResult` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>LinkHttp</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `LinkHttpInput` |
+| `command-use-case-result` | `LinkHttpResult` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+
+</details>
+
+<details>
+<summary>ValidateGraph</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereBuilderRepository` |
+| `command-use-case-input` | `ValidateGraphInput` |
+| `command-use-case-result` | `ValidateGraphResult` |
+
+</details>
+
+### Query use cases (2 added)
+
+<details>
+<summary>ComponentChecklist</summary>
+
+| Role | Component |
+| --- | --- |
+| `query-model-use-case-input` | `ComponentChecklistInput` |
+| `query-model-loader` | `ComponentChecklistLoader` |
+| `query-model` | `ComponentChecklistResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+
+</details>
+
+<details>
+<summary>ComponentSummary</summary>
+
+| Role | Component |
+| --- | --- |
+| `query-model-use-case-input` | `ComponentSummaryInput` |
+| `query-model-loader` | `ComponentSummaryLoader` |
+| `query-model` | `ComponentSummaryResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+
+</details>
+
+### Query models (3 added)
+
+- <span>ChecklistComponent</span> (query-model-value)
+- <span>ComponentChecklistErrorCode</span> (query-model-value)
+- <span>ComponentSummaryErrorCode</span> (query-model-value)
+
+### Domain (46 added, 39 removed)
+
+#### Added
+
+- <span>ApiDefinition</span> (value-object)
+- <span>BuildValidationError</span> (domain-error)
+- <span>BusinessRules</span> (value-object)
+- <span>Component</span> (value-object)
+- <span>ComponentDefinition</span> (value-object)
+- <span>ComponentNotFoundError</span> (domain-error)
+- <span>ComponentType</span> (value-object)
+- <span>ComponentTypeMismatchError</span> (domain-error)
+- <span>CustomComponentDefinition</span> (value-object)
+- <span>CustomComponentProperties</span> (value-object)
+- <span>CustomTypeAlreadyDefinedError</span> (domain-error)
+- <span>CustomTypeNotFoundError</span> (domain-error)
+- <span>DomainNotFoundError</span> (domain-error)
+- <span>DomainOperationBehavior</span> (value-object)
+- <span>DuplicateComponentError</span> (domain-error)
+- <span>DuplicateDomainError</span> (domain-error)
+- <span>DuplicateLinkError</span> (domain-error)
+- <span>DuplicateLinkWarning</span> (published-language-data-structure)
+- <span>ExistingValuePreference</span> (value-object)
+- <span>ExternalLink</span> (value-object)
+- <span>GraphDiagnostics</span> (value-object)
+- <span>GraphWarning</span> (published-language-union)
+- <span>HttpMethod</span> (value-object)
+- <span>InvalidEnrichmentTargetError</span> (domain-error)
+- <span>InvalidGraphError</span> (domain-error)
+- <span>Link</span> (value-object)
+- <span>LinkType</span> (value-object)
+- <span>MissingDomainsError</span> (domain-error)
+- <span>MissingRequiredPropertiesError</span> (domain-error)
+- <span>MissingSourcesError</span> (domain-error)
+- <span>NearMatchMismatch</span> (published-language-data-structure)
+- <span>NearMatchOptions</span> (published-language-data-structure)
+- <span>NearMatchQuery</span> (published-language-data-structure)
+- <span>NearMatchResult</span> (published-language-data-structure)
+- <span>OperationWarning</span> (published-language-union)
+- <span>OrphanComponentWarning</span> (published-language-data-structure)
+- <span>RelationshipTypeAlreadyDefinedError</span> (domain-error)
+- <span>RelationshipTypeNotFoundError</span> (domain-error)
+- <span>RiviereBuilder</span> (value-object)
+- <span>RiviereGraphDefinition</span> (value-object)
+- <span>ScalarOverwriteWarning</span> (published-language-data-structure)
+- <span>SourceConflictError</span> (domain-error)
+- <span>StateTransitions</span> (value-object)
+- <span>SubscribedEvents</span> (value-object)
+- <span>SystemType</span> (value-object)
+- <span>UnusedDomainWarning</span> (published-language-data-structure)
+
+#### Removed
+
+- <span>RiviereBuilder</span> (aggregate, `domain-model`)
+    - Methods
+        - `addApi`
+        - `addCustom`
+        - `addDomain`
+        - `addDomainOp`
+        - `addEvent`
+        - `addEventHandler`
+        - `addSource`
+        - `addUI`
+        - `addUseCase`
+        - `build`
+        - `defineCustomType`
+        - `defineRelationshipType`
+        - `enrichComponent`
+        - `link`
+        - `linkExternal`
+        - `nearMatches`
+        - `new`
+        - `orphans`
+        - `resume`
+        - `serialize`
+        - `stats`
+        - `upsertApi`
+        - `upsertCustom`
+        - `upsertDomainOp`
+        - `upsertEvent`
+        - `upsertEventHandler`
+        - `upsertUI`
+        - `upsertUseCase`
+        - `validate`
+        - `warnings`
+- <span>ApiDefinition</span> (value-object)
+- <span>BuildValidationError</span> (domain-error)
+- <span>BusinessRules</span> (value-object)
+- <span>calculateStats</span> (domain-service)
+- <span>Component</span> (aggregate-entity)
+- <span>ComponentDefinition</span> (value-object)
+- <span>ComponentType</span> (value-object)
+- <span>ComponentTypeMismatchError</span> (domain-error)
+- <span>CustomComponentDefinition</span> (value-object)
+- <span>CustomComponentProperties</span> (value-object)
+- <span>CustomTypeAlreadyDefinedError</span> (domain-error)
+- <span>CustomTypeNotFoundError</span> (domain-error)
+- <span>detectOrphanComponents</span> (domain-service)
+- <span>DomainNotFoundError</span> (domain-error)
+- <span>DomainOperationBehavior</span> (value-object)
+- <span>DuplicateComponentError</span> (domain-error)
+- <span>DuplicateDomainError</span> (domain-error)
+- <span>DuplicateLinkError</span> (domain-error)
+- <span>ExistingValuePreference</span> (value-object)
+- <span>ExternalLink</span> (value-object)
+- <span>findNearMatches</span> (domain-service)
+- <span>findOrphans</span> (domain-service)
+- <span>findWarnings</span> (domain-service)
+- <span>HttpMethod</span> (value-object)
+- <span>InvalidEnrichmentTargetError</span> (domain-error)
+- <span>InvalidGraphError</span> (domain-error)
+- <span>Link</span> (value-object)
+- <span>LinkType</span> (value-object)
+- <span>MissingDomainsError</span> (domain-error)
+- <span>MissingRequiredPropertiesError</span> (domain-error)
+- <span>MissingSourcesError</span> (domain-error)
+- <span>RelationshipTypeAlreadyDefinedError</span> (domain-error)
+- <span>RelationshipTypeNotFoundError</span> (domain-error)
+- <span>RiviereGraphDefinition</span> (value-object)
+- <span>SourceConflictError</span> (domain-error)
+- <span>StateTransitions</span> (value-object)
+- <span>SubscribedEvents</span> (value-object)
+- <span>SystemType</span> (value-object)
+
+### External clients (1 removed)
+
+<details>
+<summary>filesystem — 1 component removed</summary>
+
+<details>
+<summary>external-client-service — 1 removed</summary>
+
+- `writeUtf8File`
+
+</details>
+
+</details>
+
+### Uncategorised changes (23 removed)
+
+- <span>AddComponentErrorCode</span> (command-use-case-result-value)
+- <span>AddDomainErrorCode</span> (command-use-case-result-value)
+- <span>AddSourceErrorCode</span> (command-use-case-result-value)
+- <span>BuilderWarnings</span> (command-use-case-result-value)
+- <span>CheckConsistencyErrorCode</span> (command-use-case-result-value)
+- <span>ChecklistComponent</span> (command-use-case-result-value)
+- <span>ComponentChecklistErrorCode</span> (command-use-case-result-value)
+- <span>ComponentSummaryErrorCode</span> (command-use-case-result-value)
+- <span>DefineCustomTypeErrorCode</span> (command-use-case-result-value)
+- <span>DefineRelationshipTypeErrorCode</span> (command-use-case-result-value)
+- <span>EnrichComponentErrorCode</span> (command-use-case-result-value)
+- <span>FinalizedGraph</span> (command-use-case-result-value)
+- <span>FinalizeGraphErrorCode</span> (command-use-case-result-value)
+- <span>GraphCorruptedError</span> (data-access-error)
+- <span>GraphNotFoundError</span> (data-access-error)
+- <span>InitDomainInput</span> (command-use-case-input)
+- <span>InitGraphErrorCode</span> (command-use-case-result-value)
+- <span>LinkComponentsErrorCode</span> (command-use-case-result-value)
+- <span>LinkExternalErrorCode</span> (command-use-case-result-value)
+- <span>LinkHttpErrorCode</span> (command-use-case-result-value)
+- <span>MatchedApi</span> (command-use-case-result-value)
+- <span>ValidateGraphErrorCode</span> (command-use-case-result-value)
+- <span>ValidationData</span> (command-use-case-result-value)
+
+</details>
+
+---
+
+<details open>
+<summary><h2>🌍 riviere-extract-config</h2></summary>
+
+### Domain (11 added)
+
+- <span>parseWorkflowDefinition</span> (published-language-parser)
+- <span>WorkflowDefinition</span> (published-language-schema)
+- <span>WorkflowDefinitionParseFailure</span> (published-language-data-structure)
+- <span>WorkflowDefinitionParseResult</span> (published-language-union)
+- <span>WorkflowDefinitionParseSuccess</span> (published-language-data-structure)
+- <span>WorkflowExtractStageDefinition</span> (published-language-data-structure)
+- <span>WorkflowGraphDefinition</span> (published-language-data-structure)
+- <span>WorkflowLinkStageDefinition</span> (published-language-data-structure)
+- <span>WorkflowRunLogDefinition</span> (published-language-data-structure)
+- <span>WorkflowStageDefinition</span> (published-language-union)
+- <span>WorkflowValidateStageDefinition</span> (published-language-data-structure)
+
+</details>
+
+---
+
+<details open>
+<summary><h2>🌍 riviere-extract-ts</h2></summary>
+
+### Entry points (13 added)
+
+<details>
+<summary>createAddComponentCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseAddComponentInput` |
+
+</details>
+
+- <span>createAddDomainCommand</span>
+
+- <span>createAddSourceCommand</span>
+
+- <span>createCheckConsistencyCommand</span>
+
+<details>
+<summary>createDefineCustomTypeCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parsePropertySpecs` |
+
+</details>
+
+- <span>createDefineRelationshipTypeCommand</span>
+
+<details>
+<summary>createEnrichCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseSignature` |
+| `entrypoint-cli-input-parser` | `parseStateChanges` |
+
+</details>
+
+<details>
+<summary>createFinalizeCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-input-factory` | `createFinalizeGraphInput` |
+| `cli-response-writer` | `writeFinalizedGraph` |
+
+</details>
+
+<details>
+<summary>createInitCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseDomainJson` |
+
+</details>
+
+<details>
+<summary>createLinkCommand</summary>
+
+| Role | Component |
+| --- | --- |
+| `entrypoint-cli-input-parser` | `parseLinkSourceLocation` |
+
+</details>
+
+- <span>createLinkExternalCommand</span>
+
+- <span>createLinkHttpCommand</span>
+
+- <span>createValidateCommand</span>
+
+### Command use cases (16 added, 2 removed)
+
+#### Added
+
+<details>
+<summary>AddComponent</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `AddComponentInput` |
+| `command-use-case-result` | `AddComponentResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>AddDomain</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `AddDomainInput` |
+| `command-use-case-result` | `AddDomainResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>AddSource</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `AddSourceInput` |
+| `command-use-case-result` | `AddSourceResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>CheckConsistency</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `CheckConsistencyInput` |
+| `command-use-case-result` | `CheckConsistencyResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>DefineCustomType</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `DefineCustomTypeInput` |
+| `command-use-case-result` | `DefineCustomTypeResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>DefineRelationshipType</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `DefineRelationshipTypeInput` |
+| `command-use-case-result` | `DefineRelationshipTypeResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>EnrichComponent</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `EnrichComponentInput` |
+| `command-use-case-result` | `EnrichComponentResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>EnrichDraftComponents</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `ExtractionConfigError` |
+| `data-access-error` | `ExtractionDataAccessError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>ExtractDraftComponents</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `ExtractionConfigError` |
+| `data-access-error` | `ExtractionDataAccessError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>FinalizeGraph</summary>
+
+| Role | Component |
+| --- | --- |
+| `command-use-case-input` | `FinalizeGraphInput` |
+| `command-use-case-result` | `FinalizeGraphResult` |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>InitGraph</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `InitGraphInput` |
+| `command-use-case-result` | `InitGraphResult` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>LinkComponents</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `LinkComponentsInput` |
+| `command-use-case-result` | `LinkComponentsResult` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>LinkExternal</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `LinkExternalInput` |
+| `command-use-case-result` | `LinkExternalResult` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>LinkHttp</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `command-use-case-input` | `LinkHttpInput` |
+| `command-use-case-result` | `LinkHttpResult` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>RunWorkflow</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `ExtractionConfigError` |
+| `data-access-error` | `ExtractionDataAccessError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+| `command-use-case-input` | `RunWorkflowInput` |
+| `command-use-case-result` | `RunWorkflowResult` |
+
+</details>
+
+<details>
+<summary>ValidateGraph</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `GraphCorruptedError` |
+| `data-access-error` | `GraphNotFoundError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+| `command-use-case-input` | `ValidateGraphInput` |
+| `command-use-case-result` | `ValidateGraphResult` |
+
+</details>
+
+#### Removed
+
+<details>
+<summary>EnrichDraftComponents</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `ExtractionConfigError` |
+| `data-access-error` | `ExtractionDataAccessError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+<details>
+<summary>ExtractDraftComponents</summary>
+
+| Role | Component |
+| --- | --- |
+| `data-access-error` | `ExtractionConfigError` |
+| `data-access-error` | `ExtractionDataAccessError` |
+| `aggregate-repository` | `RiviereProjectRepository` |
+
+</details>
+
+### Domain (6 added, 4 removed)
+
+#### Added
+
+- <span>RiviereProject</span> (aggregate, `domain-model`)
+    - Aggregate entities
+        - `Workflow`
+    - Methods
+        - `addComponent`
+        - `addDomain`
+        - `addSource`
+        - `addWorkflow`
+        - `build`
+        - `defineCustomType`
+        - `defineRelationshipType`
+        - `enrichComponent`
+        - `link`
+        - `linkExternal`
+        - `rebuildGraph`
+        - `rehydrate`
+        - `serialize`
+        - `start`
+        - `validate`
+        - `warnings`
+- <span>ExtractionConfigurationUnavailableError</span> (domain-error)
+- <span>GraphStateUnavailableError</span> (domain-error)
+- <span>WorkflowDefinitionFailure</span> (value-object)
+- <span>WorkflowRunEvent</span> (value-object)
+- <span>WorkflowStage</span> (value-object)
+
+#### Removed
+
+- <span>RiviereProject</span> (aggregate, `domain-model`)
+    - Methods
+        - `parse`
+- <span>detectCallsInCallable</span> (domain-service)
+- <span>locateComponentCallables</span> (domain-service)
+- <span>resolveCallTargets</span> (domain-service)
+
+### External clients (3 added)
+
+<details>
+<summary>glob — 1 component added</summary>
+
+<details>
+<summary>external-client-service — 1 added</summary>
+
+- `globSourceFiles`
+
+</details>
+
+</details>
+
+<details>
+<summary>ts-morph — 1 component added</summary>
+
+<details>
+<summary>external-client-service — 1 added</summary>
+
+- `createTypeScriptProjects`
+
+</details>
+
+</details>
+
+<details>
+<summary>yaml — 2 components added</summary>
+
+<details>
+<summary>external-client-error — 1 added</summary>
+
+- `YamlDocumentError`
+
+</details>
+
+<details>
+<summary>external-client-service — 1 added</summary>
+
+- `YamlDocumentReader`
+
+</details>
+
+</details>
+
+### Uncategorised changes (18 added)
+
+- <span>AddComponentErrorCode</span> (command-use-case-result-value)
+- <span>AddDomainErrorCode</span> (command-use-case-result-value)
+- <span>AddSourceErrorCode</span> (command-use-case-result-value)
+- <span>BuilderWarnings</span> (command-use-case-result-value)
+- <span>CheckConsistencyErrorCode</span> (command-use-case-result-value)
+- <span>DefineCustomTypeErrorCode</span> (command-use-case-result-value)
+- <span>DefineRelationshipTypeErrorCode</span> (command-use-case-result-value)
+- <span>EnrichComponentErrorCode</span> (command-use-case-result-value)
+- <span>FinalizedGraph</span> (command-use-case-result-value)
+- <span>FinalizeGraphErrorCode</span> (command-use-case-result-value)
+- <span>InitDomainInput</span> (command-use-case-input)
+- <span>InitGraphErrorCode</span> (command-use-case-result-value)
+- <span>LinkComponentsErrorCode</span> (command-use-case-result-value)
+- <span>LinkExternalErrorCode</span> (command-use-case-result-value)
+- <span>LinkHttpErrorCode</span> (command-use-case-result-value)
+- <span>MatchedApi</span> (command-use-case-result-value)
+- <span>ValidateGraphErrorCode</span> (command-use-case-result-value)
+- <span>ValidationData</span> (command-use-case-result-value)
+
+</details>

--- a/docs/project/PRD/pull-request-diffs/prototypes/riviere-architecture-graph-fixture.ts
+++ b/docs/project/PRD/pull-request-diffs/prototypes/riviere-architecture-graph-fixture.ts
@@ -1,0 +1,261 @@
+import type {
+  Link,
+  RiviereGraph,
+} from '@living-architecture/riviere-schema-published-language/schema'
+import {
+  ArchitectureDiffPrototypeError,
+  architectureLayerNames,
+  type ArchitectureAggregate,
+  type ArchitectureItem,
+  type ArchitectureLayerName,
+  type ArchitecturePackageKind,
+  type ArchitectureSnapshot,
+  type GraphArchitectureElement,
+  type IndexedGraphArchitectureElement,
+} from './riviere-architecture-graph-types'
+
+export function architectureSnapshotToRiviereGraph(
+  snapshot: ArchitectureSnapshot,
+  repository: string,
+  commit: string,
+): RiviereGraph {
+  const indexedElements = snapshot.subdomains.flatMap((subdomain) =>
+    architectureLayerNames.flatMap((layer) => {
+      const architectureLayer = subdomain.layers[layer]
+      const aggregates = architectureLayer.aggregates.flatMap((aggregate, aggregateIndex) =>
+        aggregateElements(subdomain.name, layer, aggregate, aggregateIndex, repository),
+      )
+      const items = architectureLayer.items.map((item, itemIndex) => ({
+        component: architectureItemComponent(
+          subdomain.name,
+          layer,
+          item,
+          `item-${itemIndex}`,
+          repository,
+        ),
+        layer,
+      }))
+      return [...aggregates, ...items]
+    }),
+  )
+  return {
+    version: '1.0',
+    metadata: {
+      name: `${repository} architecture review facts`,
+      sources: [{ commit, repository }],
+      domains: Object.fromEntries(
+        snapshot.subdomains.map((subdomain) => [
+          subdomain.name,
+          { description: `${subdomain.name} architecture`, systemType: 'domain' },
+        ]),
+      ),
+      customTypes: {
+        'architecture-review-element': {
+          requiredProperties: {
+            architectureRole: { type: 'string' },
+            packageKind: { type: 'string' },
+          },
+          optionalProperties: {
+            aggregateOwnerId: { type: 'string' },
+            externalClient: { type: 'string' },
+            methods: { type: 'array' },
+          },
+        },
+      },
+      relationshipTypes: {
+        'aggregate-owns-entity': { description: 'Aggregate ownership of an entity' },
+        'supports-primary-element': {
+          description: 'Supporting architecture element association with its primary element',
+        },
+      },
+    },
+    components: indexedElements.map(({ component }) => component),
+    links: [...architectureLinks(snapshot, indexedElements)],
+  }
+}
+
+function aggregateElements(
+  subdomain: string,
+  layer: ArchitectureLayerName,
+  aggregate: ArchitectureAggregate,
+  aggregateIndex: number,
+  repository: string,
+): readonly IndexedGraphArchitectureElement[] {
+  const aggregateComponent = architectureElementComponent({
+    architectureRole: 'aggregate',
+    discriminator: `aggregate-${aggregateIndex}`,
+    layer,
+    methods: aggregate.methods,
+    name: aggregate.name,
+    packageKind: aggregate.packageKind,
+    repository,
+    subdomain,
+  })
+  const entities = aggregate.entities.map((entity, entityIndex) => ({
+    component: {
+      ...architectureItemComponent(
+        subdomain,
+        layer,
+        entity,
+        `aggregate-${aggregateIndex}-entity-${entityIndex}`,
+        repository,
+      ),
+      aggregateOwnerId: aggregateComponent.id,
+    },
+    layer,
+  }))
+  return [{ component: aggregateComponent, layer }, ...entities]
+}
+
+function architectureItemComponent(
+  subdomain: string,
+  layer: ArchitectureLayerName,
+  item: ArchitectureItem,
+  discriminator: string,
+  repository: string,
+): GraphArchitectureElement {
+  return architectureElementComponent({
+    architectureRole: item.role,
+    discriminator,
+    ...(item.externalClient === undefined ? {} : { externalClient: item.externalClient }),
+    layer,
+    name: item.name,
+    packageKind: item.packageKind,
+    repository,
+    subdomain,
+  })
+}
+
+function architectureElementComponent(input: {
+  readonly architectureRole: string
+  readonly discriminator: string
+  readonly externalClient?: string
+  readonly layer: ArchitectureLayerName
+  readonly methods?: readonly string[]
+  readonly name: string
+  readonly packageKind: ArchitecturePackageKind
+  readonly repository: string
+  readonly subdomain: string
+}): GraphArchitectureElement {
+  return {
+    id: componentId(input),
+    type: 'Custom',
+    customTypeName: 'architecture-review-element',
+    name: input.name,
+    domain: input.subdomain,
+    module: input.layer,
+    sourceLocation: {
+      repository: input.repository,
+      filePath: `${input.subdomain}/${input.layer}/${input.discriminator}`,
+    },
+    architectureRole: input.architectureRole,
+    packageKind: input.packageKind,
+    ...(input.externalClient === undefined ? {} : { externalClient: input.externalClient }),
+    ...(input.methods === undefined ? {} : { methods: input.methods }),
+  }
+}
+
+function componentId(input: {
+  readonly architectureRole: string
+  readonly discriminator: string
+  readonly layer: ArchitectureLayerName
+  readonly name: string
+  readonly subdomain: string
+}): string {
+  return [input.subdomain, input.layer, input.architectureRole, input.name, input.discriminator]
+    .map(encodeURIComponent)
+    .join(':')
+}
+
+function architectureLinks(
+  snapshot: ArchitectureSnapshot,
+  indexedElements: readonly IndexedGraphArchitectureElement[],
+): readonly Link[] {
+  const ownershipLinks = indexedElements.flatMap(({ component }) =>
+    component.architectureRole === 'aggregate'
+      ? aggregateOwnershipLinks(component, indexedElements)
+      : [],
+  )
+  const supportLinks = snapshot.subdomains.flatMap((subdomain) =>
+    architectureLayerNames.flatMap((layer) =>
+      subdomain.layers[layer].items.flatMap((item, itemIndex) =>
+        supportLinksForItem(subdomain.name, layer, item, itemIndex, indexedElements),
+      ),
+    ),
+  )
+  return [...ownershipLinks, ...supportLinks]
+}
+
+function aggregateOwnershipLinks(
+  aggregate: GraphArchitectureElement,
+  indexedElements: readonly IndexedGraphArchitectureElement[],
+): readonly Link[] {
+  return indexedElements
+    .filter(({ component }) => component.aggregateOwnerId === aggregate.id)
+    .map(({ component }) => ({
+      source: aggregate.id,
+      target: component.id,
+      relationshipType: 'aggregate-owns-entity',
+    }))
+}
+
+function supportLinksForItem(
+  subdomain: string,
+  layer: ArchitectureLayerName,
+  item: ArchitectureItem,
+  itemIndex: number,
+  indexedElements: readonly IndexedGraphArchitectureElement[],
+): readonly Link[] {
+  const sourceId = componentId({
+    architectureRole: item.role,
+    discriminator: `item-${itemIndex}`,
+    layer,
+    name: item.name,
+    subdomain,
+  })
+  const source = requiredElementById(
+    indexedElements.map(({ component }) => component),
+    sourceId,
+  )
+  return (item.relatedTo ?? []).map((relationship) => ({
+    source: source.id,
+    target: findElement(indexedElements, subdomain, layer, relationship.role, relationship.name)
+      .component.id,
+    relationshipType: 'supports-primary-element',
+  }))
+}
+
+function findElement(
+  indexedElements: readonly IndexedGraphArchitectureElement[],
+  subdomain: string,
+  layer: ArchitectureLayerName,
+  role: string,
+  name: string,
+): IndexedGraphArchitectureElement {
+  const matching = indexedElements.filter(
+    (element) =>
+      element.component.domain === subdomain &&
+      element.layer === layer &&
+      element.component.architectureRole === role &&
+      element.component.name === name,
+  )
+  if (matching.length !== 1 || matching[0] === undefined) {
+    throw new ArchitectureDiffPrototypeError(
+      `Expected one graph element for ${subdomain}/${layer}/${role}/${name}. Got ${matching.length}.`,
+    )
+  }
+  return matching[0]
+}
+
+function requiredElementById(
+  elements: readonly GraphArchitectureElement[],
+  id: string,
+): GraphArchitectureElement {
+  const element = elements.find((candidate) => candidate.id === id)
+  if (element === undefined) {
+    throw new ArchitectureDiffPrototypeError(
+      `Expected graph element '${id}'. Got no matching component.`,
+    )
+  }
+  return element
+}

--- a/docs/project/PRD/pull-request-diffs/prototypes/riviere-architecture-graph-types.ts
+++ b/docs/project/PRD/pull-request-diffs/prototypes/riviere-architecture-graph-types.ts
@@ -1,0 +1,32 @@
+import type { TypescriptWorkspaceReader } from '@living-architecture/living-documentation-use-cases/infra/external-clients/typescript/typescript-workspace-reader'
+import type { CustomComponent } from '@living-architecture/riviere-schema-published-language/schema'
+
+export type ArchitectureSnapshot = ReturnType<TypescriptWorkspaceReader['readArchitectureSnapshot']>
+export type ArchitectureLayerName = keyof ArchitectureSnapshot['subdomains'][number]['layers']
+export type ArchitecturePackageKind =
+  ArchitectureSnapshot['subdomains'][number]['layers']['domain']['items'][number]['packageKind']
+export type ArchitectureItem =
+  ArchitectureSnapshot['subdomains'][number]['layers']['domain']['items'][number]
+export type ArchitectureAggregate =
+  ArchitectureSnapshot['subdomains'][number]['layers']['domain']['aggregates'][number]
+
+export interface GraphArchitectureElement extends CustomComponent {
+  readonly aggregateOwnerId?: string
+  readonly architectureRole: string
+  readonly packageKind: ArchitecturePackageKind
+  readonly externalClient?: string
+  readonly methods?: readonly string[]
+}
+
+export interface IndexedGraphArchitectureElement {
+  readonly component: GraphArchitectureElement
+  readonly layer: ArchitectureLayerName
+}
+
+export class ArchitectureDiffPrototypeError extends Error {}
+
+export const architectureLayerNames: readonly ArchitectureLayerName[] = [
+  'entrypoints',
+  'use-cases',
+  'domain',
+]

--- a/docs/project/PRD/pull-request-diffs/prototypes/riviere-graph-architecture-diff-poc.ts
+++ b/docs/project/PRD/pull-request-diffs/prototypes/riviere-graph-architecture-diff-poc.ts
@@ -1,0 +1,224 @@
+import {
+  ArchitectureDiff,
+  ArchitectureSource,
+  extractArchitecture,
+} from '@living-architecture/living-documentation-domain-model/domain/architecture'
+import { PullRequestArchitectureDiff } from '@living-architecture/living-documentation-use-cases/features/documentation/queries/pull-request-architecture-diff'
+import type {
+  CustomComponent,
+  RiviereGraph,
+} from '@living-architecture/riviere-schema-published-language/schema'
+import { parseRiviereGraph } from '@living-architecture/riviere-schema-published-language/validation'
+import { formatPullRequestArchitectureDiff } from '../../../../../tools/living-documentation/src/features/documentation/entrypoint/generate-pr-architecture-diff/pull-request-architecture-diff-formatter'
+import {
+  ArchitectureDiffPrototypeError,
+  architectureLayerNames,
+  type ArchitectureAggregate,
+  type ArchitectureItem,
+  type ArchitectureLayerName,
+  type ArchitecturePackageKind,
+  type ArchitectureSnapshot,
+  type GraphArchitectureElement,
+} from './riviere-architecture-graph-types'
+
+export function architectureDiffFromSnapshots(
+  base: ArchitectureSnapshot,
+  head: ArchitectureSnapshot,
+): string {
+  const diff = ArchitectureDiff.fromArchitectures(
+    extractArchitecture(ArchitectureSource.from(base)),
+    extractArchitecture(ArchitectureSource.from(head)),
+  )
+  return formatPullRequestArchitectureDiff(
+    PullRequestArchitectureDiff.fromArchitectureDiff(diff, 'architecture-diff.md'),
+  )
+}
+
+export function architectureDiffFromRiviereGraphs(
+  baseInput: unknown,
+  headInput: unknown,
+  outputPath: string,
+): string {
+  const diff = riviereGraphArchitectureDiff(baseInput, headInput)
+  return formatPullRequestArchitectureDiff(
+    PullRequestArchitectureDiff.fromArchitectureDiff(diff, outputPath),
+  )
+}
+
+export function riviereGraphArchitectureDiff(
+  baseInput: unknown,
+  headInput: unknown,
+): ArchitectureDiff {
+  const baseGraph = validatedGraph(baseInput)
+  const headGraph = validatedGraph(headInput)
+  return ArchitectureDiff.fromArchitectures(
+    extractArchitecture(ArchitectureSource.from(architectureSnapshotFromRiviereGraph(baseGraph))),
+    extractArchitecture(ArchitectureSource.from(architectureSnapshotFromRiviereGraph(headGraph))),
+  )
+}
+
+function validatedGraph(input: unknown): RiviereGraph {
+  const parsed = parseRiviereGraph(input)
+  if (!parsed.success) {
+    throw new ArchitectureDiffPrototypeError(
+      `Expected valid Rivière graph. Got ${parsed.issues.join('\n')}`,
+    )
+  }
+  return parsed.graph
+}
+
+export function architectureSnapshotFromRiviereGraph(graph: RiviereGraph): ArchitectureSnapshot {
+  const elements = graph.components.flatMap((component): readonly GraphArchitectureElement[] =>
+    component.type === 'Custom' && component.customTypeName === 'architecture-review-element'
+      ? [parseArchitectureElement(component)]
+      : [],
+  )
+  return {
+    subdomains: Object.keys(graph.metadata.domains)
+      .map((name) => ({
+        name,
+        layers: {
+          domain: graphLayerSnapshot(graph, elements, name, 'domain'),
+          entrypoints: graphLayerSnapshot(graph, elements, name, 'entrypoints'),
+          'use-cases': graphLayerSnapshot(graph, elements, name, 'use-cases'),
+        },
+      }))
+      .filter((subdomain) =>
+        architectureLayerNames.some((layer) => {
+          const architectureLayer = subdomain.layers[layer]
+          return architectureLayer.aggregates.length > 0 || architectureLayer.items.length > 0
+        }),
+      ),
+  }
+}
+
+function parseArchitectureElement(component: CustomComponent): GraphArchitectureElement {
+  const aggregateOwnerId = optionalString(component['aggregateOwnerId'], 'aggregateOwnerId')
+  const architectureRole = requiredString(component['architectureRole'], 'architectureRole')
+  const packageKind = parsePackageKind(component['packageKind'])
+  const externalClient = optionalString(component['externalClient'], 'externalClient')
+  const methods = optionalStringArray(component['methods'], 'methods')
+  return {
+    ...component,
+    architectureRole,
+    packageKind,
+    ...(aggregateOwnerId === undefined ? {} : { aggregateOwnerId }),
+    ...(externalClient === undefined ? {} : { externalClient }),
+    ...(methods === undefined ? {} : { methods }),
+  }
+}
+
+function graphLayerSnapshot(
+  graph: RiviereGraph,
+  elements: readonly GraphArchitectureElement[],
+  subdomain: string,
+  layer: ArchitectureLayerName,
+): ArchitectureSnapshot['subdomains'][number]['layers'][ArchitectureLayerName] {
+  const layerElements = elements.filter(
+    (component) => component.domain === subdomain && component.module === layer,
+  )
+  const aggregates = layerElements
+    .filter((component) => component.architectureRole === 'aggregate')
+    .map((aggregate) => graphAggregate(graph, layerElements, aggregate))
+  const ownedEntityIds = new Set(
+    graph.links
+      .filter((link) => link.relationshipType === 'aggregate-owns-entity')
+      .map((link) => link.target),
+  )
+  const items = layerElements
+    .filter((component) => component.architectureRole !== 'aggregate')
+    .filter((component) => !ownedEntityIds.has(component.id))
+    .map((component) => graphArchitectureItem(graph, layerElements, component))
+  return { aggregates, items }
+}
+
+function graphAggregate(
+  graph: RiviereGraph,
+  layerElements: readonly GraphArchitectureElement[],
+  aggregate: GraphArchitectureElement,
+): ArchitectureAggregate {
+  const entities = graph.links
+    .filter(
+      (link) => link.source === aggregate.id && link.relationshipType === 'aggregate-owns-entity',
+    )
+    .map((link) => requiredElementById(layerElements, link.target))
+    .map((component) => graphArchitectureItem(graph, layerElements, component))
+  return {
+    entities,
+    methods: aggregate.methods ?? [],
+    name: aggregate.name,
+    packageKind: aggregate.packageKind,
+  }
+}
+
+function graphArchitectureItem(
+  graph: RiviereGraph,
+  layerElements: readonly GraphArchitectureElement[],
+  component: GraphArchitectureElement,
+): ArchitectureItem {
+  const relatedTo = graph.links
+    .filter(
+      (link) =>
+        link.source === component.id && link.relationshipType === 'supports-primary-element',
+    )
+    .map((link) => requiredElementById(layerElements, link.target))
+    .map((target) => ({ name: target.name, role: target.architectureRole }))
+  return {
+    name: component.name,
+    packageKind: component.packageKind,
+    role: component.architectureRole,
+    ...(component.externalClient === undefined ? {} : { externalClient: component.externalClient }),
+    ...(relatedTo.length === 0 ? {} : { relatedTo }),
+  }
+}
+
+function requiredElementById(
+  elements: readonly GraphArchitectureElement[],
+  id: string,
+): GraphArchitectureElement {
+  const element = elements.find((candidate) => candidate.id === id)
+  if (element === undefined) {
+    throw new ArchitectureDiffPrototypeError(
+      `Expected graph element '${id}'. Got no matching component.`,
+    )
+  }
+  return element
+}
+
+function parsePackageKind(value: unknown): ArchitecturePackageKind {
+  if (
+    value === 'application' ||
+    value === 'use-cases' ||
+    value === 'domain-model' ||
+    value === 'published-language'
+  ) {
+    return value
+  }
+  throw new ArchitectureDiffPrototypeError(
+    `Expected architecture package kind. Got ${JSON.stringify(value)}.`,
+  )
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ArchitectureDiffPrototypeError(
+      `Expected non-empty ${field}. Got ${JSON.stringify(value)}.`,
+    )
+  }
+  return value
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined
+  return requiredString(value, field)
+}
+
+function optionalStringArray(value: unknown, field: string): readonly string[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new ArchitectureDiffPrototypeError(
+      `Expected string array ${field}. Got ${JSON.stringify(value)}.`,
+    )
+  }
+  return value.filter((entry) => typeof entry === 'string')
+}

--- a/docs/project/PRD/pull-request-diffs/prototypes/run-pr-478-architecture-diff-benchmark.sh
+++ b/docs/project/PRD/pull-request-diffs/prototypes/run-pr-478-architecture-diff-benchmark.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+base_commit='3ec31c16fbfd02f91122a8d81f3b26010461cc47'
+head_commit='aeb7a001d060556ca5ec5fa6c8830e00a1458c29'
+base_workspace="$(mktemp -d)"
+head_workspace="$(mktemp -d)"
+published_comment="$(mktemp)"
+time_output="$(mktemp)"
+trap 'rm -rf "${base_workspace}" "${head_workspace}" "${published_comment}" "${time_output}"' EXIT
+
+cd "${repository_root}"
+git archive "${base_commit}" | tar -x -C "${base_workspace}"
+git archive "${head_commit}" | tar -x -C "${head_workspace}"
+
+pnpm exec tsx \
+  docs/project/PRD/pull-request-diffs/prototypes/benchmark-riviere-graph-architecture-diff.ts \
+  "${base_workspace}" \
+  "${head_workspace}" \
+  "${base_commit}" \
+  "${head_commit}"
+
+gh api repos/NTCoding/living-architecture/issues/comments/5454459810 \
+  --jq .body > "${published_comment}"
+
+diff \
+  --ignore-blank-lines \
+  "${published_comment}" \
+  docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-riviere-architecture-diff-original-format.txt
+
+printf '%s\n' 'Published PR #478 architecture diff: MATCH'
+
+measure_peak_memory() {
+  local approach="$1"
+  local run
+  for run in 1 2 3 4 5; do
+    /usr/bin/time -l \
+      pnpm exec tsx \
+      docs/project/PRD/pull-request-diffs/prototypes/benchmark-architecture-diff-memory-worker.ts \
+      "${approach}" \
+      "${base_workspace}" \
+      "${head_workspace}" \
+      "${base_commit}" \
+      "${head_commit}" \
+      > /dev/null 2> "${time_output}"
+    awk '/maximum resident set size/ { print $1 }' "${time_output}"
+  done
+}
+
+snapshot_peak_measurements="$(measure_peak_memory snapshot)"
+graph_peak_measurements="$(measure_peak_memory graph)"
+snapshot_peak_median="$(printf '%s\n' "${snapshot_peak_measurements}" | sort -n | sed -n '3p')"
+graph_peak_median="$(printf '%s\n' "${graph_peak_measurements}" | sort -n | sed -n '3p')"
+snapshot_peak_range="$(printf '%s\n' "${snapshot_peak_measurements}" | sort -n | sed -n '1p;5p' | paste -sd- -)"
+graph_peak_range="$(printf '%s\n' "${graph_peak_measurements}" | sort -n | sed -n '1p;5p' | paste -sd- -)"
+memory_report="docs/project/PRD/pull-request-diffs/prototypes/results/pr-478-peak-memory.txt"
+printf '%s\n\n' '# PR #478 isolated peak memory benchmark' > "${memory_report}"
+printf '%s\n\n' 'Median of five isolated process runs. Each range shows the minimum and maximum measured process peak.' >> "${memory_report}"
+printf '| Approach | Median maximum resident set size | Five-run range |\n' >> "${memory_report}"
+printf '| --- | ---: | ---: |\n' >> "${memory_report}"
+printf '| Snapshot extraction and diff | %s bytes | %s bytes |\n' "${snapshot_peak_median}" "${snapshot_peak_range}" >> "${memory_report}"
+printf '| Diff graph extraction, creation, parse, and diff | %s bytes | %s bytes |\n' "${graph_peak_median}" "${graph_peak_range}" >> "${memory_report}"
+cat "${memory_report}"

--- a/docs/project/PRD/pull-request-diffs/prototypes/tsconfig.json
+++ b/docs/project/PRD/pull-request-diffs/prototypes/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "types": ["node"],
+    "paths": {
+      "@living-architecture/living-documentation-domain-model/*": [
+        "../../../../../packages/living-documentation/domain-model/src/*"
+      ],
+      "@living-architecture/living-documentation-use-cases/*": [
+        "../../../../../packages/living-documentation/use-cases/src/*"
+      ],
+      "@living-architecture/riviere-schema-published-language/schema": [
+        "../../../../../packages/riviere-schema/published-language/src/published-language/schema.ts"
+      ],
+      "@living-architecture/riviere-schema-published-language/validation": [
+        "../../../../../packages/riviere-schema/published-language/src/published-language/validation.ts"
+      ]
+    }
+  },
+  "include": ["*.ts"]
+}

--- a/docs/project/PRD/pull-request-diffs/solution-exploration.md
+++ b/docs/project/PRD/pull-request-diffs/solution-exploration.md
@@ -80,6 +80,8 @@ The experience is designed to help a reviewer answer three questions:
 2. Has the change damaged the domain model?
 3. What code proves it?
 
+The approved review has two access paths. Public repositories use a link identifying the repository and pull request ID; Éclair retrieves the generated diff through GitHub using the agreed file convention. Private repositories use file upload instead of authenticated GitHub loading. Éclair has no backend, so uploaded files are processed in the browser. The uploaded file contains the extra GitHub metadata unavailable in this mode: repository and pull request identity and link, pull request title and description, and revision-specific source links. Displaying the uploaded review does not depend on fetching private GitHub metadata.
+
 The Éclair page begins with real pull request context. It shows one link identifying the repository and pull request, the real pull request title, and a pull request description which is collapsed by default.
 
 A global summary follows the GitHub diff convention. It keeps concise headline totals for changed subdomains, changed packages, and affected aggregates. Beneath those totals, one table is grouped by subdomain with columns for status, affected aggregates, additions, and removals. Each subdomain row names its affected aggregates and shows changes inside its `use-cases`, `domain-model`, and `published-language` packages where present. Published language remains immediately visible because it is a contract exposed to other subdomains. The headline numbers remain concise; their detail belongs in the table below.
@@ -124,6 +126,14 @@ The baseline may evolve, but its approved content hierarchy, ownership distincti
 7. The reviewer opens only the relevant subdomain, architecture layer, change direction, package, use case, aggregate, or supporting group.
 8. The reviewer follows exact base or head source links to inspect the code which proves each important architecture fact.
 9. The reviewer uses the complete GitHub code diff for the full implementation review and decides whether the pull request should be merged.
+
+### Private repository upload path
+
+1. The reviewer obtains a generated diff file containing the comparison and required GitHub metadata.
+2. The reviewer selects the file in Éclair; it is processed in the browser.
+3. Éclair presents the same approved review hierarchy, pull request context, and revision-specific source links without fetching private GitHub metadata.
+
+The exact file contract and mechanism for supplying metadata during generation remain architecture decisions.
 
 ### Unhappy paths
 

--- a/docs/project/PRD/pull-request-diffs/solution-exploration.md
+++ b/docs/project/PRD/pull-request-diffs/solution-exploration.md
@@ -1,0 +1,196 @@
+# Solution Exploration: Pull Request Architecture Diffs
+
+**Status:** Approved
+
+---
+
+## 1. Problem anchor
+
+AI agents are doing much of the implementation work, while key architecture and domain model changes can remain hidden among hundreds of lines of code. Developers and maintainers reviewing pull requests may therefore miss important decisions before merge, allowing architecture mistakes to pass unnoticed and become difficult to correct later.
+
+The same visibility problem affects principal engineers and architects who need to understand how architecture evolved across a longer period. A working architecture diff proof of concept exists, but it is an isolated TypeScript-specific script which nobody except its creator can use.
+
+## 2. Research scope and sources
+
+The approved research covered the existing Rivière proof of concept, a real pull request with a substantial domain model change, Éclair's current visual language, GitHub review conventions, semantic code diff tools, affected-project tools, architecture visualisation tools, and architecture policy tools.
+
+The research was used to find a review experience which preserves the complete architecture evidence while making important changes visible at a glance. It was not used to replace the full GitHub code diff or to automate architectural judgement.
+
+| Source | Type | Why included | Accepted finding |
+| --- | --- | --- | --- |
+| [Pull request #478](https://github.com/NTCoding/living-architecture/pull/478) and its [architecture diff](https://github.com/NTCoding/living-architecture/pull/478#issuecomment-5454459810) | internal proof of concept | A real, large domain model change with complete architecture evidence | The generated diff is the authoritative inventory and already provides a useful subdomain, layer, change direction, and element hierarchy. Its complete evidence must be preserved. |
+| `.github/workflows/pr-architecture-review.yml` | internal proof of concept | Existing automated pull request delivery | Rivière can compare base and head workspaces and update one pull request comment without requiring the proposed website. |
+| `tools/living-documentation/src/features/documentation/entrypoint/generate-pr-architecture-diff/` | internal proof of concept | Existing summary and disclosure conventions | The GitHub formatter provides the baseline summary pattern and groups entry points and use cases around their primary architectural element. |
+| `apps/eclair/src/features/comparison/`, `apps/eclair/src/features/overview/`, and `apps/eclair/src/features/modules/` | internal product source | Existing Rivière comparison and disclosure patterns | The visual experience should use Éclair's Stream shell, typography, colour variables, summary treatment, and visible disclosures rather than introducing a generic dashboard style. |
+| [GitHub pull request review documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests) | comparable product | The review environment users already understand | Keep the full code diff in GitHub and use familiar added and removed colours, compact tables, revision-specific links, and progressive disclosure. |
+| [SemanticDiff](https://semanticdiff.com/) | comparable product | A semantic approach to code review | Semantic presentation can reduce review noise, but code structure alone does not explain the Rivière domain and architecture model. |
+| [Difftastic](https://difftastic.wilfred.me.uk/) | open-source tool | Syntax-aware diff comparison | Structural diffing can improve readability, but it remains a code diff rather than a subdomain and domain model review. |
+| [Nx affected](https://nx.dev/ci/features/affected) | framework | Affected-project scoping | Affected scope is useful context, but project impact alone does not show changed aggregates, use cases, published language, or exact architecture evidence. |
+| [Structurizr](https://structurizr.com/) | comparable architecture tool | Model-based architecture visualisation | Architecture models provide useful context, but a general model view is not a substitute for a focused pull request change review. |
+| [ArchUnit](https://www.archunit.org/) | open-source architecture tool | Architecture policy enforcement | Automated rules can prevent known violations, but they complement rather than replace human review of domain model evolution. |
+
+## 3. Existing solution research
+
+The pull request #478 architecture report contains 316 architecture element rows across three subdomains and seven layer sections, plus aggregate and method changes. It proves that a complete architecture inventory can be generated from code. It also shows the limits of a long Markdown report: package changes, affected aggregates, public contracts, and the shape of each use case can require substantial scanning.
+
+The current GitHub formatter improves that baseline with a summary grouped by subdomain, collapsible subdomains, and named command and query use case disclosures. These conventions are useful and should be carried into the visual experience rather than replaced by a new information hierarchy.
+
+Éclair already provides the appropriate Rivière identity. Its Stream theme uses teal as the primary colour, Rubik headings, Lato body copy, Fira Code for code, restrained bordered surfaces, and clear disclosure controls. The approved visual direction uses that application shell while retaining conventional green additions, red removals, compact tables, and direct code links familiar from GitHub and IDE diffs.
+
+The comparable products each solve only part of the problem. SemanticDiff and Difftastic improve code-level change readability. Nx identifies affected projects. Structurizr presents architecture models. ArchUnit enforces known architecture rules. None of these replaces a complete Rivière graph diff organised around applications, subdomains, packages, use cases, aggregates, and source evidence.
+
+## 4. Candidate approaches
+
+### Option A: Keep the generated GitHub architecture diff only
+
+- Concept: Generalise the existing generator but keep the complete review experience in a GitHub comment.
+- Who it helps: Reviewers who want all evidence in the pull request and do not want another surface.
+- User change: Reviewers receive a reusable Rivière diff, but continue navigating a long Markdown report.
+- Relevant research: Pull request #478 and the current GitHub formatter prove this delivery path works.
+- Trade-off: It has the fewest operational dependencies, but important package, aggregate, and public contract changes can still be difficult to see quickly.
+- Risk: A complete report can remain technically correct while still failing the approved need for key changes to “jump out”.
+
+### Option B: Replace the GitHub architecture diff with a website
+
+- Concept: Publish the architecture comparison only as an interactive Éclair page linked from the pull request.
+- Who it helps: Reviewers who prefer a dedicated, interactive architecture experience.
+- User change: Reviewers leave GitHub to understand every architecture change.
+- Relevant research: Éclair proves that Rivière information can be presented interactively.
+- Trade-off: It gives maximum visual freedom, but makes the review dependent on a second system and removes the complete GitHub fallback.
+- Risk: Website availability, access, or link failure could hide the architecture evidence or prevent a dependable review flow.
+
+### Option C: Add an Éclair review experience to the complete GitHub diff
+
+- Concept: Generate a reusable Rivière graph diff, keep its complete GitHub representation, and add a focused Éclair page for scanning, navigation, and source evidence.
+- Who it helps: Pull request reviewers, maintainers, principal engineers, and architects who need both immediate review context and a clearer architecture view.
+- User change: Reviewers start with a concise architecture summary, open only the application, subdomain, package, use case, aggregate, or element evidence they need, and retain the complete GitHub diff as the baseline.
+- Relevant research: Combines the proven GitHub formatter hierarchy, Éclair's established design language, and familiar diff conventions without turning the page into another general architecture dashboard.
+- Trade-off: The product has two complementary representations which must stay consistent.
+- Risk: If the visual view drops facts, misstates ownership, or invents a different hierarchy, it becomes less trustworthy than the GitHub report.
+
+## 5. Selected product concept
+
+**Concept approval:** Approved
+
+Create a reusable Rivière pull request architecture comparison which keeps the complete generated GitHub architecture diff and supplements it with an Éclair review page.
+
+The experience is designed to help a reviewer answer three questions:
+
+1. What architecture changed?
+2. Has the change damaged the domain model?
+3. What code proves it?
+
+The Éclair page begins with real pull request context. It shows one link identifying the repository and pull request, the real pull request title, and a pull request description which is collapsed by default.
+
+A global summary follows the GitHub diff convention. It keeps concise headline totals for changed subdomains, changed packages, and affected aggregates. Beneath those totals, one table is grouped by subdomain with columns for status, affected aggregates, additions, and removals. Each subdomain row names its affected aggregates and shows changes inside its `use-cases`, `domain-model`, and `published-language` packages where present. Published language remains immediately visible because it is a contract exposed to other subdomains. The headline numbers remain concise; their detail belongs in the table below.
+
+Ownership must be represented honestly. Applications aggregate subdomain use cases, while subdomains own their packages. In the approved example, the CLI entry points live under `apps/cli`, not inside either `riviere-builder` or `riviere-extract-ts`. Matching base and head records are therefore shown as an application-level subdomain association change, with 13 collapsible CLI entry points and their 21 supporting application elements. A future API entry point may appear inside a subdomain when the Rivière model identifies that entry point as owned by the subdomain.
+
+Detailed subdomain content follows the generated diff rather than inventing another story:
+
+- subdomain
+- architecture layer
+- added or removed
+- package, use case, aggregate, or element evidence
+
+Use cases are separated into command and query use cases. Each named use case is independently collapsible and contains its related inputs, results, models, loaders, repositories, errors, or other supporting elements. Changes which do not belong to one named use case remain in a clearly named supporting group.
+
+Domain changes are grouped by package. Every package is an independently collapsible disclosure, closed by default, with its change count visible in the package row. This allows reviewers to move between `published-language` and `domain-model` without scrolling through every element in the preceding package.
+
+Aggregates clearly separate Name, Role, Package, and Code. Aggregate entity and method collections are collapsed by default. When opened, methods use a vertical list with one readable, non-wrapping method per line.
+
+Every architecture element available in the generated diff remains reviewable. Important application, use case, aggregate, entity, method, published language, and domain model elements link to exact source lines at the relevant base or head revision. Application reassignment evidence provides both base and head code links.
+
+The page uses the Éclair Stream visual language, with teal as the product identity. Diff content uses restrained surfaces, visible carets, monospace code, and conventional red and green change colours. Information-heavy sections remain vertically stacked and responsive rather than compressed into competing horizontal panels.
+
+Rivière exposes changes and evidence. It does not make an AI judgement about whether the architecture is good or bad. The reviewer owns that decision.
+
+The approved visual baseline is:
+
+`docs/project/PRD/pull-request-diffs/prototypes/architecture-diff-visual-mockups.html`
+
+The baseline may evolve, but its approved content hierarchy, ownership distinctions, evidence completeness, and review readability should be preserved unless later product discovery changes them.
+
+## 6. Product paths
+
+### Happy path
+
+1. A pull request is opened or updated.
+2. Rivière compares the base and head graph states and generates the complete architecture diff.
+3. The repository's workflow publishes or updates the complete GitHub architecture diff and provides access to the Éclair review experience.
+4. The reviewer sees the real repository, pull request, title, and concise headline totals.
+5. The reviewer scans the subdomain-grouped summary for changed packages, published language contracts, and named affected aggregates.
+6. The reviewer opens application changes separately from subdomain package changes.
+7. The reviewer opens only the relevant subdomain, architecture layer, change direction, package, use case, aggregate, or supporting group.
+8. The reviewer follows exact base or head source links to inspect the code which proves each important architecture fact.
+9. The reviewer uses the complete GitHub code diff for the full implementation review and decides whether the pull request should be merged.
+
+### Unhappy paths
+
+- The Éclair page is unavailable -> the complete generated GitHub architecture diff remains available; website failure must not prevent GitHub diff generation.
+- The architecture comparison is very large -> subdomains remain readable and information-heavy layers, packages, use cases, aggregates, and method groups use independent progressive disclosure.
+- A published language package changes -> the package remains visible in the global subdomain summary before the reviewer opens detailed layers.
+- A package contains many changed elements -> the package is collapsed by default so the next changed package remains reachable without scrolling through the first package.
+- A use case contains many related elements -> the named use case is collapsed independently and expands to show its related architecture evidence.
+- Application entry points change their subdomain association -> they remain under their actual application owner and show the association change with base and head evidence rather than appearing as subdomain-owned packages.
+- A future API entry point is genuinely owned by a subdomain -> it may appear within that subdomain when the Rivière model provides that ownership evidence.
+- An aggregate changes on both sides of the comparison -> the summary names it as affected, while the Domain detail shows its added and removed members without pretending that the aggregate itself was both created and deleted.
+- The pull request description is long -> it remains available but collapsed by default so it does not dominate the architecture review.
+- Architecture diff generation fails -> each repository controls whether that failure blocks merging; the website does not impose a central merge policy.
+
+## 7. No-gos and exclusions
+
+- No replacement of the complete GitHub code or architecture diff.
+- No requirement for the website to be available before the GitHub architecture diff can be generated.
+- No central decision that architecture diff failures must block every repository; each repository owns its CI and merge policy.
+- No TypeScript-specific product model. Comparison is based on Rivière graph states even when a language-specific extractor produced them.
+- No dropped, summarised-away, or hidden architecture facts from the authoritative generated diff.
+- No AI verdict, architecture score, speculative warning, or claim that a change is safe or unsafe.
+- No presentation of application-owned CLI entry points as packages inside a subdomain.
+- No assumption that every entry point belongs to an application; a subdomain-owned API entry point remains possible when supported by model evidence.
+- No package-global summary which loses the subdomain grouping used by the GitHub diff.
+- No burying published language several disclosure levels below the initial summary.
+- No long package body which must be scrolled before the next package becomes visible.
+- No horizontally competing information-heavy sections.
+- No compressed aggregate methods, wrapped multi-method lines, or ambiguous aggregate headings.
+- No generic GitHub imitation which discards Éclair's actual visual conventions.
+- No dominant purple treatment, decorative card grid, gradient-filled diff body, tiny text, or pill-heavy presentation.
+- No fake controls, dead links, repeated equivalent views, or actions which do not work.
+- No implementation or formatting mechanics presented as evidence that the review experience is usable.
+
+## 8. Risk review
+
+| Risk | Confidence | Evidence / reason | Open concern | Mitigation / next step |
+| --- | --- | --- | --- | --- |
+| Value | Medium | The selected concept directly addresses the approved need for key architecture and domain model changes to “jump out”. It was shaped against a real 316-row architecture diff and the visual baseline was explicitly approved as solid in style and content. | Approval comes from this planning and review session rather than broader use across several repositories and reviewer roles. | Use the approved PR #478 example as the first dogfood case and retain the complete GitHub fallback while gathering real review feedback. |
+| Usability | Medium | Repeated visual review produced an approved hierarchy: concise global facts, subdomain-grouped summary, separate applications, named aggregates, collapsed packages, and collapsible named use cases. Desktop and mobile browser checks found no page overflow or browser errors. | A static prototype does not prove that reviewers can navigate very large generated diffs quickly in normal pull request work. | Carry the approved hierarchy into the PRD and require dogfooding with a real generated diff before treating the experience as complete. |
+| Feasibility | Medium | The repository already compares base and head workspaces, produces a complete GitHub comment, contains Éclair comparison and disclosure components, and exposes revision-specific source locations. The prototype preserves and links the PR #478 evidence. | The reusable graph representation must distinguish application ownership from subdomain exposure and must provide enough repository metadata for exact base and head links. | Keep the product ownership rule explicit in the PRD, then resolve graph representation, source metadata, hosting, and failure isolation during architecture definition. |
+| Business viability | Medium | The additive design preserves existing GitHub review, lets each repository control CI policy, and prevents website availability from becoming a merge dependency. | Hosting, access, retention, and operational ownership of generated comparison pages still need an implementation decision. | Treat independent GitHub generation and repository-controlled enforcement as fixed product constraints; decide deployment and access in architecture planning. |
+
+## 9. Risky assumptions
+
+- Rivière graph comparisons can provide every architecture fact needed for the general experience without falling back to TypeScript-specific concepts.
+- The comparison input can distinguish an application-owned entry point from a subdomain-owned API entry point.
+- Application association changes can be recognised without misrepresenting identical base and head application elements as newly created or deleted.
+- Package changes can be grouped consistently under their owning subdomain as `use-cases`, `domain-model`, or `published-language`.
+- A concise summary plus progressive disclosure is enough for reviewers to find important changes without losing confidence in completeness.
+- Published language is a meaningful public contract signal for reviewers across subdomains, while Rivière should still avoid declaring the change breaking without proof.
+- Revision-specific repository metadata and source locations will be available for direct evidence links.
+- The visual experience and complete GitHub report can remain consistent as the underlying graph and supported architecture concepts evolve.
+- The approved PR #478 fixture is representative enough to shape the initial product concept, even though broader repository dogfooding is still needed.
+
+## 10. Rejected options
+
+- GitHub-only architecture review as the complete product direction: retained as the authoritative fallback, but rejected as the only experience because important package, aggregate, and public contract changes remain difficult to scan in a large report.
+- Website-only architecture review: rejected because website availability or access must not remove the complete architecture evidence from GitHub.
+- TypeScript-specific diff product: rejected because Rivière's graph is language agnostic and the current isolated script is part of the approved problem.
+- Package-global summary: rejected because it removes the GitHub diff's subdomain-first context. Package changes belong inside each subdomain summary row.
+- Application entry points nested inside subdomain packages: rejected because current CLI entry points live in `apps/cli`. Their relationship to subdomain use cases must not be mistaken for containment or ownership.
+- Flat Use cases tables: rejected because the GitHub formatter already provides a clearer named use case disclosure pattern.
+- Permanently expanded package sections: rejected because one large package can force reviewers to scroll past all of its elements before reaching the next package.
+- Graph-first or dashboard-first review: rejected because the primary task is understanding a concrete pull request change and its code evidence, not exploring the whole current architecture.
+- AI architecture verdict: rejected because Rivière should expose evidence and leave architectural judgement to the reviewer.
+
+## 11. Open discovery questions
+
+No open product discovery questions. The approved product concept is ready to be recorded in a PRD. Representation of application ownership, source metadata, deployment, access, and failure isolation remain architecture concerns for the later architecture stage.

--- a/knip.json
+++ b/knip.json
@@ -80,6 +80,7 @@
   },
   "ignore": [
     ".riviere/**",
+    "docs/project/**",
     "**/node_modules/**",
     "**/*.d.ts",
     "**/*.d.cts",

--- a/project-memory/architecture/memories/riviere-architecture-boundary-reasoning.md
+++ b/project-memory/architecture/memories/riviere-architecture-boundary-reasoning.md
@@ -1,0 +1,31 @@
+---
+status: approved
+dateAdded: 2026-09-05
+systemAreas:
+  - global
+  - riviere-query
+  - riviere-builder
+architectureConcepts:
+  - boundary-placement
+  - domain-modeling
+  - trade-off-reasoning
+source: "conversation: Pull Request Architecture Diffs subdomain decision"
+---
+
+# Case study: the boundary for architecture diffs for pull requests
+
+We were planning **architecture diffs for pull requests** in `docs/project/PRD/pull-request-diffs/ARCH.md`, based on the approved `PRD.md` and `solution-exploration.md` in that folder. The question was which Rivière subdomain should own the capability.
+
+Query initially seemed to fit because the capability queried graphs. However, it provided architectural insights rather than generic querying. The user rejected adding that specific responsibility to the generic tool: **“Don’t put something specific on top of a generic query tool.”** It also did not align with the Builder subdomain, where the query code lived.
+
+A separate Diff subdomain was considered next. That proposal had turned a feature into a subdomain without examining broader concepts. Applying **“broaden the narrow scope”** brought architecture into consideration as a home for multiple related capabilities, rather than just architecture diffs.
+
+Architecture then raised the opposite concern: its scope might be too broad. Applying **“narrow the scope with a more precise name”** produced `architecture-insights` as an alternative. The user’s gut feeling nevertheless favoured `architecture` because it was shorter and better. The domain could evolve and split later.
+
+The user selected **`riviere-architecture`**, which would provide architectural insights based on Rivière graphs and other Rivière concepts.
+
+## How the heuristics affected this decision
+
+- **Don’t put something specific on a generic query tool.** Querying graphs made Query a plausible home, but architectural insights were a more specific responsibility. This distinction ruled out treating “it queries a graph” as sufficient justification.
+- **Broaden the narrow scope.** Moving from **Diff → Architecture** changed the proposed boundary from one feature to a home for multiple related capabilities.
+- **Narrow with a more precise name.** Testing **Architecture → Architecture Insights** exposed the risk that Architecture was too broad. The user still preferred the shorter name, Architecture, while accepting that it could evolve and split later.

--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.159",
+  "version": "0.0.160",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/planning-stages/architecture-drafting.md
+++ b/tools/dev-workflow-v2/planning-stages/architecture-drafting.md
@@ -138,14 +138,17 @@ Ask the user to approve one of these conclusions:
 
 Stop after this discussion if a loop-back is needed.
 
-## Step 1: Decide top-level architecture ownership
+## Step 1: Shape interactions and decide top-level architecture boundaries
 
-Research the PRD, existing architecture, and relevant architecture memories, then propose ownership options.
-The user owns the decision.
-A recommendation is not approval.
+Research the PRD, existing architecture, and relevant architecture memories, then use domain message flow modelling to shape and compare the interaction and boundary options.
 
-Do not write component internals yet.
-Do not mark an ownership decision approved until the user explicitly approves, rejects, or combines the options.
+Read and apply `skills/domain-message-flow/SKILL.md` completely before drafting any boundary option. Its notation, option template, colours, legend, layout, message table, pros and cons, and validation rules are mandatory.
+
+The user owns every boundary decision. A recommendation is not approval.
+
+Do not write component internals in this step. Do not name classes, functions, repositories, adapters, roles, or files merely to make a boundary option look detailed. Detailed component design happens only after the user approves the interactions and boundaries.
+
+Do not mark a boundary decision approved until the user explicitly approves, rejects, or combines the options.
 
 ### Research inputs
 
@@ -160,33 +163,42 @@ Read:
 
 ### What to identify
 
-- new apps, packages, libraries, tools, or modules
-- existing apps, packages, libraries, tools, or modules that may change
+- the concrete user or system scenario that exposes the unresolved boundary
+- actors, apps, subdomains, and external systems involved in that scenario
+- commands, events, and queries crossing those boundaries
+- significant message data needed by each recipient
 - responsibilities that need an architectural home
+- new or existing apps and subdomains that may own those responsibilities
 - existing boundaries or ADRs that constrain placement
 - approved architecture memories that may inform reasoning, trade-offs, or anti-pattern avoidance
+- assumptions, failure paths, and unresolved interactions that distinguish the options
 
-### Required discussion output
+### Boundary option process
 
-For each major responsibility, present placement options:
+For each unresolved major boundary:
 
-| Option | Bucket placement | What changes there | Trade-off |
-| --- | --- | --- | --- |
-| A | `<app/package/tool/module>` | `<responsibility>` | `<cost/benefit>` |
-| B | `<app/package/tool/module>` | `<responsibility>` | `<cost/benefit>` |
+1. Select one concrete scenario from approved product context. If no approved scenario exposes the boundary, ask the user rather than inventing one.
+2. Keep that scenario fixed while comparing options.
+3. Produce the strongest genuinely different boundary options using the exact option structure from `skills/domain-message-flow/SKILL.md`.
+4. Make the interaction or ownership difference visible in the diagrams, not only in prose.
+5. Include only valid options. Do not pad the set with renamed flows or an option that breaks an approved constraint.
+6. Add one short recommendation after the options, with its specific reason.
+7. Add `Decision status: Waiting for user approval`.
 
-Then add:
+If there is only one valid boundary, still use the message flow template to show it and explain in the cons why the obvious alternatives violate approved constraints or repository boundaries.
 
-```markdown
-Recommendation: <one short reason>
-Decision status: Waiting for user approval
-```
+Write the unapproved options under `## 2. Ownership and boundaries` in `architecturePath`. They are proposals, not approved decisions. Preserve any previously approved boundary decisions in that section.
 
-If there is only one valid bucket, still explain why the other obvious buckets are rejected.
+Stop after presenting the boundary options. Continue only after the user approves, rejects, or combines them.
 
-Stop after this discussion. Continue only after the user approves, rejects, or combines the options.
+After approval:
 
-## Step 2: Present component design options
+- record the approved interaction and boundary direction under `## 2. Ownership and boundaries`;
+- retain concise rejected alternatives and their reasons;
+- mark the relevant boundary decision approved;
+- proceed to detailed component design only on a later planning turn.
+
+## Step 2: Present detailed component design options
 
 Work with the user to design the software components to implement the new capabilities.
 

--- a/tools/dev-workflow-v2/skills/domain-message-flow/SKILL.md
+++ b/tools/dev-workflow-v2/skills/domain-message-flow/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: domain-message-flow
+description: Shape and compare architecture boundaries through standardised domain message flow options before detailed component design.
+---
+
+# Domain message flow
+
+Use this skill while shaping architecture interactions and boundaries. It follows the [DDD Crew Domain Message Flow Modelling](https://github.com/ddd-crew/domain-message-flow-modelling) technique.
+
+A domain message flow shows the ordered commands, events, and queries exchanged by actors, apps, subdomains, and external systems for one scenario. It is not a component diagram. Do not show classes, functions, repositories, adapters, files, roles, or other component internals.
+
+Use message flow options before detailed component design. Once the user approves the interactions and boundaries, stop using this skill and continue with the detailed component design process.
+
+## Source discipline
+
+Use only:
+
+- approved product requirements and solution decisions;
+- repository behaviour observed from approved research;
+- approved architecture decisions;
+- user-confirmed assumptions.
+
+Keep observed behaviour, proposals, and approved decisions distinct. Do not invent a message, participant, responsibility, data field, failure path, or boundary to make a diagram look complete.
+
+If an interaction is unresolved, state it in the description or cons. Do not draw an invented interaction.
+
+## Compare boundary options
+
+Use the same concrete scenario when comparing options. Keep actors, scenario scope, terminology, legend, colours, shapes, direction, and table columns fixed so the interaction and boundary differences stand out.
+
+Each option must differ through at least one meaningful boundary decision:
+
+- a responsibility moves between an app, subdomain, or external system;
+- a message crosses a different boundary;
+- one boundary owns an interaction that another option delegates;
+- coupling, autonomy, or dependency direction changes.
+
+Renaming the same participants or messages is not a different option.
+
+The user owns the boundary decision. Do not mark an option approved until the user explicitly approves, rejects, or combines the options.
+
+## Required option structure
+
+Use this relative heading structure. Choose the option heading level to fit its parent document; all headings inside the option are one level below it.
+
+```markdown
+<Option heading> Option <n>: <intention revealing name>
+
+<Two to four sentences describing the design, its key boundary idea, what distinguishes it, and any important assumptions or preconditions.>
+
+<standard Mermaid domain message flow>
+
+<Message details heading>
+
+<standard message details table>
+
+<Pros heading>
+
+- <benefit specific to this boundary design>
+
+<Cons heading>
+
+- <cost, risk, or limitation specific to this boundary design>
+```
+
+A standalone option uses:
+
+```markdown
+# Option 1: <Intention revealing name>
+## Message details
+## Pros
+## Cons
+```
+
+An option beneath a level 2 architecture section uses:
+
+```markdown
+### Option 1: <Intention revealing name>
+#### Message details
+#### Pros
+#### Cons
+```
+
+Do not add more sections unless the user approves a change to the standard.
+
+## Mermaid standard
+
+Use `flowchart LR`.
+
+The diagram must contain only:
+
+- one scenario;
+- participants;
+- compact numbered message boxes containing only the message name;
+- solid directional lines from sender to message to recipient;
+- the standard legend and class definitions below.
+
+Do not put message data, return values, annotations, paths, role names, or explanatory prose inside message boxes or on connecting lines. Put those details in the table below the diagram.
+
+Use short labels where their meaning remains clear. Prefer `PR` over `pull request` inside the diagram. Participant boxes contain only the participant name. Do not repeat `Actor`, `App`, `Subdomain`, or `External system` inside scenario participant boxes; the legend already explains their notation.
+
+Use a conventional user icon for an actor. Never use a solid black actor box.
+
+A command sends an instruction to a recipient. An event announces something that happened. A query requests information and includes its response as part of the same message. Do not define a command as merely asking for a state change.
+
+Aim for five to nine messages, following the DDD Crew guidance. Use fewer when another message would only expose an internal implementation detail. Split the scenario rather than making an unreadable diagram.
+
+Use lower camel case alphanumeric Mermaid node IDs. Never use literal `\n` in labels. Use `<br/>` only where a participant name genuinely needs a line break.
+
+Use this exact visual notation:
+
+```mermaid
+flowchart LR
+  subgraph legend[Legend]
+    direction TB
+    legendActor(["👤<br/>Actor"])
+    legendApp[["App"]]
+    legendSubdomain(["Subdomain"])
+    legendSystem{{"External system"}}
+    legendCommand["Command"]
+    legendEvent["Event"]
+    legendQuery["Query"]
+  end
+
+  subgraph scenario["Scenario: <short scenario name>"]
+    direction LR
+
+    actor(["👤<br/><b><actor name></b>"])
+    app[["<app name>"]]
+    subdomain(["<subdomain name>"])
+    externalSystem{{"<external system name>"}}
+
+    message1["1 · <message name>"]
+    message2["2 · <message name>"]
+    message3["3 · <message name>"]
+
+    actor --> message1 --> app
+    app --> message2 --> subdomain
+    subdomain --> message3 --> externalSystem
+  end
+
+  classDef actor fill:#ffffff,stroke:#374151,color:#111827,stroke-width:2px,font-size:18px;
+  classDef app fill:#ccfbf1,stroke:#0f766e,color:#134e4a,stroke-width:4px,font-size:20px;
+  classDef subdomain fill:#ddd6fe,stroke:#7c3aed,color:#2e1065,stroke-width:4px,font-size:20px;
+  classDef system fill:#f3f4f6,stroke:#374151,color:#111827,stroke-width:3px,font-size:18px;
+  classDef command fill:#7dd3fc,stroke:#0369a1,color:#082f49,stroke-width:2px,font-size:13px;
+  classDef event fill:#fdba74,stroke:#c2410c,color:#431407,stroke-width:2px,font-size:13px;
+  classDef query fill:#d9f99d,stroke:#4d7c0f,color:#1a2e05,stroke-width:2px,font-size:13px;
+
+  class actor,legendActor actor;
+  class app,legendApp app;
+  class subdomain,legendSubdomain subdomain;
+  class externalSystem,legendSystem system;
+  class message1,legendCommand command;
+  class legendEvent event;
+  class message2,message3,legendQuery query;
+```
+
+Delete unused example participants and messages. Keep every legend item so diagrams use one stable visual language. Assign every scenario participant and message to exactly one class.
+
+## Message details table
+
+Use these exact columns and keep rows in message order:
+
+```markdown
+| # | Type | Message | Sender → recipient | Significant data |
+| ---: | --- | --- | --- | --- |
+| 1 | Command | `<name>` | `<sender>` → `<recipient>` | Instruction: `<instruction and significant data>`. |
+| 2 | Query | `<name>` | `<sender>` → `<recipient>` | Request: `<data>`. Response: `<data>`. |
+| 3 | Event | `<name>` | `<sender>` → `<recipient>` | Facts: `<significant facts carried by the event>`. |
+```
+
+For a query, name both request and response data. Do not draw a separate return arrow. The query represents request and response as one message, following the DDD Crew convention.
+
+For a command, state the instruction and significant data. Do not invent a response unless the scenario contains a separate message for it.
+
+For an event, use past tense and state the significant facts it carries.
+
+## Pros and cons
+
+Pros and cons must be consequences of the specific boundary design. Connect them to concrete concerns such as:
+
+- boundary ownership;
+- dependency direction;
+- coupling;
+- autonomy;
+- consistency between consumers;
+- failure isolation;
+- information availability;
+- reuse across scenarios.
+
+Do not write generic claims such as “more scalable”, “cleaner”, “flexible”, or “easy to maintain” without explaining the concrete mechanism.
+
+Record unresolved interactions and required preconditions as cons when they limit the option. Do not hide them behind implementation detail.
+
+## Validation
+
+Before presenting or writing an option, check:
+
+1. The option follows the required heading order.
+2. The diagram shows one named scenario.
+3. Every participant is an actor, app, subdomain, or external system.
+4. Apps are not labelled as subdomains. Determine participant type from the approved repository boundary, not its behaviour.
+5. Message boxes contain only their order and name.
+6. Lines contain no data annotations.
+7. The table contains every diagram message exactly once and in order.
+8. Every query row names its request and response data.
+9. Every command is an instruction.
+10. Every event announces something that happened.
+11. The sender and recipient in each table row match the diagram direction.
+12. Mermaid subgraphs and code fences are balanced.
+13. The standard legend, shapes, colours, and classes are unchanged.
+14. Pros and cons describe real differences and known limitations.
+15. No detailed component design has leaked into boundary shaping.
+
+Correct formatting, rendering, and consistency defects directly. Do not ask the user to approve defect fixes. Ask for approval only when the option requires a product or architecture decision.

--- a/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/plugin-assets.spec.ts
@@ -108,6 +108,47 @@ describe('plugin Agent Skills', () => {
     },
   )
 
+  it('uses standardised domain message flows before detailed component design', () => {
+    const skill = readPluginFile('skills/domain-message-flow/SKILL.md')
+    const architectureDrafting = readPluginFile('planning-stages/architecture-drafting.md')
+    const boundaryStepPosition = architectureDrafting.indexOf(
+      '## Step 1: Shape interactions and decide top-level architecture boundaries',
+    )
+    const componentStepPosition = architectureDrafting.indexOf(
+      '## Step 2: Present detailed component design options',
+    )
+
+    expect({
+      hasSkillName: skill.includes('name: domain-message-flow'),
+      hasApprovedOptionOrder:
+        skill.indexOf('# Option 1:') < skill.indexOf('## Message details') &&
+        skill.indexOf('## Message details') < skill.indexOf('## Pros') &&
+        skill.indexOf('## Pros') < skill.indexOf('## Cons'),
+      keepsMessageDataOutOfDiagram: skill.includes(
+        'Do not put message data, return values, annotations, paths, role names, or explanatory prose inside message boxes or on connecting lines.',
+      ),
+      requiresDetailsTable: skill.includes(
+        '| # | Type | Message | Sender → recipient | Significant data |',
+      ),
+      invokesSkillDuringBoundaries: architectureDrafting.includes(
+        'Read and apply `skills/domain-message-flow/SKILL.md` completely',
+      ),
+      separatesBoundaryAndComponentDesign:
+        boundaryStepPosition > -1 &&
+        componentStepPosition > boundaryStepPosition &&
+        architectureDrafting.includes(
+          'proceed to detailed component design only on a later planning turn',
+        ),
+    }).toStrictEqual({
+      hasSkillName: true,
+      hasApprovedOptionOrder: true,
+      keepsMessageDataOutOfDiagram: true,
+      requiresDetailsTable: true,
+      invokesSkillDuringBoundaries: true,
+      separatesBoundaryAndComponentDesign: true,
+    })
+  })
+
   it('selects the code-review execution mechanism for all supported harnesses', () => {
     const skill = readPluginFile('skills/code-review/SKILL.md')
     const command = readPluginFile('commands/code-review.md')


### PR DESCRIPTION
## Problem

AI agents are doing much of the implementation work, while key architecture and domain model changes can remain hidden among hundreds of lines of code. Developers and maintainers reviewing pull requests may miss important decisions before merge, allowing architecture mistakes to pass unnoticed and become difficult to correct later.

Principal engineers and architects also need visibility into how architecture evolves while they are away from the immediate team. The working architecture diff proof of concept is currently an isolated script which nobody except its creator can use.

## Solution

Add the approved problem definition for the pull request diffs planning topic. Record the affected people, current limitation, relevant comparison contexts, critical review timing, and impact of missed architecture decisions. Add the conventional planning marker and advance it to solution exploration without prematurely creating a PRD or selecting a solution.

## Acceptance Criteria

- `problem-definition.md` records approved Who, What, Where, When, and Why inputs.
- The approved problem statement contains no architecture decision, implementation detail, or delivery milestone.
- `marker.yml` identifies the planning session and records `stage: solution-exploration`.
- No later planning artefacts are created prematurely.
- `pnpm verify` passes.

## Architecture and software design

This pull request makes no architecture or software design changes. Architecture and implementation decisions remain open for the later solution exploration and architecture stages.

## Validation

- `pnpm verify`