### PR TITLE
fix(workflow): accept pnpm argument separator

### DIFF
--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.164",
+  "version": "0.0.165",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/src/features/workflow/entrypoint/prepare-implementation-branch/entrypoint.spec.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/entrypoint/prepare-implementation-branch/entrypoint.spec.ts
@@ -36,6 +36,35 @@ describe('prepare implementation branch entrypoint', () => {
     })
   })
 
+  it('prepares the requested branch when pnpm forwards its argument separator', () => {
+    const execute = vi.fn(() => ({
+      branch: 'issue-42-example',
+      remoteDefaultBranch: 'origin/trunk',
+      type: 'created' as const,
+    }))
+    const writeCliResponse = vi.fn()
+    const originalArguments = process.argv
+    process.argv = ['node', 'prepare-implementation-branch', '--', 'issue-42-example']
+
+    try {
+      runPrepareImplementationBranchEntrypoint({
+        formatPreparedImplementationBranch,
+        formatFailedCliResponse,
+        parseImplementationBranchTarget,
+        prepareImplementationBranch: { execute },
+        writeCliResponse,
+      })
+    } finally {
+      process.argv = originalArguments
+    }
+
+    expect(execute).toHaveBeenCalledWith({ targetBranch: 'issue-42-example' })
+    expect(writeCliResponse).toHaveBeenCalledWith({
+      message: 'Prepared issue-42-example from origin/trunk (created).\n',
+      stream: 'stdout',
+    })
+  })
+
   it('presents a missing target argument as a CLI failure', () => {
     const execute = vi.fn()
     const writeCliResponse = vi.fn()

--- a/tools/dev-workflow-v2/src/features/workflow/entrypoint/prepare-implementation-branch/prepare-implementation-branch-target.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/entrypoint/prepare-implementation-branch/prepare-implementation-branch-target.ts
@@ -2,5 +2,6 @@
 export function parseImplementationBranchTarget(
   cliArguments: readonly string[],
 ): string | undefined {
-  return cliArguments.length === 1 ? cliArguments[0] : undefined
+  const targetArguments = cliArguments[0] === '--' ? cliArguments.slice(1) : cliArguments
+  return targetArguments.length === 1 ? targetArguments[0] : undefined
 }


### PR DESCRIPTION
## Problem

The documented start implementation command invokes the branch preparation package script with pnpm's conventional `--` argument separator. pnpm 11 forwards that separator to file based Node scripts, so the CLI receives both `--` and the target branch and rejects the invocation as having more than one argument.

## Proposed outcome

Branch preparation accepts the documented pnpm invocation while preserving strict validation for missing and additional target arguments.

## Changes

- Treat one leading `--` as an optional package runner separator before parsing the target branch.
- Add a regression test using the exact argument shape forwarded by pnpm.
- Bump the Claude plugin patch version so the corrected plugin asset is refreshed.

## Acceptance criteria

- `pnpm ... run prepare-implementation-branch -- <target>` reaches branch preparation with `<target>` as the target branch.
- Direct invocation with one target remains supported.
- Missing or additional target arguments remain invalid.

## Validation

- `pnpm nx test dev-workflow-v2` — 98 tests passed with 100% coverage.
- `pnpm nx lint dev-workflow-v2` — passed.
- `pnpm nx build dev-workflow-v2` — passed.
- `pnpm verify` — passed across the repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the implementation-branch command to correctly handle the `--` argument separator when invoked through pnpm.
  - Branch targets are now parsed correctly in both direct and forwarded command-line usage.
  - Added coverage to verify the command continues to produce the expected output.

- **Chores**
  - Updated the development workflow plugin version to 0.0.165.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->