### PR TITLE
fix(workflow): handle unknown commands safely

### DIFF
--- a/packages/dev-workflow-v2/use-cases/package.json
+++ b/packages/dev-workflow-v2/use-cases/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@living-architecture/dev-workflow-v2-domain-model": "workspace:*",
-    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.7",
+    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.8",
     "@nt-ai-lab/deterministic-agent-workflow-engine": "0.4.7",
     "zod": "^3.23.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,8 +290,8 @@ importers:
         specifier: workspace:*
         version: link:../domain-model
       '@nt-ai-lab/deterministic-agent-workflow-cli':
-        specifier: 0.4.7
-        version: 0.4.7
+        specifier: 0.4.8
+        version: 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-engine':
         specifier: 0.4.7
         version: 0.4.7
@@ -461,14 +461,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/dev-workflow-v2/use-cases
       '@nt-ai-lab/deterministic-agent-workflow-claude-code':
-        specifier: 0.4.7
-        version: 0.4.7
+        specifier: 0.4.8
+        version: 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-cli':
-        specifier: 0.4.7
-        version: 0.4.7
+        specifier: 0.4.8
+        version: 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-codex':
-        specifier: 0.4.9
-        version: 0.4.9
+        specifier: 0.4.10
+        version: 0.4.10
       '@nt-ai-lab/deterministic-agent-workflow-engine':
         specifier: 0.4.7
         version: 0.4.7
@@ -476,11 +476,11 @@ importers:
         specifier: 0.4.7
         version: 0.4.7
       '@nt-ai-lab/deterministic-agent-workflow-opencode':
-        specifier: 0.4.7
-        version: 0.4.7
+        specifier: 0.4.8
+        version: 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-pi':
-        specifier: 0.5.4
-        version: 0.5.4(@earendil-works/pi-coding-agent@0.84.4(supports-color@8.1.1)(ws@8.19.0)(zod@4.3.5))
+        specifier: 0.5.5
+        version: 0.5.5(@earendil-works/pi-coding-agent@0.84.4(supports-color@8.1.1)(ws@8.19.0)(zod@4.3.5))
       esbuild:
         specifier: 0.27.2
         version: 0.27.2
@@ -2349,14 +2349,14 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.4.7':
-    resolution: {integrity: sha512-PPIvcCxM2yStOQ9Sl+yQmnEjIv++DMNaAs/tyP+tvgSQuXTMpNdiYAX4mgig4xtHbjhyKERvVx5CPODm1UtYSQ==}
+  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.4.8':
+    resolution: {integrity: sha512-zO9upNX9LvdYfMyxmT2YlCVm7/4lQi34WaiN+5A2Ah+2ZPLNzbrBNwzRPspOqrgi9sZ3YgZgfJeDmGFO5PhsGQ==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.7':
-    resolution: {integrity: sha512-JDlQhPf/Xg96gAqSsH7toYKcc+gY0HflZ3jHjpLNJJr8ebcrpYI3PjkQAL4n/p+wj0BpLEpmcR4ETbHcdhKePw==}
+  '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.8':
+    resolution: {integrity: sha512-LuoZ8N6pqeoBogazo713bo4zWnowxgthG02dQ9UPHRPfCe0tgp2gYl4W6gi81USrJF9hDwW2S2YSHJcY5MEUFQ==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.9':
-    resolution: {integrity: sha512-/Mp/VXxE6a0vKCLEGuZfhkKlQYI6rgUI75Mdl+wEDCFDiEVvNcTDNUy+Hsmy5hU8uH8Sm0FZprEYj7f/MSbQmQ==}
+  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.10':
+    resolution: {integrity: sha512-NXx6mrUG+Yy9kufrBBbCxCVOwLIEc30p8sKyEO2m2/qjuKgn5lZh2ZHV4/oOE5EOkfmYzXBG1aijsfKz+Mi3cQ==}
 
   '@nt-ai-lab/deterministic-agent-workflow-dsl@0.4.7':
     resolution: {integrity: sha512-PvgbJYKNxNKnDlteOTx6urkhc0hnfqJUxUJToC+H5oCTfqHOJpOGIS3A/l0b9FMpxKhCpQNlGS5iNLLRxU2d+w==}
@@ -2367,11 +2367,11 @@ packages:
   '@nt-ai-lab/deterministic-agent-workflow-event-store@0.4.7':
     resolution: {integrity: sha512-SrDiSOZ0pZ/Jz10HQZl3/MbCr2+vMZfWe4Mqsco2RZ5QjGhpuXTC8boRapjcMX544ZrxUDzYv249+MPcyjdcSA==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.7':
-    resolution: {integrity: sha512-N0zDyz11Zts5OW/R9uXEQ/0hiWxzdeHya4GeTuVnyTETNQ9Gu9khMcU6ozSIIKX9tniX7eddmAXLRkIdfabgUQ==}
+  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.8':
+    resolution: {integrity: sha512-uf5kIl1xi/dMtr6DWYbyPtJNibBovCr6pPfctqWBa6LgdJb7778YQZt9WYpcTlZe5+V1L1qpGMpsvH8nRG+6fg==}
 
-  '@nt-ai-lab/deterministic-agent-workflow-pi@0.5.4':
-    resolution: {integrity: sha512-s1rHJQLnJmUThaq8EMdc7deOukvlPKf188GYcTAtFqXLRVwyhuEkL7p+vfm3c8ucLSKnen+jkbBRJjlxfEti2Q==}
+  '@nt-ai-lab/deterministic-agent-workflow-pi@0.5.5':
+    resolution: {integrity: sha512-DjRC/g2K7R6WJ/oiwVXoYcvNiDZc4oq3jwUm8nfgIhN9fw03rpIh+Hho0BTcUyNOQ05VbcnJ5jqjM/n4IZxAYg==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
       '@earendil-works/pi-coding-agent': ^0.84.4
@@ -11210,22 +11210,22 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.4.7':
+  '@nt-ai-lab/deterministic-agent-workflow-claude-code@0.4.8':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.7
+      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.7
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.7':
+  '@nt-ai-lab/deterministic-agent-workflow-cli@0.4.8':
     dependencies:
       '@nt-ai-lab/deterministic-agent-workflow-dsl': 0.4.7
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.7
       '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.7
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.9':
+  '@nt-ai-lab/deterministic-agent-workflow-codex@0.4.10':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.7
+      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.7
       '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.7
       zod: 3.25.76
@@ -11243,9 +11243,9 @@ snapshots:
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.7
       zod: 3.25.76
 
-  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.7':
+  '@nt-ai-lab/deterministic-agent-workflow-opencode@0.4.8':
     dependencies:
-      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.7
+      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.7
       '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.7
       '@opencode-ai/plugin': 1.18.23
@@ -11255,10 +11255,10 @@ snapshots:
       - '@opentui/keymap'
       - '@opentui/solid'
 
-  '@nt-ai-lab/deterministic-agent-workflow-pi@0.5.4(@earendil-works/pi-coding-agent@0.84.4(supports-color@8.1.1)(ws@8.19.0)(zod@4.3.5))':
+  '@nt-ai-lab/deterministic-agent-workflow-pi@0.5.5(@earendil-works/pi-coding-agent@0.84.4(supports-color@8.1.1)(ws@8.19.0)(zod@4.3.5))':
     dependencies:
       '@earendil-works/pi-coding-agent': 0.84.4(supports-color@8.1.1)(ws@8.19.0)(zod@4.3.5)
-      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.7
+      '@nt-ai-lab/deterministic-agent-workflow-cli': 0.4.8
       '@nt-ai-lab/deterministic-agent-workflow-engine': 0.4.7
       '@nt-ai-lab/deterministic-agent-workflow-event-store': 0.4.7
       typebox: 1.3.19

--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/package.json
+++ b/tools/dev-workflow-v2/package.json
@@ -19,13 +19,13 @@
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.84.4",
     "@living-architecture/dev-workflow-v2-use-cases": "workspace:*",
-    "@nt-ai-lab/deterministic-agent-workflow-claude-code": "0.4.7",
-    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.7",
-    "@nt-ai-lab/deterministic-agent-workflow-codex": "0.4.9",
+    "@nt-ai-lab/deterministic-agent-workflow-claude-code": "0.4.8",
+    "@nt-ai-lab/deterministic-agent-workflow-cli": "0.4.8",
+    "@nt-ai-lab/deterministic-agent-workflow-codex": "0.4.10",
     "@nt-ai-lab/deterministic-agent-workflow-engine": "0.4.7",
     "@nt-ai-lab/deterministic-agent-workflow-event-store": "0.4.7",
-    "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.4.7",
-    "@nt-ai-lab/deterministic-agent-workflow-pi": "0.5.4",
+    "@nt-ai-lab/deterministic-agent-workflow-opencode": "0.4.8",
+    "@nt-ai-lab/deterministic-agent-workflow-pi": "0.5.5",
     "esbuild": "0.27.2",
     "tsx": "4.21.0"
   },

--- a/tools/dev-workflow-v2/src/features/workflow/entrypoint/workflow/__fixtures__/workflow-cli-test-runner.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/entrypoint/workflow/__fixtures__/workflow-cli-test-runner.ts
@@ -24,6 +24,7 @@ export const runner = createWorkflowRunner({
     parseOptionalStringArgument,
     parseStringArguments,
   }),
+  unknownCommandMessage: 'Unknown test workflow command.',
   bashForbidden: {
     commands: ['gh pr', 'git push'],
     flags: ['--no-verify', '--force', '--hard'],

--- a/tools/dev-workflow-v2/src/features/workflow/entrypoint/workflow/workflow-cli.spec.ts
+++ b/tools/dev-workflow-v2/src/features/workflow/entrypoint/workflow/workflow-cli.spec.ts
@@ -28,11 +28,11 @@ describe('workflow-cli commands', () => {
     return ctx
   }
 
-  it('returns error for unknown command', () => {
+  it('returns configured error for unknown command', () => {
     const ctx = setup()
     const result = runCommand(ctx, ['bogus'])
     expect(result.exitCode).toStrictEqual(1)
-    expect(result.output).toContain('Unknown command: bogus')
+    expect(result.output).toStrictEqual('Unknown test workflow command.')
   })
 
   describe('init', () => {

--- a/tools/dev-workflow-v2/src/shell/cli.ts
+++ b/tools/dev-workflow-v2/src/shell/cli.ts
@@ -61,6 +61,7 @@ function sleepMs(ms: number): void {
 createClaudeCodeWorkflowCli({
   workflowDefinition,
   routes,
+  unknownCommandMessage: sharedWorkflowRuntime.unknownCommandMessage,
   bashForbidden,
   isWriteAllowed: workflowConfiguration.isWriteAllowed,
   processDeps: createDefaultProcessDeps(),

--- a/tools/dev-workflow-v2/src/shell/codex-cli.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-cli.ts
@@ -32,6 +32,7 @@ const processDeps = {
 createCodexWorkflowCli({
   workflowDefinition: runtime.workflowDefinition,
   routes: runtime.routes,
+  unknownCommandMessage: runtime.unknownCommandMessage,
   bashForbidden: runtime.bashForbidden,
   isWriteAllowed: runtime.isWriteAllowed,
   workflowCommand,

--- a/tools/dev-workflow-v2/src/shell/codex-workflow-command.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-workflow-command.spec.ts
@@ -9,6 +9,10 @@ import { describe, expect, it } from 'vitest'
 const shellDirectory = dirname(fileURLToPath(import.meta.url))
 const workflowCommandPath = join(shellDirectory, '../../dist/codex-workflow-command.js')
 const codexCliPath = join(shellDirectory, '../../dist/codex-cli.js')
+const unknownCommandMessage = [
+  '[dev-workflow-v2-automated-message]: Error: You tried to run a command that does not exist. STOP working immediately and switch to BLOCKED. Report this to the user along with a root cause analysis of why you tried to run a command that does not exist.',
+  'STOP and fix the workflow. It is broken. Do not attempt to create a workaround. YOU must immediately switch to blocked and stop.',
+].join('\n\n')
 
 describe('Codex workflow command', () => {
   it('loads the compiled workflow command without source resolution', () => {
@@ -19,6 +23,27 @@ describe('Codex workflow command', () => {
 
     expect(result.stderr).toContain('Codex workflow command requires <operation> [args]')
     expect(result.stderr).not.toContain('ERR_MODULE_NOT_FOUND')
+  })
+
+  it('returns the workflow recovery instructions when the operation does not exist', () => {
+    const home = mkdtempSync(join(tmpdir(), 'codex-workflow-command-'))
+    const result = spawnSync(process.execPath, [workflowCommandPath, 'missing-operation'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODEX_THREAD_ID: 'test-session',
+        HOME: home,
+        NODE_OPTIONS: '',
+        WORKFLOW_EVENTS_DB: join(home, 'workflow-events.db'),
+      },
+    })
+
+    try {
+      expect(result.status).toBe(1)
+      expect(result.stdout).toBe(unknownCommandMessage)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 
   it('provides stdin to reflection commands without patching the Codex package', () => {

--- a/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
+++ b/tools/dev-workflow-v2/src/shell/codex-workflow-command.ts
@@ -81,6 +81,7 @@ const getSessionTranscriptPath = () => {
 const result = createWorkflowRunner({
   workflowDefinition: runtime.workflowDefinition,
   routes: runtime.routes,
+  unknownCommandMessage: runtime.unknownCommandMessage,
   bashForbidden: runtime.bashForbidden,
   isWriteAllowed: runtime.isWriteAllowed,
 })([operation, ...args], engineDeps, runtime.buildWorkflowDeps(platform), {

--- a/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
+++ b/tools/dev-workflow-v2/src/shell/opencode-plugin.ts
@@ -139,6 +139,7 @@ const basePlugin = createOpenCodeWorkflowPlugin<
 >({
   workflowDefinition,
   routes,
+  unknownCommandMessage: sharedWorkflowRuntime.unknownCommandMessage,
   bashForbidden,
   isWriteAllowed: workflowConfiguration.isWriteAllowed,
   pluginRoot,

--- a/tools/dev-workflow-v2/src/shell/pi-plugin.ts
+++ b/tools/dev-workflow-v2/src/shell/pi-plugin.ts
@@ -94,6 +94,7 @@ function registerPiCommands(pi: ExtensionAPI): void {
 const workflowExtension = createPiWorkflowExtension({
   workflowDefinition,
   routes,
+  unknownCommandMessage: sharedWorkflowRuntime.unknownCommandMessage,
   bashForbidden,
   isWriteAllowed: workflowConfiguration.isWriteAllowed,
   pluginRoot,

--- a/tools/dev-workflow-v2/src/shell/workflow-cli-runtime.ts
+++ b/tools/dev-workflow-v2/src/shell/workflow-cli-runtime.ts
@@ -40,6 +40,10 @@ const bashForbidden = {
   flags: ['--no-verify', '--force', '--hard'],
 }
 const workflowRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const unknownCommandMessage = [
+  '[dev-workflow-v2-automated-message]: Error: You tried to run a command that does not exist. STOP working immediately and switch to BLOCKED. Report this to the user along with a root cause analysis of why you tried to run a command that does not exist.',
+  'STOP and fix the workflow. It is broken. Do not attempt to create a workaround. YOU must immediately switch to blocked and stop.',
+].join('\n\n')
 
 class InvalidSleepDurationError extends Error {
   constructor() {
@@ -78,6 +82,7 @@ export function createWorkflowCliRuntime() {
     isWriteAllowed: workflowConfiguration.isWriteAllowed,
     workflowRoot,
     processDeps: createDefaultProcessDeps(),
+    unknownCommandMessage,
     stopPreventionMessage:
       '[dev-workflow-v2-automated-response] If you are blocked, switch to the `BLOCKED` state.',
     buildWorkflowDeps,


### PR DESCRIPTION
## Problem

The latest deterministic agent workflow CLI requires workflow implementations to provide the message returned for unknown commands. The maintainer workflow must adopt the new package versions and fail with explicit recovery instructions when an agent invokes an operation that does not exist.

## Proposed outcome

Every dev-workflow-v2 provider and direct runner supplies the same project-specific unknown command response. An invalid operation tells the agent to stop, switch to `BLOCKED`, report the failure and root cause, and repair the workflow rather than inventing a workaround.

## Changes

- update each deterministic agent workflow dependency to its latest published version
- define the unknown command response once in the shared workflow runtime
- pass it to Claude Code, Codex, OpenCode, Pi, and the direct Codex runner
- update the workflow test runner for the mandatory configuration
- test the configured runner response and compiled Codex command output
- bump the Claude plugin patch version to `0.0.166`

## Acceptance criteria

- unknown workflow commands return the configured automated message with an error exit code
- every production provider supplies the mandatory configuration
- the lockfile resolves the latest official deterministic workflow packages
- all repository verification checks pass

## Validation

- `pnpm nx build dev-workflow-v2`
- `pnpm nx lint dev-workflow-v2`
- `pnpm nx typecheck dev-workflow-v2`
- `pnpm nx test dev-workflow-v2`
- `pnpm verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized the message shown when an unknown workflow command is entered.
  - Unknown commands now provide clear recovery instructions, including stopping execution and reporting the root cause.
  - Preserved the existing failure behavior and exit status for invalid commands.

- **Chores**
  - Updated workflow tooling and plugin package versions to their latest patch releases.
  - Improved coverage for invalid-command handling across supported workflow integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->