### PR TITLE
docs(workflow): require explicit, unambiguous planning issue guidance

### DIFF
--- a/tools/dev-workflow-v2/.claude-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.179",
+  "version": "0.0.180",
   "description": "Event-sourced workflow state machine for structured task lifecycle"
 }

--- a/tools/dev-workflow-v2/.codex-plugin/plugin.json
+++ b/tools/dev-workflow-v2/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow-v2",
-  "version": "0.0.152",
+  "version": "0.0.153",
   "description": "Event-sourced workflow state machine for a structured task lifecycle.",
   "author": {
     "name": "NTCoding",

--- a/tools/dev-workflow-v2/planning-stages/architecture-drafting.md
+++ b/tools/dev-workflow-v2/planning-stages/architecture-drafting.md
@@ -627,6 +627,74 @@ The subagent that writes an option is responsible for applying those constraints
 
 The main agent must not perform a full semantic review of all written option bodies. If deeper review is needed, invoke a fresh specialist review subagent against `architecturePath` and the relevant marker block rather than loading all option bodies into the main-agent context.
 
+## Terminology
+
+Rules:
+
+- A term is defined once, in the terminology source.
+- The terminology source is the PRD terminology section, or `docs/architecture/domain-terminology/contextive/definitions.glossary.yml`.
+- Use a term as the terminology source defines it. Do not write a second definition.
+- Do not introduce a term that is not in the terminology source. Add it to the terminology source first.
+- Do not invent language for something that already has a name.
+
+Example:
+
+Bad:
+
+```text
+Teams with EventCatalog must currently import domains, services, events, and producer/consumer relationships manually, so authoritative spec facts cannot participate in one Workflow.
+```
+
+Good:
+
+```text
+Teams with EventCatalog must copy the domains, services, events, and producer and consumer relationships into the graph by hand.
+```
+
+## Code and configuration samples
+
+Rules:
+
+- Introduce every code, configuration, or flow sample with a sentence that says what the file is, who writes it, where it lives, and whether it is the whole file or part of a file.
+- Keep the sample as it appears in the source. Do not shorten it.
+
+Example:
+
+Bad:
+
+```yaml
+# eventcatalog-import.yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: false
+```
+
+Good:
+
+This is the whole of `specs/eventcatalog-import.yaml`, a file the customer writes in their own repository. The `eventcatalog-import` stage of `riviere-workflow.yaml` points at it.
+
+```yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: false
+```
+
+## Role and location table
+
+Rules:
+
+- The table has a `Change` column.
+- Its value is one of `new`, `changed`, `removed`, or `unchanged`.
+
+Example:
+
+| Proposed Element | Kind | Role | Sublocation | Change | Confidence | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| LoadEventCatalogSource | type/interface | `domain-port` | extract domain-model domain/ports/ | new | High | Domain-owned external-fact contract |
+| EventCatalogSourceAdapter | function/class | `domain-port-adapter` | extract use-cases features/extract/adapters/ | new | High | Translates SDK client results |
+| EventCatalogClient | function/class | `external-client-service` | extract use-cases infra/external-clients/eventcatalog/ | new | High | Only location importing the SDK |
+| RiviereProject | class | `aggregate` | extract domain-model domain/ | changed | High | Owns mapping and Builder mutation |
+
 ## Draft approval and completion
 
 After the user approves, rejects, or combines the architecture options into one architecture direction, update `ARCH.md` with:

--- a/tools/dev-workflow-v2/planning-stages/delivery-planning.md
+++ b/tools/dev-workflow-v2/planning-stages/delivery-planning.md
@@ -109,6 +109,353 @@ Lower-level architectural checks are allowed, but they must not replace the prim
 
 Do not invent unapproved implementation APIs, roles, loaders, materialisers, repositories, services, or persistence concepts to make a delivery slice sound complete. If the approved architecture does not define the implementation shape clearly enough for task creation, stop and ask for clarification or return to architecture rather than filling the gap.
 
+## Acceptance criteria
+
+Every criterion has two parts, in this order.
+
+**Rules**
+
+A rule states the behaviour. A rule contains no values and no file contents.
+
+**Example**
+
+An example is one case. Write it in Gherkin.
+
+- `Given` states a pre-condition.
+- `When` states an action.
+- `Then` describes the result.
+
+## Example
+
+**Rule:** EventCatalog services are added as `UseCase` components in a Riviere graph.
+
+**Example:** `OrdersService` is added as the `PlaceOrder` use case.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-import.yaml`
+
+```yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: false
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following item is added to the Riviere graph
+
+```json
+{
+  "id": "orders:checkout:usecase:placeorder",
+  "type": "UseCase",
+  "name": "PlaceOrder",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+**Rule:** EventCatalog events are added as `Event` components in a Riviere graph.
+
+**Example:** `OrderCreated` is added as the `OrderPlaced` event.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+events:
+  OrderCreated:
+    name: OrderPlaced
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following item is added to the Riviere graph
+
+```json
+{
+  "id": "orders:checkout:event:orderplaced",
+  "type": "Event",
+  "name": "OrderPlaced",
+  "eventName": "OrderPlaced",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+**Rule:** A service that produces an event is linked to that event's component, with type `async`.
+
+**Example:** `OrdersService` produces `OrderCreated`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+events:
+  OrderCreated:
+    name: OrderPlaced
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following item is added to the Riviere graph
+
+```json
+{
+  "source": "orders:checkout:usecase:placeorder",
+  "target": "orders:checkout:event:orderplaced",
+  "type": "async"
+}
+```
+
+**Rule:** A service that consumes an event is linked from that event's component, with type `async`.
+
+**Example:** `ShippingService` consumes `OrderCreated`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] },
+    { "id": "ShippingService", "name": "Shipping", "produces": [], "consumes": ["OrderCreated"] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+  ShippingService:
+    type: UseCase
+    domain: shipping
+    module: fulfillment
+    name: ShipOrder
+events:
+  OrderCreated:
+    name: OrderPlaced
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following items are added to the Riviere graph
+
+```json
+{
+  "id": "orders:checkout:usecase:placeorder",
+  "type": "UseCase",
+  "name": "PlaceOrder",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+```json
+{
+  "id": "shipping:fulfillment:usecase:shiporder",
+  "type": "UseCase",
+  "name": "ShipOrder",
+  "domain": "shipping",
+  "module": "fulfillment",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+```json
+{
+  "id": "orders:checkout:event:orderplaced",
+  "type": "Event",
+  "name": "OrderPlaced",
+  "eventName": "OrderPlaced",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+```json
+{
+  "source": "orders:checkout:usecase:placeorder",
+  "target": "orders:checkout:event:orderplaced",
+  "type": "async"
+}
+```
+
+```json
+{
+  "source": "orders:checkout:event:orderplaced",
+  "target": "shipping:fulfillment:usecase:shiporder",
+  "type": "async"
+}
+```
+
+**Rule:** A record with no mapping fails the stage when `allow-unmapped` is `false`.
+
+**Example:** `OrdersService` has no mapping and `allow-unmapped` is `false`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": [], "consumes": [] }
+  ],
+  "events": []
+}
+```
+
+And the configuration file `specs/eventcatalog-import.yaml`
+
+```yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: false
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services: {}
+events: {}
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the stage fails with
+
+```text
+Unmapped EventCatalog records: service 'OrdersService'
+```
+
+and `.riviere/ecommerce-architecture.json` is unchanged.
+
+**Rule:** A record with no mapping is skipped and recorded as a diagnostic when `allow-unmapped` is `true`.
+
+**Example:** `OrdersService` and `OrderCreated` have no mapping and `allow-unmapped` is `true`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": [], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-import.yaml`
+
+```yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: true
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services: {}
+events: {}
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the run result contains
+
+```json
+{ "kind": "unmapped-record", "recordKind": "service", "recordId": "OrdersService" }
+```
+
+and
+
+```json
+{ "kind": "unmapped-record", "recordKind": "event", "recordId": "OrderCreated" }
+```
+
 ## Conversation flow
 
 The prompts below are internal objectives, not user-facing scripts. Ask naturally. Avoid prompt IDs and stage mechanics.

--- a/tools/dev-workflow-v2/planning-stages/prd-drafting.md
+++ b/tools/dev-workflow-v2/planning-stages/prd-drafting.md
@@ -72,6 +72,30 @@ If the PRD needs information that is not present in approved discovery artefacts
 1. add a clarification to the PRD from the current conversation, or
 2. return to `solution-exploration` because discovery is incomplete.
 
+## Terminology
+
+Rules:
+
+- A term is defined once, in the terminology source.
+- The terminology source is the PRD terminology section, or `docs/architecture/domain-terminology/contextive/definitions.glossary.yml`.
+- Use a term as the terminology source defines it. Do not write a second definition.
+- Do not introduce a term that is not in the terminology source. Add it to the terminology source first.
+- Do not invent language for something that already has a name.
+
+Example:
+
+Bad:
+
+```text
+Teams with EventCatalog must currently import domains, services, events, and producer/consumer relationships manually, so authoritative spec facts cannot participate in one Workflow.
+```
+
+Good:
+
+```text
+Teams with EventCatalog must copy the domains, services, events, and producer and consumer relationships into the graph by hand.
+```
+
 ## PRD standard
 
 The PRD must capture WHAT and WHY, not HOW.

--- a/tools/dev-workflow-v2/planning-stages/task-creation.md
+++ b/tools/dev-workflow-v2/planning-stages/task-creation.md
@@ -172,6 +172,7 @@ Write the solution in this order:
 1. Start with the high-level purpose of the change.
 2. Add the relevant capability detail and clarification.
 3. Explain why the resulting capability matters to the user or customer.
+4. State how this capability fits with the neighbouring capabilities: which stage or command runs immediately before it, which runs immediately after it, and what this capability contributes that they do not. Name the neighbouring capability and the exact handover between them, such as the file, type, or state that passes across. Do not describe delivery order, ticket dependencies, or why the slice was sequenced this way. That belongs in `## Dependencies`.
 
 High-level purpose does not mean abstract wording. The first sentence must name the product capability, the action the user takes, and the result the user needs. Never use an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, “everything”, or “works together”. At the point of reference, name the file, stages, sources, commands, outputs, or decision involved, or link to the exact source that defines it. For a Workflow deliverable, an agent must write `riviere-workflow.yaml` with its named stages, not “the Workflow”.
 
@@ -234,8 +235,17 @@ Include role and location decisions from the approved architecture and `.riviere
 
 When the ticket touches role-enforced TypeScript code, include a table with:
 
-| Proposed Element | Kind | Role | Sublocation | Confidence | Notes |
-|------------------|------|------|-------------|------------|-------|
+| Proposed Element | Kind | Role | Sublocation | Change | Confidence | Notes |
+|------------------|------|------|-------------|--------|------------|-------|
+
+The `Change` column value is one of `new`, `changed`, `removed`, or `unchanged`.
+
+| Proposed Element | Kind | Role | Sublocation | Change | Confidence | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| LoadEventCatalogSource | type/interface | `domain-port` | extract domain-model domain/ports/ | new | High | Domain-owned external-fact contract |
+| EventCatalogSourceAdapter | function/class | `domain-port-adapter` | extract use-cases features/extract/adapters/ | new | High | Translates SDK client results |
+| EventCatalogClient | function/class | `external-client-service` | extract use-cases infra/external-clients/eventcatalog/ | new | High | Only location importing the SDK |
+| RiviereProject | class | `aggregate` | extract domain-model domain/ | changed | High | Owns mapping and Builder mutation |
 
 The table must name concrete proposed elements from the approved architecture. Do not replace role/location decisions with prose.
 
@@ -291,6 +301,351 @@ This section must contain these subsections in this order:
 #### Product
 
 List observable product/system behaviour that proves the ticket's problem slice is solved. Include happy paths and source-backed unhappy paths.
+
+Every criterion has two parts, in this order.
+
+**Rules**
+
+A rule states the behaviour. A rule contains no values and no file contents.
+
+**Example**
+
+An example is one case. Write it in Gherkin.
+
+- `Given` states a pre-condition.
+- `When` states an action.
+- `Then` describes the result.
+
+Here is the worked example. Each rule below is followed by its example.
+
+**Rule:** EventCatalog services are added as `UseCase` components in a Riviere graph.
+
+**Example:** `OrdersService` is added as the `PlaceOrder` use case.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-import.yaml`
+
+```yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: false
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following item is added to the Riviere graph
+
+```json
+{
+  "id": "orders:checkout:usecase:placeorder",
+  "type": "UseCase",
+  "name": "PlaceOrder",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+**Rule:** EventCatalog events are added as `Event` components in a Riviere graph.
+
+**Example:** `OrderCreated` is added as the `OrderPlaced` event.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+events:
+  OrderCreated:
+    name: OrderPlaced
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following item is added to the Riviere graph
+
+```json
+{
+  "id": "orders:checkout:event:orderplaced",
+  "type": "Event",
+  "name": "OrderPlaced",
+  "eventName": "OrderPlaced",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+**Rule:** A service that produces an event is linked to that event's component, with type `async`.
+
+**Example:** `OrdersService` produces `OrderCreated`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+events:
+  OrderCreated:
+    name: OrderPlaced
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following item is added to the Riviere graph
+
+```json
+{
+  "source": "orders:checkout:usecase:placeorder",
+  "target": "orders:checkout:event:orderplaced",
+  "type": "async"
+}
+```
+
+**Rule:** A service that consumes an event is linked from that event's component, with type `async`.
+
+**Example:** `ShippingService` consumes `OrderCreated`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": ["OrderCreated"], "consumes": [] },
+    { "id": "ShippingService", "name": "Shipping", "produces": [], "consumes": ["OrderCreated"] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services:
+  OrdersService:
+    type: UseCase
+    domain: orders
+    module: checkout
+    name: PlaceOrder
+  ShippingService:
+    type: UseCase
+    domain: shipping
+    module: fulfillment
+    name: ShipOrder
+events:
+  OrderCreated:
+    name: OrderPlaced
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the following items are added to the Riviere graph
+
+```json
+{
+  "id": "orders:checkout:usecase:placeorder",
+  "type": "UseCase",
+  "name": "PlaceOrder",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+```json
+{
+  "id": "shipping:fulfillment:usecase:shiporder",
+  "type": "UseCase",
+  "name": "ShipOrder",
+  "domain": "shipping",
+  "module": "fulfillment",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+```json
+{
+  "id": "orders:checkout:event:orderplaced",
+  "type": "Event",
+  "name": "OrderPlaced",
+  "eventName": "OrderPlaced",
+  "domain": "orders",
+  "module": "checkout",
+  "sourceLocation": {
+    "repository": "https://github.com/ntcoding/ecommerce-demo-app",
+    "filePath": "specs/eventcatalog"
+  }
+}
+```
+
+```json
+{
+  "source": "orders:checkout:usecase:placeorder",
+  "target": "orders:checkout:event:orderplaced",
+  "type": "async"
+}
+```
+
+```json
+{
+  "source": "orders:checkout:event:orderplaced",
+  "target": "shipping:fulfillment:usecase:shiporder",
+  "type": "async"
+}
+```
+
+**Rule:** A record with no mapping fails the stage when `allow-unmapped` is `false`.
+
+**Example:** `OrdersService` has no mapping and `allow-unmapped` is `false`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": [], "consumes": [] }
+  ],
+  "events": []
+}
+```
+
+And the configuration file `specs/eventcatalog-import.yaml`
+
+```yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: false
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services: {}
+events: {}
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the stage fails with
+
+```text
+Unmapped EventCatalog records: service 'OrdersService'
+```
+
+and `.riviere/ecommerce-architecture.json` is unchanged.
+
+**Rule:** A record with no mapping is skipped and recorded as a diagnostic when `allow-unmapped` is `true`.
+
+**Example:** `OrdersService` and `OrderCreated` have no mapping and `allow-unmapped` is `true`.
+
+Given the EventCatalog source `specs/eventcatalog`
+
+```json
+{
+  "domains": [],
+  "services": [
+    { "id": "OrdersService", "name": "Orders", "produces": [], "consumes": [] }
+  ],
+  "events": [{ "id": "OrderCreated", "name": "Order Created" }]
+}
+```
+
+And the configuration file `specs/eventcatalog-import.yaml`
+
+```yaml
+source: ./eventcatalog
+mappings: ./eventcatalog-mappings.yaml
+allow-unmapped: true
+```
+
+And the configuration file `specs/eventcatalog-mappings.yaml`
+
+```yaml
+services: {}
+events: {}
+```
+
+When running the `eventcatalog-import` stage of the workflow
+
+Then the run result contains
+
+```json
+{ "kind": "unmapped-record", "recordKind": "service", "recordId": "OrdersService" }
+```
+
+and
+
+```json
+{ "kind": "unmapped-record", "recordKind": "event", "recordId": "OrderCreated" }
+```
 
 #### Design
 
@@ -425,17 +780,34 @@ This section must name the concrete exclusions that stop the ticket drifting int
 
 ### Glossary
 
-Populate from the source-of-truth glossary at `docs/architecture/domain-terminology/contextive/definitions.glossary.yml`.
+Populate from the terminology source: the PRD terminology section, and the source-of-truth glossary at `docs/architecture/domain-terminology/contextive/definitions.glossary.yml`.
 
 This section must:
 
-- reference `docs/architecture/domain-terminology/contextive/definitions.glossary.yml` as the source glossary
-- include only key domain or architecture terms used in the issue body
-- use the exact term name and definition from the source glossary
+- reference the terminology source files
+- copy into the issue every term that the terminology source defines and that appears in the issue body
+- copy each definition word for word
+- use the exact term name from the terminology source
 
 Do not invent inline glossary definitions inside the issue.
 
-If the issue needs a domain or architecture term that is not already in the source glossary, add the term to `docs/architecture/domain-terminology/contextive/definitions.glossary.yml` first using source-backed wording from approved planning artefacts. If the definition cannot be populated from approved artefacts, block task creation rather than inventing it.
+If the issue uses a term that the terminology source does not define, add the term to the terminology source first using source-backed wording from approved planning artefacts. If the definition cannot be populated from approved artefacts, block task creation rather than inventing it.
+
+Example:
+
+```markdown
+## Glossary
+
+Source: `docs/architecture/domain-terminology/contextive/definitions.glossary.yml`, and `docs/project/PRD/active/PRD-phase-13-extraction-workflows.md` §12.
+
+**Component**: A discrete unit of software functionality in a Riviere graph. Has a type, belongs to a domain, and connects to other components via links.
+
+**Link**: A directed relationship from one source Component to one target Component. Each Link represents one source occurrence and may have a Relationship Type, condition, sync or async type, and Source Location.
+
+**Domain**: A logical grouping of related components. Each component belongs to exactly one domain. Domains have a systemType (domain, bff, ui, external-service, other).
+
+**Canonical Identity**: The final Riviere component identity produced by stage mappings/config and Project behaviour before the Builder sees it. Upsert happens only after identity is established.
+```
 
 ## Step 4: ensure GitHub milestone and label exist
 
@@ -520,6 +892,13 @@ Block task creation if any of these are true:
 34. a dogfooding ticket presents source files, configurations, fixtures, tooling, or README changes as its solution instead of naming the user action, product capabilities, and observable result it demonstrates
 35. a dogfooding ticket claims to demonstrate a capability that the product cannot yet run through the demo
 36. `## Solution` uses an undefined reference such as “the Workflow”, “the demo”, “the customer journey”, “the result”, “all capabilities”, “everything”, or “works together” instead of naming the file, stages, sources, commands, outputs, decision, or exact source reference at the point of reference
+37. `## Solution` does not state how the capability fits with the stages or commands immediately before and after it, and what passes between them
+38. a criterion has no example, or describes an item in words that could be shown
+39. a criterion uses the word `scenario`
+40. the role and location table has no `Change` column, or uses a value other than `new`, `changed`, `removed`, or `unchanged`
+41. a code or configuration sample has no sentence saying what the file is, who writes it, where it lives, and whether it is whole or part of a file
+42. the issue uses a term that the terminology source does not define
+43. a term defined by the terminology source appears in the issue body but is missing from `## Glossary`
 
 If blocked, the current planning command must produce:
 

--- a/tools/dev-workflow-v2/plugin.json
+++ b/tools/dev-workflow-v2/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "dev-workflow-v2",
-  "version": "0.0.154",
+  "version": "0.0.155",
   "description": "Event-sourced workflow state machine for a structured task lifecycle.",
   "author": {
     "name": "NTCoding"

--- a/tools/dev-workflow-v2/src/shell/planning-guidance.spec.ts
+++ b/tools/dev-workflow-v2/src/shell/planning-guidance.spec.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), '../..')
+
+const readPluginFile = (path: string): string => readFileSync(join(pluginRoot, path), 'utf8')
+
+describe('planning guidance acceptance criteria', () => {
+  it('requires accepted terminology, samples, role change, and acceptance criteria guidance', () => {
+    const taskCreation = readPluginFile('planning-stages/task-creation.md')
+    const prdDrafting = readPluginFile('planning-stages/prd-drafting.md')
+    const architectureDrafting = readPluginFile('planning-stages/architecture-drafting.md')
+    const deliveryPlanning = readPluginFile('planning-stages/delivery-planning.md')
+    const terminologyRules = [
+      'A term is defined once, in the terminology source.',
+      'The terminology source is the PRD terminology section, or `docs/architecture/domain-terminology/contextive/definitions.glossary.yml`.',
+      'Use a term as the terminology source defines it. Do not write a second definition.',
+      'Do not introduce a term that is not in the terminology source. Add it to the terminology source first.',
+      'Do not invent language for something that already has a name.',
+    ]
+    const sampleRules = [
+      'Introduce every code, configuration, or flow sample with a sentence that says what the file is, who writes it, where it lives, and whether it is the whole file or part of a file.',
+      'Keep the sample as it appears in the source. Do not shorten it.',
+    ]
+    const criteriaRules = [
+      'Every criterion has two parts, in this order.',
+      'A rule states the behaviour. A rule contains no values and no file contents.',
+      'An example is one case. Write it in Gherkin.',
+      '- `Given` states a pre-condition.',
+      '- `When` states an action.',
+      '- `Then` describes the result.',
+    ]
+    expect({
+      prdDraftingHasTerminologyRules: terminologyRules.every((rule) => prdDrafting.includes(rule)),
+      architectureDraftingHasTerminologyRules: terminologyRules.every((rule) =>
+        architectureDrafting.includes(rule),
+      ),
+      architectureDraftingHasSampleRules: sampleRules.every((rule) =>
+        architectureDrafting.includes(rule),
+      ),
+      deliveryPlanningHasCriteriaRules: criteriaRules.every((rule) =>
+        deliveryPlanning.includes(rule),
+      ),
+      taskCreationHasCriteriaRules: criteriaRules.every((rule) => taskCreation.includes(rule)),
+      taskCreationHasSolutionFitRule: taskCreation.includes(
+        'State how this capability fits with the neighbouring capabilities: which stage or command runs immediately before it, which runs immediately after it, and what this capability contributes that they do not.',
+      ),
+      taskCreationHasRoleChangeColumn: taskCreation.includes(
+        '| Proposed Element | Kind | Role | Sublocation | Change | Confidence | Notes |',
+      ),
+      architectureDraftingHasRoleChangeColumn: architectureDrafting.includes(
+        'Its value is one of `new`, `changed`, `removed`, or `unchanged`.',
+      ),
+      taskCreationCopiesDefinedTerms: taskCreation.includes(
+        'copy into the issue every term that the terminology source defines and that appears in the issue body',
+      ),
+      taskCreationBlocksScenarioWord: taskCreation.includes('a criterion uses the word `scenario`'),
+      taskCreationBlocksMissingGlossaryTerm: taskCreation.includes(
+        'a term defined by the terminology source appears in the issue body but is missing from `## Glossary`',
+      ),
+      taskCreationBlocksUndefinedTerm: taskCreation.includes(
+        'the issue uses a term that the terminology source does not define',
+      ),
+      taskCreationBlocksUndescribedSample: taskCreation.includes(
+        'a code or configuration sample has no sentence saying what the file is, who writes it, where it lives, and whether it is whole or part of a file',
+      ),
+      showsWorkedCriteriaExample: taskCreation.includes(
+        '**Rule:** EventCatalog services are added as `UseCase` components in a Riviere graph.',
+      ),
+      showsRealComponentValues: taskCreation.includes('"id": "orders:checkout:usecase:placeorder"'),
+    }).toStrictEqual({
+      prdDraftingHasTerminologyRules: true,
+      architectureDraftingHasTerminologyRules: true,
+      architectureDraftingHasSampleRules: true,
+      deliveryPlanningHasCriteriaRules: true,
+      taskCreationHasCriteriaRules: true,
+      taskCreationHasSolutionFitRule: true,
+      taskCreationHasRoleChangeColumn: true,
+      architectureDraftingHasRoleChangeColumn: true,
+      taskCreationCopiesDefinedTerms: true,
+      taskCreationBlocksScenarioWord: true,
+      taskCreationBlocksMissingGlossaryTerm: true,
+      taskCreationBlocksUndefinedTerm: true,
+      taskCreationBlocksUndescribedSample: true,
+      showsWorkedCriteriaExample: true,
+      showsRealComponentValues: true,
+    })
+  })
+})


### PR DESCRIPTION
Planning issues produced by task creation are hard to read. A reader who has not read the PRD, and an agent with no prior experience, cannot tell what the ticket is asking for. This pull request adds guidance to the planning stages so the issues produced by the workflow are explicit.

The guidance covers five areas. Terms are defined once, in the terminology source, and no new language is invented for something that already has a name. Code and configuration samples are introduced with a sentence saying what the file is, who writes it, where it lives, and whether it is the whole file. The role and location table gains a `Change` column with `new`, `changed`, `removed`, or `unchanged`. Acceptance criteria are written as rules and at least one example, with the example written in Gherkin and the values shown in full. In task creation, the solution section states how the capability fits with the stages or commands immediately before and after it, and the issue copies across every term the terminology source defines that appears in the issue body.

## Files

- `tools/dev-workflow-v2/planning-stages/prd-drafting.md`: terminology rules
- `tools/dev-workflow-v2/planning-stages/architecture-drafting.md`: terminology rules, code and configuration sample rules, role and location table rule
- `tools/dev-workflow-v2/planning-stages/delivery-planning.md`: acceptance criteria rules, with the worked EventCatalog example
- `tools/dev-workflow-v2/planning-stages/task-creation.md`: solution fit rule, role and location `Change` column, glossary rule, acceptance criteria rules, and eight new blocking items
- `tools/dev-workflow-v2/src/shell/planning-guidance.spec.ts`: assertions that pin the new guidance
- `tools/dev-workflow-v2/plugin.json`, `tools/dev-workflow-v2/.claude-plugin/plugin.json`, `tools/dev-workflow-v2/.codex-plugin/plugin.json`: version bumps

## Acceptance criteria

**Rule:** Every planning stage states the terminology rules.

**Example:** `prd-drafting.md` and `architecture-drafting.md` each contain the five terminology rules.

**Rule:** The architecture stage states the code and configuration sample rules.

**Example:** `architecture-drafting.md` contains the two sample rules.

**Rule:** The delivery planning stage states the acceptance criteria rules.

**Example:** `delivery-planning.md` contains the criteria rules and the worked EventCatalog example.

**Rule:** Task creation states the solution fit rule, the role `Change` column, the glossary rule, and the acceptance criteria rules.

**Example:** `task-creation.md` contains each of them.

**Rule:** Task creation blocks an issue that breaks any of the new rules.

**Example:** `task-creation.md` contains blocking items 37 to 43.

**Rule:** Every new rule is pinned by a test.

**Example:** `planning-guidance.spec.ts` asserts each rule is present.

## How to verify

```bash
pnpm nx test dev-workflow-v2
```

Expected: all tests pass, with 100% coverage.

```bash
pnpm verify
```

Expected: all targets pass.

Both commands were run on this branch and passed.

## Out of scope

The fourteen open phase 13 issues are not edited here. They are patched separately once this guidance is in place. The five closed phase 13 issues are left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added clearer planning guidance for consistent terminology, architecture samples, role and location changes, solution flow, glossaries, and acceptance criteria.
  - Added practical Gherkin examples covering EventCatalog imports, service and event mapping, relationships, and unmapped-record handling.
  - Expanded task-creation requirements and blocking checks to improve planning completeness and consistency.

- **Tests**
  - Added automated validation to confirm required planning guidance is present and consistent.

- **Chores**
  - Updated development workflow plugin versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->